### PR TITLE
fix(web/features/menu/list): force close menu when using the nui event

### DIFF
--- a/web/src/features/menu/list/index.tsx
+++ b/web/src/features/menu/list/index.tsx
@@ -37,8 +37,8 @@ const ListMenu: React.FC = () => {
   const [indexStates, setIndexStates] = useState<Record<number, number>>({});
   const listRefs = useRef<Array<HTMLDivElement | null>>([]);
 
-  const closeMenu = (ignoreFetch?: boolean, keyPressed?: string) => {
-    if (menu.canClose === false) return;
+  const closeMenu = (ignoreFetch?: boolean, keyPressed?: string, forceClose?: boolean) => {
+    if (menu.canClose === false && !forceClose) return;
     setVisible(false);
     if (!ignoreFetch) fetchNui('closeMenu', keyPressed);
   };
@@ -119,7 +119,7 @@ const ListMenu: React.FC = () => {
     return () => window.removeEventListener('keydown', keyHandler);
   }, [visible]);
 
-  useNuiEvent('closeMenu', () => closeMenu(true));
+  useNuiEvent('closeMenu', () => closeMenu(true, undefined, true));
 
   useNuiEvent('setMenu', (data: MenuSettings) => {
     if (!data.startItemIndex || data.startItemIndex < 0) data.startItemIndex = 0;


### PR DESCRIPTION
This fixes the issue of canClose stopping the menu from being closed when using lib.hideMenu