### PR TITLE
Revert "fix(version): properly compare minor/patch semver"

### DIFF
--- a/resource/version/server.lua
+++ b/resource/version/server.lua
@@ -19,11 +19,13 @@ function lib.versionCheck(repository)
 			local latestVersion = response.tag_name:match('%d%.%d+%.%d+')
 			if not latestVersion or latestVersion == currentVersion then return end
 
-			local cMajor, cMinor = string.strsplit('.', currentVersion, 2)
-			local lMajor, lMinor = string.strsplit('.', latestVersion, 2)
+			local cv = { string.strsplit('.', currentVersion) }
+			local lv = { string.strsplit('.', latestVersion) }
 
-			if tonumber(cMajor) < tonumber(lMajor) or tonumber(cMinor) < tonumber(lMinor) then
-				return print(('^3An update is available for %s (current version: %s)\r\n%s^0'):format(resource, currentVersion, response.html_url))
+			for i = 1, #cv do
+				if tonumber(cv[i]) < tonumber(lv[i]) then
+					return print(('^3An update is available for %s (current version: %s)\r\n%s^0'):format(resource, currentVersion, response.html_url))
+				end
 			end
 		end, 'GET')
 	end)

--- a/resource/version/shared.lua
+++ b/resource/version/shared.lua
@@ -2,16 +2,18 @@ function lib.checkDependency(resource, minimumVersion, printMessage)
 	local currentVersion = GetResourceMetadata(resource, 'version', 0):match('%d%.%d+%.%d+')
 
 	if currentVersion ~= minimumVersion then
-		local cMajor, cMinor = string.strsplit('.', currentVersion, 2)
-		local mMajor, mMinor = string.strsplit('.', minimumVersion, 2)
-
+		local cv = { string.strsplit('.', currentVersion) }
+		local mv = { string.strsplit('.', minimumVersion) }
 		local msg = ("^1%s requires version '%s' of '%s' (current version: %s)^0"):format(GetInvokingResource() or GetCurrentResourceName(), minimumVersion, resource, currentVersion)
-		if tonumber(cMajor) < tonumber(mMajor) or tonumber(cMinor) < tonumber(mMinor) then
-			if printMessage then
-				return print(msg)
-			end
 
-			return false, msg
+		for i = 1, #cv do
+			if tonumber(cv[i]) < tonumber(mv[i]) then
+				if printMessage then
+					return print(msg)
+				end
+
+				return false, msg
+			end
 		end
 	end
 


### PR DESCRIPTION
The following version check fails:
- minimum version `2.11.2`
- current version `2.11.1`

Thus, the following version check should also fail:
- minimum version `2.11.10`
- current version `2.11.1`

But with the current way of checking the version, this actually passes.
I didn't directly check this through a script, but this bug should happen since `0.1 == 0.10`.

Revert commit bdb88e74c5e80ce5a9bd6eea268f11970c6d4962.