### PR TITLE
fix(imports/scaleform): return scaleform handle

### DIFF
--- a/imports/requestScaleformMovie/client.lua
+++ b/imports/requestScaleformMovie/client.lua
@@ -1,22 +1,22 @@
 ---Load a scaleform movie. When called from a thread, it will yield until it has loaded.
 ---@param scaleformName string
 ---@param timeout number? Number of ticks to wait for the scaleform movie to load. Default is 500.
----@return string? scaleformName
+---@return number? scaleform
 function lib.requestScaleformMovie(scaleformName, timeout)
-    if HasScaleformMovieLoaded(scaleformName) then return scaleformName end
-
     if type(scaleformName) ~= 'string' then
         error(("expected scaleformName to have type 'string' (received %s)"):format(type(scaleformName)))
     end
 
-    RequestScaleformMovie(scaleformName)
+    local scaleform = RequestScaleformMovie(scaleformName)
+
+    if HasScaleformMovieLoaded(scaleform) then return scaleform end
 
     if coroutine.running() then
         timeout = tonumber(timeout) or 500
 
         for _ = 1, timeout do
-            if HasScaleformMovieLoaded(scaleformName) then
-                return scaleformName
+            if HasScaleformMovieLoaded(scaleform) then
+                return scaleform
             end
 
             Wait(0)
@@ -25,7 +25,7 @@ function lib.requestScaleformMovie(scaleformName, timeout)
         print(("failed to load scaleformName '%s' after %s ticks"):format(scaleformName, timeout))
     end
 
-    return scaleformName
+    return scaleform
 end
 
 return lib.requestScaleformMovie


### PR DESCRIPTION
Some scaleform related natives requires the scaleform handle - eg. `BeginScaleformMovieMethod`.