### PR TITLE
Fix timeout

### DIFF
--- a/resource/streaming/client.lua
+++ b/resource/streaming/client.lua
@@ -7,7 +7,7 @@ local function request(native, hasLoaded, requestType, name, timeout)
 		end
 
 		for i = 1, timeout do
-			Wait(0)
+			Wait(1)
 			if hasLoaded(name) then
 				return name
 			end


### PR DESCRIPTION
Prevent it from returning the "Failed to load %s '%s' after %s ticks" due to an inaccurate timeout