### PR TITLE
lastzone command and relative movement for zone creator

### DIFF
--- a/resource/zoneCreator/client.lua
+++ b/resource/zoneCreator/client.lua
@@ -67,8 +67,6 @@ local function closeCreator(cancel)
             }}
         }) or {}
 
-        format = input[2] or 'array'
-
 		TriggerServerEvent('ox_lib:saveZone', {
 			zoneType = zoneType,
 			name = input[1] or 'none',

--- a/resource/zoneCreator/client.lua
+++ b/resource/zoneCreator/client.lua
@@ -146,7 +146,7 @@ local function drawLines()
 	end
 end
 
-local function rotate(origin, point, theta)
+local function getRelativePos(origin, point, theta)
     if theta == 0.0 then return point end
     local p = point - origin
     local pX, pY = p.x, p.y
@@ -276,7 +276,7 @@ local function startCreator(arg, useLast)
             elseif IsDisabledControlJustReleased(0, 32) then -- w
                 change = true
                 if useRelativeMomvement then
-                    local newX, newY = rotate(vec2(xCoord, yCoord), vec2(xCoord, yCoord + lStep), GetGameplayCamRot(2).z)
+                    local newX, newY = getRelativePos(vec2(xCoord, yCoord), vec2(xCoord, yCoord + lStep), GetGameplayCamRot(2).z)
                     if math.abs(newX) < minCheck then
                         newX = 0.0
                     end
@@ -295,7 +295,7 @@ local function startCreator(arg, useLast)
             elseif IsDisabledControlJustReleased(0, 33) then -- s
                 change = true
                 if useRelativeMomvement then
-                    local newX, newY = rotate(vec2(xCoord, yCoord), vec2(xCoord, yCoord - lStep), GetGameplayCamRot(2).z)
+                    local newX, newY = getRelativePos(vec2(xCoord, yCoord), vec2(xCoord, yCoord - lStep), GetGameplayCamRot(2).z)
                     if math.abs(newX) < minCheck then
                         newX = 0.0
                     end
@@ -314,7 +314,7 @@ local function startCreator(arg, useLast)
             elseif IsDisabledControlJustReleased(0, 35) then -- d
                 change = true
                 if useRelativeMomvement then
-                    local newX, newY = rotate(vec2(xCoord, yCoord), vec2(xCoord + lStep, yCoord), GetGameplayCamRot(2).z)
+                    local newX, newY = getRelativePos(vec2(xCoord, yCoord), vec2(xCoord + lStep, yCoord), GetGameplayCamRot(2).z)
                     if math.abs(newX) < minCheck then
                         newX = 0.0
                     end
@@ -333,7 +333,7 @@ local function startCreator(arg, useLast)
             elseif IsDisabledControlJustReleased(0, 34) then -- a
                 change = true
                 if useRelativeMomvement then
-                    local newX, newY = rotate(vec2(xCoord, yCoord), vec2(xCoord - lStep, yCoord), GetGameplayCamRot(2).z)
+                    local newX, newY = getRelativePos(vec2(xCoord, yCoord), vec2(xCoord - lStep, yCoord), GetGameplayCamRot(2).z)
                     if math.abs(newX) < minCheck then
                         newX = 0.0
                     end

--- a/resource/zoneCreator/client.lua
+++ b/resource/zoneCreator/client.lua
@@ -67,6 +67,8 @@ local function closeCreator(cancel)
             }}
         }) or {}
 
