### PR TITLE
Add support for explicit nils in callbacks

### DIFF
--- a/imports/callback/client.lua
+++ b/imports/callback/client.lua
@@ -23,6 +23,19 @@ local function eventTimer(event, delay)
 	return true
 end
 
+---@param ... any
+---@return function
+local function tuple(...)
+    local co = coroutine.wrap(function(...)
+        coroutine.yield()
+        while true do
+            coroutine.yield(...)
+        end
+    end)
+    co(...)
+    return co
+end
+
 ---@param _ any
 ---@param event string
 ---@param delay number | false
@@ -43,18 +56,19 @@ local function triggerServerCallback(_, event, delay, cb, ...)
 	---@type promise | false
 	local promise = not cb and promise.new()
 
-	events[key] = function(response)
+	events[key] = function(...)
 		events[key] = nil
-
 		if promise then
-			return promise:resolve(response or {})
+			return promise:resolve(select('#', ...) ~= 0 and tuple(...) or tuple({}))
 		end
 
-		return cb and cb(table.unpack(response or {}))
+		return cb and cb(select('#', ...) ~= 0 and ... or {})
 	end
 
 	if promise then
-		return table.unpack(Citizen.Await(promise))
+		---@type function
+		local retData = Citizen.Await(promise)
+		return retData()
 	end
 end
 
@@ -79,7 +93,7 @@ local function callbackResponse(success, result, ...)
 		return false
 	end
 
-	return { result, ... }
+	return tuple(result, ...)()
 end
 
 local pcall = pcall

--- a/imports/callback/client.lua
+++ b/imports/callback/client.lua
@@ -66,9 +66,7 @@ local function triggerServerCallback(_, event, delay, cb, ...)
 	end
 
 	if promise then
-		---@type function
-		local retData = Citizen.Await(promise)
-		return retData()
+		return Citizen.Await(promise)()
 	end
 end
 

--- a/imports/callback/client.lua
+++ b/imports/callback/client.lua
@@ -91,7 +91,7 @@ local function callbackResponse(success, result, ...)
 		return false
 	end
 
-	return tuple(result, ...)()
+	return result, ...
 end
 
 local pcall = pcall

--- a/imports/callback/client.lua
+++ b/imports/callback/client.lua
@@ -58,11 +58,12 @@ local function triggerServerCallback(_, event, delay, cb, ...)
 
 	events[key] = function(...)
 		events[key] = nil
+
 		if promise then
-			return promise:resolve(select('#', ...) ~= 0 and tuple(...) or tuple({}))
+			return promise:resolve(tuple(...))
 		end
 
-		return cb and cb(select('#', ...) ~= 0 and ... or {})
+		return cb and cb(...)
 	end
 
 	if promise then

--- a/imports/callback/server.lua
+++ b/imports/callback/server.lua
@@ -72,7 +72,7 @@ local function callbackResponse(success, result, ...)
 		return false
 	end
 
-	return tuple(result, ...)()
+	return result, ...
 end
 
 local pcall = pcall

--- a/imports/callback/server.lua
+++ b/imports/callback/server.lua
@@ -47,9 +47,7 @@ local function triggerClientCallback(_, event, playerId, cb, ...)
 	end
 
 	if promise then
-		---@type function
-		local retData = Citizen.Await(promise)
-		return retData()
+		return Citizen.Await(promise)()
 	end
 end
 

--- a/imports/callback/server.lua
+++ b/imports/callback/server.lua
@@ -39,11 +39,12 @@ local function triggerClientCallback(_, event, playerId, cb, ...)
 
 	events[key] = function(...)
 		events[key] = nil
+
 		if promise then
-			return promise:resolve(select('#', ...) ~= 0 and tuple(...) or tuple({}))
+			return promise:resolve(tuple(...))
 		end
 
-		return cb and cb(select('#', ...) ~= 0 and ... or {})
+		return cb and cb(...)
 	end
 
 	if promise then


### PR DESCRIPTION
Lua tables do not support explicit nils. This causes problems if you have a callback that may want to return multiple values, one of which could be nil, like `return '1', nil, '3'` which after being packed and unpacked into a table, would return `'1' nil, nil` . I found this working on my own callback system before finding ox_lib, and found a solution here https://riptutorial.com/lua/example/15644/advanced-usage using a tuple function, which I have added to the ox_lib callbacks here.