### PR TITLE
fix(logger): Fix bad argument #2 to strsplit

### DIFF
--- a/imports/logger/server.lua
+++ b/imports/logger/server.lua
@@ -143,7 +143,7 @@ if service == 'loki' then
         local values = {message = message}
 
         -- Format the args into strings
-        local tags = formatTags(source, ... and string.strjoin(',', string.tostringall(...)) or nil)
+        local tags = formatTags(source, ... and string.strjoin(',', string.tostringall(...)) or {})
         local tagsTable = convertDDTagsToKVP(tags)
 
         -- Concatenates tags kvp table to the values table


### PR DESCRIPTION
Only Loki logging was affected. When no tags were given and the source is console the `convertDDTagsToKVP` break because of the nil value.
```
[ script:ox_inventory] SCRIPT ERROR: @ox_lib/logger/server.lua:103: bad argument #2 to 'strsplit' (string expected, got nil)
```