### PR TITLE
fix(web/menu/list): Move firstRenderRef check earlier in the function

### DIFF
--- a/web/src/features/menu/list/index.tsx
+++ b/web/src/features/menu/list/index.tsx
@@ -87,11 +87,11 @@ const ListMenu: React.FC = () => {
   };
 
   useEffect(() => {
-    if (!menu.items[selected]?.values) return;
     if (firstRenderRef.current) {
       firstRenderRef.current = false;
       return;
     }
+    if (!menu.items[selected]?.values) return;
     const timer = setTimeout(() => {
       fetchNui('changeIndex', [selected, indexStates[selected]]).catch();
     }, 100);


### PR DESCRIPTION
* This fixes a case where, if the first option selected in a menu doesn't have side scroll values, the first time that you *did* side scroll on an item in that menu it would not trigger onSideScroll