### PR TITLE
fix(getNearbyVehicles): return correct coords

### DIFF
--- a/imports/getNearbyVehicles/client.lua
+++ b/imports/getNearbyVehicles/client.lua
@@ -19,7 +19,7 @@ function lib.getNearbyVehicles(coords, maxDistance, includePlayerVehicle)
 				count += 1
 				nearby[count] = {
 					vehicle = vehicle,
-					coords = coords
+					coords = vehicleCoords
 				}
 			end
 		end


### PR DESCRIPTION
Currently it is returning the coords passed to the function, instead of the coords for each vehicle, this resolves that issue.