### PR TITLE
open state getter for textUI

### DIFF
--- a/package/client/resource/interface/textui.ts
+++ b/package/client/resource/interface/textui.ts
@@ -10,3 +10,5 @@ interface OptionsProps {
 export const showTextUI = (text: string, options?: OptionsProps): void => exports.ox_lib.showTextUI(text, options);
 
 export const hideTextUI = (): void => exports.ox_lib.hideTextUI();
+
+export const isTextUIOpen = (): boolean => exports.ox_lib.isTextUIOpen();

--- a/resource/interface/client/textui.lua
+++ b/resource/interface/client/textui.lua
@@ -4,6 +4,8 @@
 ---@field iconColor? string;
 ---@field style? string;
 
+local isOpen = false
+
 ---@param text string
 ---@param options TextUIOptions
 function lib.showTextUI(text, options)
@@ -13,10 +15,17 @@ function lib.showTextUI(text, options)
         action = 'textUi',
         data = options
     })
+    isOpen = true
 end
 
 function lib.hideTextUI()
     SendNUIMessage({
         action = 'textUiHide'
     })
+    isOpen = false
+end
+
+---@return boolean
+function lib.isTextUIOpen()
+    return isOpen
 end


### PR DESCRIPTION
Since the text ui can be overwritten using lib.showTextUI or hidden when it shouldn't, we should be able to check whether the textui is already open or not to prevent it