### PR TITLE
Add cached coords + Menu list design clean up

### DIFF
--- a/resource/cache/client.lua
+++ b/resource/cache/client.lua
@@ -10,6 +10,7 @@ function cache:set(key, value)
 	end
 end
 
+local GetEntityCoords = GetEntityCoords
 local GetVehiclePedIsIn = GetVehiclePedIsIn
 local GetPedInVehicleSeat = GetPedInVehicleSeat
 local GetVehicleMaxNumberOfPassengers = GetVehicleMaxNumberOfPassengers
@@ -18,7 +19,8 @@ local GetCurrentPedWeapon = GetCurrentPedWeapon
 CreateThread(function()
 	while true do
 		local ped = PlayerPedId()
-		cache:set('ped', ped)
+		local coords = GetEntityCoords(ped)
+		cache:set('coords', coords)
 
 		local vehicle = GetVehiclePedIsIn(ped, false)
 

--- a/resource/cache/client.lua
+++ b/resource/cache/client.lua
@@ -19,6 +19,7 @@ local GetCurrentPedWeapon = GetCurrentPedWeapon
 CreateThread(function()
 	while true do
 		local ped = PlayerPedId()
+		cache:set('ped', ped)
 		local coords = GetEntityCoords(ped)
 		cache:set('coords', coords)
 

--- a/web/src/features/menu/list/Header.tsx
+++ b/web/src/features/menu/list/Header.tsx
@@ -9,10 +9,10 @@ const Header: React.FC<{ title: string }> = ({ title }) => {
       borderTopLeftRadius="md"
       borderTopRightRadius="md"
       bg="#25262B"
-      height="60px"
+      height="50px"
       width="sm"
     >
-      <Text fontSize={24} textTransform="uppercase" fontWeight={600} fontFamily="Nunito">
+      <Text fontSize={20} fontWeight={600} fontFamily="Nunito">
         {title}
       </Text>
     </Box>

--- a/web/src/features/menu/list/ListItem.tsx
+++ b/web/src/features/menu/list/ListItem.tsx
@@ -19,7 +19,7 @@ const ListItem = forwardRef<Array<HTMLDivElement | null>, Props>(({ item, index,
       tabIndex={index}
       scrollMargin={2}
       p={2}
-      height="60px"
+      height="50px"
       key={`item-${index}`}
       _focus={{ bg: '#373A40', outline: 'none' }}
       ref={(element) => {

--- a/web/src/features/menu/list/index.tsx
+++ b/web/src/features/menu/list/index.tsx
@@ -155,7 +155,7 @@ const ListMenu: React.FC = () => {
     },
     [indexStates, selected]
   );
-
+  
   useNuiEvent('closeMenu', () => closeMenu(true, undefined, true));
 
   useNuiEvent('setMenu', (data: MenuSettings) => {
@@ -181,7 +181,7 @@ const ListMenu: React.FC = () => {
   return (
     <>
       {visible && (
-        <Tooltip
+        <Tooltip hasArrow
           label={
             isValuesObject(menu.items[selected].values)
               ? // @ts-ignore
@@ -203,7 +203,7 @@ const ListMenu: React.FC = () => {
           <Box
             position="absolute"
             pointerEvents="none"
-            mt={menu.position === 'top-left' || menu.position === 'top-right' ? 5 : 0}
+            mt={menu.position === 'top-left' || menu.position === 'top-right' ? 12 : 0}
             ml={menu.position === 'top-left' || menu.position === 'bottom-left' ? 5 : 0}
             mr={menu.position === 'top-right' || menu.position === 'bottom-right' ? 5 : 0}
             mb={menu.position === 'bottom-left' || menu.position === 'bottom-right' ? 5 : 0}


### PR DESCRIPTION
Cached coords and cleaned up the menu list a little, this makes the menu list look less "bulky" and also fixes an issue with it overlapping with the fivem watermark when placed in the top right.