### PR TITLE
feat(keybinds): add keymap manager

### DIFF
--- a/imports/keybinds/client.lua
+++ b/imports/keybinds/client.lua
@@ -1,0 +1,45 @@
+---@class CKeybind
+---@field name string
+---@field category string
+---@field description string
+---@field keybind string
+---@field disabled boolean
+---@field disable? fun(self: CKeybind, toggle: boolean)
+---@field onPressed? fun(self: CKeybind)
+---@field onReleased? fun(self: CKeybind)
+
+local keybinds = {}
+
+local function disableKeybind(self, toggle)
+    keybinds[self.name].disabled = toggle
+end
+
+lib.keybinds = {
+    ---@return CKeybind
+    new = function(self)
+        self.keybind = self.keybind or ''
+        self.disabled = self.disabled or false
+        self.disable = disableKeybind
+    
+        RegisterCommand('+'..self.name, function()
+            if IsPauseMenuActive() then return end
+            if keybinds[self.name].disabled then return end
+            if self.onPressed then self:onPressed() end
+        end)
+    
+        RegisterCommand('-'..self.name, function()
+            if IsPauseMenuActive() then return end
+            if keybinds[self.name].disabled then return end
+            if self.onReleased then self:onReleased() end
+        end)
+    
+        RegisterKeyMapping('+'..self.name, self.description, 'keyboard', self.keybind)
+        return self
+    end,
+
+    ---@return CKeybind | false
+    get = function(name)
+        if not keybinds[name] then return false end
+        return keybinds[name]
+    end
+}

--- a/imports/keybinds/client.lua
+++ b/imports/keybinds/client.lua
@@ -34,6 +34,8 @@ lib.keybinds = {
         end)
     
         RegisterKeyMapping('+'..self.name, self.description, 'keyboard', self.keybind)
+        TriggerEvent('chat:removeSuggestion', ('/+%s'):format(self.name))
+        TriggerEvent('chat:removeSuggestion', ('/-%s'):format(self.name))
         return self
     end,
 

--- a/imports/keybinds/client.lua
+++ b/imports/keybinds/client.lua
@@ -43,3 +43,5 @@ lib.keybinds = {
         return keybinds[name]
     end
 }
+
+return lib.keybinds

--- a/imports/keybinds/client.lua
+++ b/imports/keybinds/client.lua
@@ -43,8 +43,7 @@ lib.keybinds = {
 
     ---@return CKeybind | false
     get = function(name)
-        if not keybinds[name] then return false end
-        return keybinds[name]
+        return keybinds[name] or false
     end
 }
 

--- a/imports/keybinds/client.lua
+++ b/imports/keybinds/client.lua
@@ -1,6 +1,5 @@
 ---@class CKeybind
 ---@field name string
----@field category string
 ---@field description string
 ---@field keybind string
 ---@field disabled boolean

--- a/imports/keybinds/client.lua
+++ b/imports/keybinds/client.lua
@@ -36,6 +36,8 @@ lib.keybinds = {
         RegisterKeyMapping('+'..self.name, self.description, 'keyboard', self.keybind)
         TriggerEvent('chat:removeSuggestion', ('/+%s'):format(self.name))
         TriggerEvent('chat:removeSuggestion', ('/-%s'):format(self.name))
+        
+        keybinds[self.name] = self
         return self
     end,
 


### PR DESCRIPTION
This adds a management interface for keymaps to allow you to disable, enable and control them in a centralized manner.

Usage:
```lua
local function handsupFuncPress()
    -- triggered when the button is pressed
end

local function handsupFuncRelease()
    -- triggered when the button is released
end

local handsup = lib.keybinds.new({
    name = 'handsup', -- name has to be unique (the case for commands stuff)
    keybind = 'X',
    description = 'Put Your Hands Up',
    onPressed = handsupFuncPress,
    onReleased = handsupFuncRelease,
})

local function anotherFunc()
    -- doing something here, disable handsup keybind
    handsup:disable(true)

    -- another statement, re enable handsup keybind
    handsup:disable(false)
end

-- Another script
local handsup = lib.keybinds.get('handsup')
-- print(handsup.disabled) prints true or false and if a keybind with that
-- name is not registered handsup will return false.
```
