### PR TITLE
Add help text support for command arguments

### DIFF
--- a/imports/addCommand/server.lua
+++ b/imports/addCommand/server.lua
@@ -1,106 +1,32 @@
-local commands = {}
-
-SetTimeout(1000, function()
-	TriggerClientEvent('chat:addSuggestions', -1, commands)
-end)
-
-AddEventHandler('playerJoining', function(source)
-	TriggerClientEvent('chat:addSuggestions', source, commands)
-end)
-
-local function chatSuggestion(name, parameters, help)
-	local params = {}
-
-	if parameters then
-		for i = 1, #parameters do
-			local arg, argType, helpText = string.strsplit(':', parameters[i])
-			argType = argType ~= '' and argType or nil
-
-			if argType and argType:sub(0, 1) == '?' then
-				argType = argType:sub(2, #argType)
-			end
-
-			params[i] = {
-				name = arg,
-				help = (helpText and argType and ("%s (%s)"):format(helpText, argType)) or argType or helpText
-			}
-		end
-	end
-
-	commands[#commands + 1] = {
-		name = '/'..name,
-		help = help,
-		params = params
-	}
-end
-
 ---@param group string | string[] | false
 ---@param name string | string[]
 ---@param callback function
 ---@param parameters table
+---@deprecated Use lib.registerCommand instead
 function lib.addCommand(group, name, callback, parameters, help)
-	if not group then group = 'builtin.everyone' end
-
-	if type(name) == 'table' then
-		for i = 1, #name do
-			lib.addCommand(group, name[i], callback, parameters, help)
-		end
-	else
-		chatSuggestion(name, parameters, help)
-
-		RegisterCommand(name, function(source, args, raw)
-			source = tonumber(source) --[[@as number]]
-
-			if parameters then
-				for i = 1, #parameters do
-					local arg, argType = string.strsplit(':', parameters[i])
-					local value = args[i]
-
-					if arg == 'target' and value == 'me' then value = source end
-
-					if argType and argType ~= '' then
-						local optional
-
-						if argType:sub(0, 1) == '?' then
-							argType = argType:sub(2, #argType)
-							optional = true
-						end
-
-						if argType == 'number' then
-							value = tonumber(value) or value
-						end
-
-						local type = type(value)
-
-						if type ~= argType and (not optional or type ~= 'nil') then
-							local invalid = ('^1%s expected <%s> for argument %s (%s), received %s^0'):format(name, argType, i, arg, type)
-							if source < 1 then
-								return print(invalid)
-							else
-								return TriggerClientEvent('chat:addMessage', source, invalid)
-							end
-						end
-					end
-
-					args[arg] = value
-					args[i] = nil
-				end
+	local splitParameters = parameters and {} or nil
+	if parameters then
+		for i = 1, #parameters do
+			local arg, argType = string.strsplit(':', parameters[i])
+			local required = true
+			if argType and argType:sub(0, 1) == '?' then
+				argType = argType:sub(2, #argType)
+				required = false
 			end
-
-			callback(source, args, raw)
-		end, group and true)
-
-		name = ('command.%s'):format(name)
-		if type(group) == 'table' then
-			for _, v in ipairs(group) do
-				if not IsPrincipalAceAllowed(v, name) then lib.addAce(v, name) end
-			end
-		else
-			if not IsPrincipalAceAllowed(group, name) then lib.addAce(group, name) end
+			splitParameters[i] = {
+				name = arg,
+				type = argType,
+				required = required
+			}
 		end
 	end
+	lib.registerCommand({
+		name = name,
+		groups = group,
+		params = splitParameters,
+		help = help
+	}, callback)
 end
-
 return lib.addCommand
 
 --[[ Example
@@ -109,6 +35,6 @@ return lib.addCommand
 		if args.item and args.count > 0 then
 			Inventory.AddItem(args.target, args.item.name, args.count, args.metatype)
 		end
-	end, {'target:number', 'item:string', 'count:number:Number of items to give', 'metatype:?string'})
+	end, {'target:number', 'item:string', 'count:number', 'metatype:?string'})
 	-- /additem 1 burger 1
 ]]

--- a/imports/addCommand/server.lua
+++ b/imports/addCommand/server.lua
@@ -13,7 +13,8 @@ local function chatSuggestion(name, parameters, help)
 
 	if parameters then
 		for i = 1, #parameters do
-			local arg, argType = string.strsplit(':', parameters[i])
+			local arg, argType, helpText = string.strsplit(':', parameters[i])
+			argType = argType ~= '' and argType or nil
 
 			if argType and argType:sub(0, 1) == '?' then
 				argType = argType:sub(2, #argType)
@@ -21,7 +22,7 @@ local function chatSuggestion(name, parameters, help)
 
 			params[i] = {
 				name = arg,
-				help = argType
+				help = (helpText and argType and ("%s (%s)"):format(helpText, argType)) or argType or helpText
 			}
 		end
 	end
@@ -57,7 +58,7 @@ function lib.addCommand(group, name, callback, parameters, help)
 
 					if arg == 'target' and value == 'me' then value = source end
 
-					if argType then
+					if argType and argType ~= '' then
 						local optional
 
 						if argType:sub(0, 1) == '?' then
@@ -108,6 +109,6 @@ return lib.addCommand
 		if args.item and args.count > 0 then
 			Inventory.AddItem(args.target, args.item.name, args.count, args.metatype)
 		end
-	end, {'target:number', 'item:string', 'count:number', 'metatype:?string'})
+	end, {'target:number', 'item:string', 'count:number:Number of items to give', 'metatype:?string'})
 	-- /additem 1 burger 1
 ]]

