### PR TITLE
fix/feat(setClipboard): Allow use of setClipboard while menu is active

### DIFF
--- a/resource/interface/client/clipboard.lua
+++ b/resource/interface/client/clipboard.lua
@@ -1,7 +1,20 @@
 ---@param value string
 function lib.setClipboard(value)
+    local is_menu_open = lib.getOpenMenu() ~= nil
+    if is_menu_open then
+        SendNUIMessage({
+            action = 'setMenuFocus',
+            data = true
+        })
+    end
     SendNUIMessage({
         action = 'setClipboard',
         data = value
     })
+    if is_menu_open then
+        SendNUIMessage({
+            action = 'setMenuFocus',
+            data = false
+        })
+    end
 end

--- a/resource/interface/client/clipboard.lua
+++ b/resource/interface/client/clipboard.lua
@@ -1,20 +1,7 @@
 ---@param value string
 function lib.setClipboard(value)
-    local is_menu_open = lib.getOpenMenu() ~= nil
-    if is_menu_open then
-        SendNUIMessage({
-            action = 'setMenuFocus',
-            data = true
-        })
-    end
     SendNUIMessage({
         action = 'setClipboard',
         data = value
     })
-    if is_menu_open then
-        SendNUIMessage({
-            action = 'setMenuFocus',
-            data = false
-        })
-    end
 end

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,18 +5,33 @@ import TextUI from './features/textui/TextUI';
 import InputDialog from './features/dialog/InputDialog';
 import ContextMenu from './features/menu/context/ContextMenu';
 import { useNuiEvent } from './hooks/useNuiEvent';
-import { setClipboard } from './utils/setClipboard';
+import { copyClipboard } from './utils/copyClipboard';
 import { fetchNui } from './utils/fetchNui';
 import AlertDialog from './features/dialog/AlertDialog';
 import ListMenu from './features/menu/list';
 import Dev from './features/dev';
 import { isEnvBrowser } from './utils/misc';
 import SkillCheck from './features/skillcheck';
+import { useState, useEffect } from 'react';
 
 const App: React.FC = () => {
+
+  let [pauseFocus, setPauseFocus] = useState(false);
+  let [clipboard, setClipboard] = useState('');
+
   useNuiEvent('setClipboard', (data: string) => {
     setClipboard(data);
+    setPauseFocus(true);
   });
+
+  useEffect(() => {
+    if (clipboard !== '') {
+      copyClipboard(clipboard);
+      setClipboard('');
+      setPauseFocus(false);
+    }
+  }, [pauseFocus]);
+
 
   fetchNui('init');
 
@@ -29,7 +44,7 @@ const App: React.FC = () => {
       <InputDialog />
       <AlertDialog />
       <ContextMenu />
-      <ListMenu />
+      <ListMenu pauseFocus={pauseFocus} />
       <SkillCheck />
       {isEnvBrowser() && <Dev />}
     </>

--- a/web/src/features/menu/list/index.tsx
+++ b/web/src/features/menu/list/index.tsx
@@ -30,7 +30,7 @@ export interface MenuSettings {
   startItemIndex?: number;
 }
 
-const ListMenu: React.FC = () => {
+const ListMenu: React.FC<{pauseFocus: boolean}> = ({ pauseFocus }) => {
   const [menu, setMenu] = useState<MenuSettings>({
     position: 'top-left',
     title: '',
@@ -38,7 +38,6 @@ const ListMenu: React.FC = () => {
   });
   const [selected, setSelected] = useState(0);
   const [visible, setVisible] = useState(false);
-  const [trapFocus, setTrapFocus] = useState(false);
   const [indexStates, setIndexStates] = useState<Record<number, number>>({});
   const [checkedStates, setCheckedStates] = useState<Record<number, boolean>>({});
   const listRefs = useRef<Array<HTMLDivElement | null>>([]);
@@ -154,12 +153,8 @@ const ListMenu: React.FC = () => {
   );
 
   useNuiEvent('closeMenu', () => closeMenu(true, undefined, true));
-
-  useNuiEvent('setMenuFocus', (newFocus: boolean) => {
-    setTrapFocus(newFocus)
-    if (!newFocus)
-      listRefs.current[selected]?.focus();
-  });
+  useNuiEvent('moveMenu', (newPosition: MenuSettings["position"]) => setMenu({ ...menu, position: newPosition }))
+  
 
   useNuiEvent('setMenu', (data: MenuSettings) => {
     firstRenderRef.current = true;
@@ -227,7 +222,7 @@ const ListMenu: React.FC = () => {
               borderTopRightRadius="none"
               onKeyDown={(e) => moveMenu(e)}
             >
-              <FocusTrap active={visible} paused={trapFocus}>
+              <FocusTrap active={visible} paused={pauseFocus}>
                 <Stack direction="column" p={2} overflowY="scroll">
                   {menu.items.map((item, index) => (
                     <React.Fragment key={`menu-item-${index}`}>

--- a/web/src/features/menu/list/index.tsx
+++ b/web/src/features/menu/list/index.tsx
@@ -38,6 +38,7 @@ const ListMenu: React.FC = () => {
   });
   const [selected, setSelected] = useState(0);
   const [visible, setVisible] = useState(false);
+  const [trapFocus, setTrapFocus] = useState(false);
   const [indexStates, setIndexStates] = useState<Record<number, number>>({});
   const [checkedStates, setCheckedStates] = useState<Record<number, boolean>>({});
   const listRefs = useRef<Array<HTMLDivElement | null>>([]);
@@ -154,6 +155,12 @@ const ListMenu: React.FC = () => {
 
   useNuiEvent('closeMenu', () => closeMenu(true, undefined, true));
 
+  useNuiEvent('setMenuFocus', (newFocus: boolean) => {
+    setTrapFocus(newFocus)
+    if (!newFocus)
+      listRefs.current[selected]?.focus();
+  });
+
   useNuiEvent('setMenu', (data: MenuSettings) => {
     firstRenderRef.current = true;
     if (!data.startItemIndex || data.startItemIndex < 0) data.startItemIndex = 0;
@@ -220,7 +227,7 @@ const ListMenu: React.FC = () => {
               borderTopRightRadius="none"
               onKeyDown={(e) => moveMenu(e)}
             >
-              <FocusTrap active={visible}>
+              <FocusTrap active={visible} paused={trapFocus}>
                 <Stack direction="column" p={2} overflowY="scroll">
                   {menu.items.map((item, index) => (
                     <React.Fragment key={`menu-item-${index}`}>

--- a/web/src/utils/copyClipboard.ts
+++ b/web/src/utils/copyClipboard.ts
@@ -1,5 +1,5 @@
 // yoinked from https://github.com/project-error/npwd/blob/d8dc5b7f47faf5fc581ffee30f31ff61d184cfe7/phone/src/os/phone/hooks/useClipboard.ts#L1
-export const setClipboard = (value: string) => {
+export const copyClipboard = (value: string) => {
   const clipElem = document.createElement('input');
   clipElem.value = value;
   document.body.appendChild(clipElem);


### PR DESCRIPTION
This could be a bug fix or a new feature depending on initial intentions.  FocusTrap prevents using lib.setClipboard while the menu is active. This commit fixes it by toggling the FocusTrap `paused` prop (don't know exactly on what it differs from the `active` prop) when lib.setClipboard is called while the menu is visible.