### PR TITLE
chore(ox_lib): add required field type in docs

### DIFF
--- a/resource/interface/client/notify.lua
+++ b/resource/interface/client/notify.lua
@@ -5,6 +5,7 @@
 	description: string
 	duration?: number
 	position?: 'top' | 'top-right' | 'top-left' | 'bottom' | 'bottom-right' | 'bottom-left'
+    type: 'inform' | 'error' | 'success'
 	style?: table
 	icon?: string
 	iconColor?: string


### PR DESCRIPTION
OX Documentation (ox_lib/Interface/Client/notify) 📰

-- id: string (optional)
-- title: string (if description then optional)
-- description: string (if title then optional)
-- duration: number (optional)
-- position: 'top' | 'top-right' | 'top-left' | 'bottom' | 'bottom-right' | 'bottom-left' (optional)
-- type: 'inform' | 'error' | 'success'
-- style: table (optional)
-- icon: string (optional)
-- iconColor: string (optional)

Is stated in documentation but codebase misses "**type**" field.

You are more than welcome to not accept this PR due to it being so minimal & not really a large contribution. 

Just wanted to make sure others who look to read codebase don't lose their mind for 15 minutes 😆