### PR TITLE
feat(web/alert): new options for alert dialog

### DIFF
--- a/package/client/resource/interface/alert.ts
+++ b/package/client/resource/interface/alert.ts
@@ -2,6 +2,8 @@ interface AlertDialogProps {
   header: string;
   content: string;
   centered?: boolean;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  overflow?: boolean;
   cancel?: boolean;
   labels?: {
     cancel?: string;

--- a/resource/interface/client/alert.lua
+++ b/resource/interface/client/alert.lua
@@ -4,6 +4,8 @@ local alert = nil
 ---@field header string;
 ---@field content string;
 ---@field centered? boolean?;
+---@field size? 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+---@field overflow? boolean?;
 ---@field cancel? boolean?;
 ---@field labels? {cancel?: string, confirm?: string}
 

--- a/web/src/features/dev/debug/alert.ts
+++ b/web/src/features/dev/debug/alert.ts
@@ -9,6 +9,8 @@ export const debugAlert = () => {
         header: 'Hello there',
         content: 'General kenobi  \n Markdown works',
         centered: true,
+        size: 'lg',
+        overflow: true,
         cancel: true,
         // labels: {
         //   confirm: 'Ok',

--- a/web/src/features/dialog/AlertDialog.tsx
+++ b/web/src/features/dialog/AlertDialog.tsx
@@ -10,6 +10,8 @@ export interface AlertProps {
   header: string;
   content: string;
   centered?: boolean;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  overflow?: boolean;
   cancel?: boolean;
   labels?: {
     cancel?: string;
@@ -45,6 +47,8 @@ const AlertDialog: React.FC = () => {
       <Modal
         opened={opened}
         centered={dialogData.centered}
+        size={dialogData.size || 'md'}
+        overflow={dialogData.overflow ? 'inside' : 'outside'}
         closeOnClickOutside={false}
         onClose={() => {
           setOpened(false);


### PR DESCRIPTION
In regards to this suggestion: #178

Added:
- size prop
- overflow prop

Updated:
- npm package types to reflect the newly added ones
- lua types to also reflect the newly added ones 

seem that the centered prop is already added as an option to the alert dialog.