### PR TITLE
fix(init): lib.notify locale handler

### DIFF
--- a/imports/locale/shared.lua
+++ b/imports/locale/shared.lua
@@ -3,18 +3,19 @@ local dict
 ---@param str string
 ---@param ... string | number
 ---@return string
+---@return boolean
 function locale(str, ...)
 	local lstr = dict[str]
 
 	if lstr then
 		if ... then
-			return lstr and lstr:format(...)
+			return lstr and lstr:format(...), true
 		end
 
-		return lstr
+		return lstr, true
 	end
 
-	return ("Translation for '%s' does not exist"):format(str)
+	return ("Translation for '%s' does not exist"):format(str), false
 end
 
 ---@return { [string]: string }

--- a/init.lua
+++ b/init.lua
@@ -160,11 +160,13 @@ if context == 'client' then
 	RegisterNetEvent(('%s:notify'):format(cache.resource), function(data)
 		if locale then
 			if data.title then
-				data.title = locale(data.title) or data.title
+				local title, success = locale(data.title)
+				data.title = success and title or data.title
 			end
 
 			if data.description then
-				data.description = locale(data.description) or data.description
+				local description, success = locale(data.description)
+				data.description = success and description or data.description
 			end
 		end
 


### PR DESCRIPTION
When using lib.notify on the server you are forced to use a key for a valid locale, you can not use your own text. This solves that issue so you can use both locales and custom text.