### PR TITLE
fix(resource/input): dialog not closing on first confirm

### DIFF
--- a/resource/interface/client/input.lua
+++ b/resource/interface/client/input.lua
@@ -27,7 +27,6 @@ end
 RegisterNUICallback('inputData', function(data, cb)
 	cb(1)
 	SetNuiFocus(false, false)
-	local promise = input
+	input:resolve(data)
 	input = nil
-	promise:resolve(data)
 end)


### PR DESCRIPTION
Moving the promise of `input` to another variable and making it nil returned the right value to lib.inputDialog but it didn't let the dialog close on confirm for some reason, once the promise is resolved directly on `input`, the UI does close on confirm.