--- a/imports/registerCommand/server.lua
+++ b/imports/registerCommand/server.lua
@@ -1,0 +1,160 @@
+local commands = {}
+
+---@class Param
+---@field name string
+---@field help? string
+---@field type string
+---@field required? boolean
+
+---@class CommandData
+---@field name string | string[]
+---@field help? string
+---@field params? Param[]
+---@field groups? string | string[]
+
+SetTimeout(1000, function()
+    TriggerClientEvent('chat:addSuggestions', -1, commands)
+end)
+
+AddEventHandler('playerJoining', function(source)
+    TriggerClientEvent('chat:addSuggestions', source, commands)
+end)
+
+function firstToUpper(str)
+    return (str:gsub("^%l", string.upper))
+end
+
+local function chatSuggestions(name, parameters, help)
+    local params = {}
+
+    if parameters then
+        for i = 1, #parameters do
+            local paramater = parameters[i]
+
+            local paramHelp = ''
+            if paramater.help and paramater.type then
+                paramHelp = ('%s (%s)'):format(paramater.help, firstToUpper(paramater.type))
+            elseif paramater.help then
+                paramHelp = paramater.help
+            elseif paramater.type then
+                paramHelp = firstToUpper(paramater.type)
+            end
+
+            params[i] = {
+                name = paramater.name,
+                help = paramHelp
+            }
+        end
+    end
+
+    commands[#commands + 1] = {
+        name = '/' .. name,
+        help = help,
+        params = params
+    }
+end
+
+---@param data CommandData
+---@param callback function
+function lib.registerCommand(data, callback)
+    if not data.groups then data.groups = 'builtin.everyone' end
+    if type(data.name) == "table" then
+        for i = 1, #data.name do
+            lib.registerCommand({
+                name = data.name[i],
+                help = data.help,
+                params = data.params,
+                groups = data.groups
+            }, callback)
+        end
+    else
+        chatSuggestions(data.name, data.params, data.help)
+
+        RegisterCommand(data.name, function(source, args, raw)
+            source = tonumber(source) --[[@as number]]
+
+            if data.params then
+                for i = 1, #data.params do
+                    local currParam = data.params[i]
+                    local arg, argType = currParam.name, currParam.type
+                    local value = args[i]
+
+                    if arg == 'target' and value == 'me' then value = source end
+
+                    if argType and argType ~= '' then
+                        if argType == 'number' then
+                            value = tonumber(value) or value
+                        end
+
+                        local type = type(value)
+
+                        if data.required and type ~= argType then
+                            local invalid = ('^1%s expected <%s> for argument %s (%s), received %s^0'):format(data.name,
+                                argType, i, arg, type)
+                            if source < 1 then
+                                return print(invalid)
+                            else
+                                return TriggerClientEvent('chat:addMessage', source, invalid)
+                            end
+                        end
+                    end
+
+                    args[arg] = value
+                    args[i] = nil
+                end
+            end
+
+            callback(source, args, raw)
+        end, data.groups and true)
+
+        data.name = ('command.%s'):format(data.name)
+        if type(data.groups) == 'table' then
+            for _, v in ipairs(data.groups) do
+                if not IsPrincipalAceAllowed(v, data.name) then lib.addAce(v, data.name) end
+            end
+        else
+            if not IsPrincipalAceAllowed(data.groups, data.name) then lib.addAce(data.groups, data.name) end
+        end
+    end
+end
+
+return lib.registerCommand
+
+--[[ example
+lib.registerCommand({
+    name = {'testshit', 'testshit2'},
+    help = "Give an item to a player",
+    groups = {'admin', 'moderator'},
+    params = {
+        {
+            name = "target",
+            help = "Server ID",
+            type = "number",
+            required = true
+        },
+        {
+            name = "item",
+            help = "Name of the item to give",
+            type = "string",
+            required = true
+        },
+        {
+            name = "count",
+            help = "Amount of the item to give, leave blank for 1",
+            type = "number",
+            required = false
+        },
+        {
+            name = "metatype",
+            help = "Metatype of the item",
+            type = "string",
+            required = false
+        }
+    },
+}, function(source, args)
+    args.item = Items(args.item)
+    if args.item and args.count > 0 then
+        Inventory.AddItem(args.target, args.item.name, args.count, args.metatype)
+    end
+end)
+]]


### PR DESCRIPTION
Allows for use of an additional `:` after the arg type where you can specify help text for individual arguments