### PR TITLE
feature: progress bar in context menu's metadata

### DIFF
--- a/web/src/features/dev/debug/context.ts
+++ b/web/src/features/dev/debug/context.ts
@@ -10,6 +10,32 @@ export const debugContext = () => {
         options: [
           { title: 'Empty button' },
           {
+            title: 'Karin Kuruma',
+            image: 'https://cdn.discordapp.com/attachments/1063098499027173461/1064276343585505330/screenshot.jpg',
+            arrow: true,
+            colorScheme: 'blue',
+            metadata: [
+              {
+                ["label"]: "Body",
+                ["value"]: "55%",
+                ["progress"]: 55
+              },
+              {
+                ["label"]: "Engine",
+                ["value"]: "100%",
+                ["progress"]: 100
+              },
+              {
+                ["label"]: "Oil",
+                ["progress"]: 11
+              },
+              {
+                ["label"]: "Fuel",
+                ["progress"]: 87
+              },
+            ],
+          },
+          {
             title: 'Example button',
             description: 'Example button description',
             icon: 'inbox',

--- a/web/src/features/menu/context/components/ContextButton.tsx
+++ b/web/src/features/menu/context/components/ContextButton.tsx
@@ -90,10 +90,16 @@ const ContextButton: React.FC<{
         <HoverCard.Dropdown className={classes.dropdown}>
           {button.image && <Image src={button.image} />}
           {Array.isArray(button.metadata) ? (
-            button.metadata.map((metadata: string | { label: string; value: any }, index: number) => (
-              <Text key={`context-metadata-${index}`}>
-                {typeof metadata === 'string' ? `${metadata}` : `${metadata.label}: ${metadata.value}`}
-              </Text>
+            button.metadata.map((metadata: string | { label: string; value?: any; progress?: number }, index: number) => (
+              <>
+                <Text key={`context-metadata-${index}`}>
+                  {typeof metadata === 'string' ? `${metadata}` : `${metadata.label}: ${metadata?.value ?? ""}`}
+                </Text>
+
+                {typeof metadata === 'object' && metadata?.progress && (
+                  <Progress value={metadata.progress || 0} size="sm" color={button.colorScheme || 'dark.3'} />
+                )}
+              </>
             ))
           ) : (
             <>

--- a/web/src/features/menu/context/components/ContextButton.tsx
+++ b/web/src/features/menu/context/components/ContextButton.tsx
@@ -96,8 +96,8 @@ const ContextButton: React.FC<{
                   {typeof metadata === 'string' ? `${metadata}` : `${metadata.label}: ${metadata?.value ?? ""}`}
                 </Text>
 
-                {typeof metadata === 'object' && metadata?.progress && (
-                  <Progress value={metadata.progress || 0} size="sm" color={button.colorScheme || 'dark.3'} />
+                {typeof metadata === 'object' && metadata.progress !== undefined && (
+                  <Progress value={metadata.progress} size="sm" color={button.colorScheme || 'dark.3'} />
                 )}
               </>
             ))

--- a/web/src/interfaces/context.ts
+++ b/web/src/interfaces/context.ts
@@ -10,7 +10,7 @@ export interface Option {
   iconColor?: string;
   progress?: number;
   colorScheme?: string;
-  metadata?: string[] | { [key: string]: any } | { label: string; value: any }[];
+  metadata?: string[] | { [key: string]: any } | { label: string; value: any; progress: number; }[];
   disabled?: boolean;
   event?: string;
   serverEvent?: string;


### PR DESCRIPTION
On each metadata item you can set progressbar also you can still set value (not required) like this;
```
{
    ["label"]: "Body",
    ["value"]: "55%",
    ["progress"]: 55
}
```
or just like this;
```
{
    ["label"]: "Oil",
    ["progress"]: 11
}
```

![new feat ox_lib](https://user-images.githubusercontent.com/67207947/216769752-1575f188-e198-492c-b81d-4625b347ca92.png)
