### PR TITLE
feat(context): prevent event triggering

### DIFF
--- a/resource/interface/client/context.lua
+++ b/resource/interface/client/context.lua
@@ -13,7 +13,7 @@ function lib.showContext(id)
             menu = data.menu,
             options = data.options
         }
-    }, {sort_keys=true}))
+    }, { sort_keys = true }))
 end
 
 function lib.registerContext(context)
@@ -34,11 +34,13 @@ RegisterNUICallback('openContext', function(id, cb)
     lib.showContext(id)
 end)
 
-RegisterNUICallback('clickContext', function(data, cb)
+RegisterNUICallback('clickContext', function(id, cb)
     cb(1)
     SetNuiFocus(false, false)
+    local data = contextMenus[openContextMenu].options[id]
     if data.event then TriggerEvent(data.event, data.args) end
     if data.serverEvent then TriggerServerEvent(data.serverEvent, data.args) end
+
     openContextMenu = nil
     SendNUIMessage({
         action = 'hideContext'

--- a/web/src/features/menu/Item.tsx
+++ b/web/src/features/menu/Item.tsx
@@ -13,19 +13,12 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Option, ContextMenuProps } from "../../interfaces/context";
 import { fetchNui } from "../../utils/fetchNui";
 
-interface DataProps {
-  event?: string;
-  serverEvent?: string;
-  args?: any;
-}
-
 const openMenu = (id: string | undefined) => {
   fetchNui<ContextMenuProps>("openContext", id);
 };
 
-const clickContext = (data: DataProps) => {
-  if (!data.event && !data.serverEvent) return;
-  fetchNui("clickContext", data);
+const clickContext = (id: string) => {
+  fetchNui("clickContext", id);
 };
 
 const Item: React.FC<{
@@ -58,11 +51,7 @@ const Item: React.FC<{
               onClick={() =>
                 option[1].menu
                   ? openMenu(option[1].menu)
-                  : clickContext({
-                      event: option[1].event,
-                      serverEvent: option[1].serverEvent,
-                      args: option[1].args,
-                    })
+                  : clickContext(option[0])
               }
             >
               <Box>


### PR DESCRIPTION
Fixes a security flaw, where players can use nui_devtools to trigger any server / client event. 