### PR TITLE
[Menu] Progress Bars

### DIFF
--- a/web/src/features/dev/debug/context.ts
+++ b/web/src/features/dev/debug/context.ts
@@ -22,8 +22,15 @@ export const debugContext = () => {
             description: 'Vehicle oil level',
             progress: 30,
             icon: 'oil-can',
-            colorScheme: 'orange',
             metadata: [{ label: 'Remaining Oil', value: '30%' }],
+            arrow: true,
+          },
+          {
+            title: 'Durability',
+            progress: 80,
+            icon: 'car-side',
+            metadata: [{ label: 'Durability', value: '80%' }],
+            colorScheme: 'blue'
           },
           {
             title: 'Menu button',

--- a/web/src/features/dev/debug/context.ts
+++ b/web/src/features/dev/debug/context.ts
@@ -18,6 +18,14 @@ export const debugContext = () => {
             disabled: true,
           },
           {
+            title: 'Oil Level',
+            description: 'Vehicle oil level',
+            progress: 30,
+            icon: 'oil-can',
+            colorScheme: 'orange',
+            metadata: [{ label: 'Remaining Oil', value: '30%' }],
+          },
+          {
             title: 'Menu button',
             icon: 'bars',
             menu: 'other_example_menu',

--- a/web/src/features/dev/debug/menu.ts
+++ b/web/src/features/dev/debug/menu.ts
@@ -33,7 +33,8 @@ export const debugMenu = () => {
             progress: 80,
             icon: 'car-side',
             description: 'Durability: 80%',
-            colorScheme: 'blue'
+            colorScheme: 'blue',
+            iconColor: '#55778d'
           },
           { label: 'Option 1' },
           { label: 'Option 2' },

--- a/web/src/features/dev/debug/menu.ts
+++ b/web/src/features/dev/debug/menu.ts
@@ -26,8 +26,14 @@ export const debugMenu = () => {
             label: 'Oil Level',
             progress: 30,
             icon: 'oil-can',
-            colorScheme: 'orange',
             description: 'Remaining Oil: 30%',
+          },
+          {
+            label: 'Durability',
+            progress: 80,
+            icon: 'car-side',
+            description: 'Durability: 80%',
+            colorScheme: 'blue'
           },
           { label: 'Option 1' },
           { label: 'Option 2' },

--- a/web/src/features/dev/debug/menu.ts
+++ b/web/src/features/dev/debug/menu.ts
@@ -22,6 +22,13 @@ export const debugMenu = () => {
             icon: 'tag',
             description: 'Side scroll general description',
           },
+          {
+            label: 'Oil Level',
+            progress: 30,
+            icon: 'oil-can',
+            colorScheme: 'orange',
+            description: 'Remaining Oil: 30%',
+          },
           { label: 'Option 1' },
           { label: 'Option 2' },
           {

--- a/web/src/features/menu/context/Item.tsx
+++ b/web/src/features/menu/context/Item.tsx
@@ -10,7 +10,7 @@ import {
   Spacer,
   Image,
   HStack,
-  Progress
+  Progress,
 } from '@chakra-ui/react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Option, ContextMenuProps } from '../../../interfaces/context';
@@ -73,13 +73,19 @@ const Item: React.FC<{
                     {button.title ? button.title : buttonKey}
                   </Text>
                 </Box>
-                { button.description && (
-                  <Box paddingBottom={1} color={button.disabled ? '#718096' : undefined}">
+                {button.description && (
+                  <Box paddingBottom={1} color={button.disabled ? '#718096' : undefined}>
                     <Text>{button.description}</Text>
                   </Box>
                 )}
-                { button?.progress && (
-                    <Progress value={button.progress} size="sm" colorScheme={button.colorScheme || "gray"} borderRadius="md" marginRight="5px"/>
+                {button?.progress && (
+                  <Progress
+                    value={button.progress}
+                    size="sm"
+                    colorScheme={button.colorScheme || 'gray'}
+                    borderRadius="md"
+                    marginRight="5px"
+                  />
                 )}
               </Box>
               {(button.menu || button.arrow) && button.arrow !== false && (

--- a/web/src/features/menu/context/Item.tsx
+++ b/web/src/features/menu/context/Item.tsx
@@ -79,7 +79,7 @@ const Item: React.FC<{
                   </Box>
                 )}
                 { button?.progress && (
-                    <Progress value={button.progress} size="sm" colorScheme={button.colorScheme ? button.colorScheme : "gray"} borderRadius="md" marginRight="5px"/>
+                    <Progress value={button.progress} size="sm" colorScheme={button.colorScheme || "gray"} borderRadius="md" marginRight="5px"/>
                 )}
               </Box>
               {(button.menu || button.arrow) && button.arrow !== false && (

--- a/web/src/features/menu/context/Item.tsx
+++ b/web/src/features/menu/context/Item.tsx
@@ -10,6 +10,7 @@ import {
   Spacer,
   Image,
   HStack,
+  Progress
 } from '@chakra-ui/react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Option, ContextMenuProps } from '../../../interfaces/context';
@@ -66,13 +67,15 @@ const Item: React.FC<{
                   }}
                 />
               )}
-              <Box>
+              <Box w="100%">
                 <Box paddingBottom={button.description ? 1 : 0}>
                   <Text w="100%" fontWeight="medium" color={button.disabled ? '#718096' : undefined}>
                     {button.title ? button.title : buttonKey}
                   </Text>
                 </Box>
-                {button.description && (
+                { button.progress ? (
+                    <Progress value={button.progress} size="sm" colorScheme={button.colorScheme} borderRadius="md" marginRight="5px"/>
+                ) : button.description && (
                   <Box paddingBottom={1} color={button.disabled ? '#718096' : undefined}>
                     <Text>{button.description}</Text>
                   </Box>

--- a/web/src/features/menu/context/Item.tsx
+++ b/web/src/features/menu/context/Item.tsx
@@ -68,17 +68,18 @@ const Item: React.FC<{
                 />
               )}
               <Box w="100%">
-                <Box paddingBottom={button.description ? 1 : 0}>
+                <Box>
                   <Text w="100%" fontWeight="medium" color={button.disabled ? '#718096' : undefined}>
                     {button.title ? button.title : buttonKey}
                   </Text>
                 </Box>
-                { button.progress ? (
-                    <Progress value={button.progress} size="sm" colorScheme={button.colorScheme} borderRadius="md" marginRight="5px"/>
-                ) : button.description && (
-                  <Box paddingBottom={1} color={button.disabled ? '#718096' : undefined}>
+                { button.description && (
+                  <Box paddingBottom={1} color={button.disabled ? '#718096' : undefined} fontWeight="light">
                     <Text>{button.description}</Text>
                   </Box>
+                )}
+                { button?.progress && (
+                    <Progress value={button.progress} size="sm" colorScheme={button.colorScheme ? button.colorScheme : "gray"} borderRadius="md" marginRight="5px"/>
                 )}
               </Box>
               {(button.menu || button.arrow) && button.arrow !== false && (

--- a/web/src/features/menu/context/Item.tsx
+++ b/web/src/features/menu/context/Item.tsx
@@ -74,7 +74,7 @@ const Item: React.FC<{
                   </Text>
                 </Box>
                 { button.description && (
-                  <Box paddingBottom={1} color={button.disabled ? '#718096' : undefined} fontWeight="light">
+                  <Box paddingBottom={1} color={button.disabled ? '#718096' : undefined}">
                     <Text>{button.description}</Text>
                   </Box>
                 )}

--- a/web/src/features/menu/list/ListItem.tsx
+++ b/web/src/features/menu/list/ListItem.tsx
@@ -63,7 +63,7 @@ const ListItem = forwardRef<Array<HTMLDivElement | null>, Props>(({ item, index,
         ) : item.progress !== undefined ? (
           <Flex flexDirection="column" w="100%" marginRight="5px">
             <Text verticalAlign="middle" marginBottom="3px"> {item.label} </Text>
-            <Progress value={item.progress} size="sm" colorScheme={item.colorScheme} borderRadius="md"/>
+            <Progress value={item.progress} size="sm" colorScheme={item.colorScheme ? item.colorScheme : 'gray'} borderRadius="md"/>
           </Flex>
         ) : (
           <Text>{item.label}</Text>

--- a/web/src/features/menu/list/ListItem.tsx
+++ b/web/src/features/menu/list/ListItem.tsx
@@ -31,7 +31,7 @@ const ListItem = forwardRef<Array<HTMLDivElement | null>, Props>(({ item, index,
       <Flex alignItems="center" height="100%" gap="15px">
         {item.icon && (
           <Box display="flex" alignItems="center">
-            <FontAwesomeIcon icon={item.icon} fontSize={24} color="#909296" fixedWidth />
+            <FontAwesomeIcon icon={item.icon} fontSize={24} color={item.iconColor || "#909296"} fixedWidth />
           </Box>
         )}
         {Array.isArray(item.values) ? (
@@ -63,7 +63,7 @@ const ListItem = forwardRef<Array<HTMLDivElement | null>, Props>(({ item, index,
         ) : item.progress !== undefined ? (
           <Flex flexDirection="column" w="100%" marginRight="5px">
             <Text verticalAlign="middle" marginBottom="3px"> {item.label} </Text>
-            <Progress value={item.progress} size="sm" colorScheme={item.colorScheme ? item.colorScheme : 'gray'} borderRadius="md"/>
+            <Progress value={item.progress} size="sm" colorScheme={item.colorScheme || 'gray'} borderRadius="md"/>
           </Flex>
         ) : (
           <Text>{item.label}</Text>

--- a/web/src/features/menu/list/ListItem.tsx
+++ b/web/src/features/menu/list/ListItem.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Stack, Text } from '@chakra-ui/react';
+import { Box, Flex, Stack, Text, Progress } from '@chakra-ui/react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { forwardRef } from 'react';
 import CustomCheckbox from './CustomCheckbox';
@@ -28,7 +28,7 @@ const ListItem = forwardRef<Array<HTMLDivElement | null>, Props>(({ item, index,
           return (ref.current = [...ref.current, element]);
       }}
     >
-      <Flex alignItems="center" height="100%" gap="20px">
+      <Flex alignItems="center" height="100%" gap="15px">
         {item.icon && (
           <Box display="flex" alignItems="center">
             <FontAwesomeIcon icon={item.icon} fontSize={24} color="#909296" fixedWidth />
@@ -59,6 +59,11 @@ const ListItem = forwardRef<Array<HTMLDivElement | null>, Props>(({ item, index,
           <Flex alignItems="center" justifyContent="space-between" w="100%">
             <Text>{item.label}</Text>
             <CustomCheckbox checked={checked}></CustomCheckbox>
+          </Flex>
+        ) : item.progress !== undefined ? (
+          <Flex flexDirection="column" w="100%" marginRight="5px">
+            <Text verticalAlign="middle" marginBottom="3px"> {item.label} </Text>
+            <Progress value={item.progress} size="sm" colorScheme={item.colorScheme} borderRadius="md"/>
           </Flex>
         ) : (
           <Text>{item.label}</Text>

--- a/web/src/features/menu/list/ListItem.tsx
+++ b/web/src/features/menu/list/ListItem.tsx
@@ -31,7 +31,7 @@ const ListItem = forwardRef<Array<HTMLDivElement | null>, Props>(({ item, index,
       <Flex alignItems="center" height="100%" gap="15px">
         {item.icon && (
           <Box display="flex" alignItems="center">
-            <FontAwesomeIcon icon={item.icon} fontSize={24} color={item.iconColor || "#909296"} fixedWidth />
+            <FontAwesomeIcon icon={item.icon} fontSize={24} color={item.iconColor || '#909296'} fixedWidth />
           </Box>
         )}
         {Array.isArray(item.values) ? (
@@ -62,8 +62,10 @@ const ListItem = forwardRef<Array<HTMLDivElement | null>, Props>(({ item, index,
           </Flex>
         ) : item.progress !== undefined ? (
           <Flex flexDirection="column" w="100%" marginRight="5px">
-            <Text verticalAlign="middle" marginBottom="3px"> {item.label} </Text>
-            <Progress value={item.progress} size="sm" colorScheme={item.colorScheme || 'gray'} borderRadius="md"/>
+            <Text verticalAlign="middle" marginBottom="3px">
+              {item.label}
+            </Text>
+            <Progress value={item.progress} size="sm" colorScheme={item.colorScheme || 'gray'} borderRadius="md" />
           </Flex>
         ) : (
           <Text>{item.label}</Text>

--- a/web/src/features/menu/list/index.tsx
+++ b/web/src/features/menu/list/index.tsx
@@ -11,6 +11,8 @@ import React from 'react';
 
 export interface MenuItem {
   label: string;
+  progress?: number;
+  colorScheme?: string;
   checked?: boolean;
   values?: Array<string | { label: string; description: string }>;
   description?: string;

--- a/web/src/features/menu/list/index.tsx
+++ b/web/src/features/menu/list/index.tsx
@@ -17,6 +17,7 @@ export interface MenuItem {
   values?: Array<string | { label: string; description: string }>;
   description?: string;
   icon?: IconProp;
+  iconColor?: string;
   defaultIndex?: number;
   close?: boolean;
 }

--- a/web/src/interfaces/context.ts
+++ b/web/src/interfaces/context.ts
@@ -8,6 +8,8 @@ export interface Option {
   image?: string;
   icon?: IconProp;
   iconColor?: string;
+  progress?: number;
+  colorScheme?: string;
   metadata?: string[] | { [key: string]: any } | { label: string; value: any }[];
   disabled?: boolean;
   event?: string;


### PR DESCRIPTION
Adds support for progress bars to items in both context and list menus. 

-  `progress` key in the option. It will be a number between 0 and 100 (inclusive) as a percentage.
-  `colorScheme` key in the option for the progress bar. Defaults to gray.
- `iconColor` added to menu

![image](https://user-images.githubusercontent.com/6852526/205460006-191ca404-64b7-40da-8017-62ce3a8ed603.png)
![image](https://user-images.githubusercontent.com/6852526/205459510-7663fe97-3663-41f9-a4c6-d987cb1be25e.png)