+        format = input[2]
+
 		TriggerServerEvent('ox_lib:saveZone', {
 			zoneType = zoneType,
 			name = input[1] or 'none',

--- a/resource/zoneCreator/client.lua
+++ b/resource/zoneCreator/client.lua
@@ -8,6 +8,7 @@ local displayModes = {'basic', 'walls', 'axes', 'both'}
 local displayMode = 1
 local minCheck = steps[1][1] / 2
 local lastZone = nil
+local useRelativeMomvement = false
 
 local function firstToUpper(str)
     return (str:gsub("^%l", string.upper))
@@ -39,6 +40,7 @@ local function updateText()
 	end
 
 	text[#text + 1] = 'Toggle controls - [X]  \n'
+    text[#text + 1] = 'Toggle relative movement - [M]  \n'
 	text[#text + 1] = 'Save - [Enter]  \n'
 	text[#text + 1] = 'Cancel - [Esc]'
 
@@ -144,6 +146,18 @@ local function drawLines()
 	end
 end
 
+local function rotate(origin, point, theta)
+    if theta == 0.0 then return point end
+    local p = point - origin
+    local pX, pY = p.x, p.y
+    theta = math.rad(theta)
+    local cosTheta = math.cos(theta)
+    local sinTheta = math.sin(theta)
+    local x = math.floor(((pX * cosTheta - pY * sinTheta) + origin.x) * 100 + 0.0) / 100
+    local y = math.floor(((pX * sinTheta + pY * cosTheta) + origin.y) * 100 + 0.0) / 100
+    return x, y
+  end
+
 local isFivem = cache.game == 'fivem'
 local controls = {
     ['INPUT_LOOK_LR'] = isFivem and 1 or 0xA987235F,
@@ -177,6 +191,12 @@ local function startCreator(arg, useLast)
                 controlsActive = not controlsActive
             end
         end
+        if IsDisabledControlJustReleased(0, 301) then -- m
+            if creatorActive then
+                useRelativeMomvement = not useRelativeMomvement
+            end
+        end
+
 
         if displayMode == 3 or displayMode == 4 then
             DrawLine(xCoord, yCoord, zCoord, xCoord + 2, yCoord, zCoord, 0, 0, 255, 225)
@@ -255,32 +275,80 @@ local function startCreator(arg, useLast)
                 end
             elseif IsDisabledControlJustReleased(0, 32) then -- w
                 change = true
-                local newValue = yCoord + lStep
-                if math.abs(newValue) < minCheck then
-                    newValue = 0.0
+                if useRelativeMomvement then
+                    local newX, newY = rotate(vec2(xCoord, yCoord), vec2(xCoord, yCoord + lStep), GetGameplayCamRot(2).z)
+                    if math.abs(newX) < minCheck then
+                        newX = 0.0
+                    end
+                    if math.abs(newY) < minCheck then
+                        newY = 0.0
+                    end
+                    xCoord = newX
+                    yCoord = newY
+                else
+                    local newValue = yCoord + lStep
+                    if math.abs(newValue) < minCheck then
+                        newValue = 0.0
+                    end
+                    yCoord = newValue
                 end
-                yCoord = newValue
             elseif IsDisabledControlJustReleased(0, 33) then -- s
                 change = true
-                local newValue = yCoord - lStep
-                if math.abs(newValue) < minCheck then
-                    newValue = 0.0
+                if useRelativeMomvement then
+                    local newX, newY = rotate(vec2(xCoord, yCoord), vec2(xCoord, yCoord - lStep), GetGameplayCamRot(2).z)
+                    if math.abs(newX) < minCheck then
+                        newX = 0.0
+                    end
+                    if math.abs(newY) < minCheck then
+                        newY = 0.0
+                    end
+                    xCoord = newX
+                    yCoord = newY
+                else
+                    local newValue = yCoord - lStep
+                    if math.abs(newValue) < minCheck then
+                        newValue = 0.0
+                    end
+                    yCoord = newValue
                 end
-                yCoord = newValue
             elseif IsDisabledControlJustReleased(0, 35) then -- d
                 change = true
-                local newValue = xCoord + lStep
-                if math.abs(newValue) < minCheck then
-                    newValue = 0.0
+                if useRelativeMomvement then
+                    local newX, newY = rotate(vec2(xCoord, yCoord), vec2(xCoord + lStep, yCoord), GetGameplayCamRot(2).z)
+                    if math.abs(newX) < minCheck then
+                        newX = 0.0
+                    end
+                    if math.abs(newY) < minCheck then
+                        newY = 0.0
+                    end
+                    xCoord = newX
+                    yCoord = newY
+                else
+                    local newValue = xCoord + lStep
+                    if math.abs(newValue) < minCheck then
+                        newValue = 0.0
+                    end
+                    xCoord = newValue
                 end
-                xCoord = newValue
             elseif IsDisabledControlJustReleased(0, 34) then -- a
                 change = true
-                local newValue = xCoord - lStep
-                if math.abs(newValue) < minCheck then
-                    newValue = 0.0
+                if useRelativeMomvement then
+                    local newX, newY = rotate(vec2(xCoord, yCoord), vec2(xCoord - lStep, yCoord), GetGameplayCamRot(2).z)
+                    if math.abs(newX) < minCheck then
+                        newX = 0.0
+                    end
+                    if math.abs(newY) < minCheck then
+                        newY = 0.0
+                    end
+                    xCoord = newX
+                    yCoord = newY
+                else
+                    local newValue = xCoord - lStep
+                    if math.abs(newValue) < minCheck then
+                        newValue = 0.0
+                    end
+                    xCoord = newValue
                 end
-                xCoord = newValue
             elseif IsDisabledControlJustReleased(0, 45) then -- r
                 change = true
                 local newValue = zCoord + lStep


### PR DESCRIPTION
Both of these are features from PolyZone that I found myself missing when we switched over to using GLM. 

saving a zone saves some of its data to the lastZone variable. If the lastzone command is run, it then uses these values instead of the defaults to keep the same shape as the last zone created. This only works for box and sphere zones

for relative movement I did some small edits to the Polyzone.rotate function from PolyZone to make it fit and used that to determine the new position based on the camera rotation. I.e. when you press 'w', the zone will move in what ever direction the camera is facing, a will move it to the left of that direction, etc.