### PR TITLE
feat: Support image Tag in buttons

### DIFF
--- a/package/client/resource/interface/context.ts
+++ b/package/client/resource/interface/context.ts
@@ -6,7 +6,7 @@ interface ContextMenuItem {
   description?: string;
   arrow?: boolean;
   image?: string;
-  icon?: IconName | [IconPrefix, IconName];
+  icon?: IconName | [IconPrefix, IconName] | string;
   iconColor?: string;
   progress?: number;
   colorScheme?: string;

--- a/package/client/resource/interface/menu.ts
+++ b/package/client/resource/interface/menu.ts
@@ -5,7 +5,7 @@ type ChangeFunction = (selected: number, scrollIndex?: number, args?: any, check
 
 interface MenuOptions {
   label: string;
-  icon?: IconName | [IconPrefix, IconName];
+  icon?: IconName | [IconPrefix, IconName] | string;
   checked?: boolean;
   values?: Array<string | { label: string; description: string }>;
   description?: string;

--- a/web/src/features/menu/context/components/ContextButton.tsx
+++ b/web/src/features/menu/context/components/ContextButton.tsx
@@ -3,6 +3,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import ReactMarkdown from 'react-markdown';
 import { Option, ContextMenuProps } from '../../../../typings';
 import { fetchNui } from '../../../../utils/fetchNui';
+import { isIconUrl } from '../../../../utils/isIconUrl';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 const openMenu = (id: string | undefined) => {
   fetchNui<ContextMenuProps>('openContext', { id: id, back: false });
@@ -21,8 +23,8 @@ const useStyles = createStyles((theme, params: { disabled?: boolean }) => ({
     color: params.disabled ? theme.colors.dark[3] : theme.colors.dark[0],
     whiteSpace: 'pre-wrap',
   },
-  image: {
-    maxWidth: '30px'
+  iconImage: {
+    maxWidth: '25px',
   },
   description: {
     color: params.disabled ? theme.colors.dark[3] : theme.colors.dark[2],
@@ -64,12 +66,20 @@ const ContextButton: React.FC<{
             <Group position="apart" w="100%" noWrap>
               <Stack spacing={4} style={{ flex: '1' }}>
                 <Group spacing={8} noWrap>
-                  {button?.icon && !button?.image && (
+                  {button?.icon && (
                     <Stack w={25} h={25} justify="center" align="center">
-                      <FontAwesomeIcon icon={button.icon} fixedWidth size="lg" style={{ color: button.iconColor }} />
+                      {typeof button.icon === 'string' && isIconUrl(button.icon) ? (
+                        <img src={button.icon} className={classes.iconImage} alt="Missing img" />
+                      ) : (
+                        <FontAwesomeIcon
+                          icon={button.icon as IconProp}
+                          fixedWidth
+                          size="lg"
+                          style={{ color: button.iconColor }}
+                        />
+                      )}
                     </Stack>
                   )}
-                  {button?.image && !button?.icon && <Image src={button.image} className={classes.image} /> }
                   <Text sx={{ overflowWrap: 'break-word' }}>
                     <ReactMarkdown>{button.title || buttonKey}</ReactMarkdown>
                   </Text>

--- a/web/src/features/menu/context/components/ContextButton.tsx
+++ b/web/src/features/menu/context/components/ContextButton.tsx
@@ -22,8 +22,7 @@ const useStyles = createStyles((theme, params: { disabled?: boolean }) => ({
     whiteSpace: 'pre-wrap',
   },
   image: {
-    marginRight: '10px',
-    maxWidth: '50px'
+    maxWidth: '30px'
   },
   description: {
     color: params.disabled ? theme.colors.dark[3] : theme.colors.dark[2],

--- a/web/src/features/menu/context/components/ContextButton.tsx
+++ b/web/src/features/menu/context/components/ContextButton.tsx
@@ -21,6 +21,10 @@ const useStyles = createStyles((theme, params: { disabled?: boolean }) => ({
     color: params.disabled ? theme.colors.dark[3] : theme.colors.dark[0],
     whiteSpace: 'pre-wrap',
   },
+  image: {
+    marginRight: '10px',
+    maxWidth: '50px'
+  },
   description: {
     color: params.disabled ? theme.colors.dark[3] : theme.colors.dark[2],
   },
@@ -61,11 +65,12 @@ const ContextButton: React.FC<{
             <Group position="apart" w="100%" noWrap>
               <Stack spacing={4} style={{ flex: '1' }}>
                 <Group spacing={8} noWrap>
-                  {button?.icon && (
+                  {button?.icon && !button?.image && (
                     <Stack w={25} h={25} justify="center" align="center">
                       <FontAwesomeIcon icon={button.icon} fixedWidth size="lg" style={{ color: button.iconColor }} />
                     </Stack>
                   )}
+                  {button?.image && !button?.icon && <Image src={button.image} className={classes.image} /> }
                   <Text sx={{ overflowWrap: 'break-word' }}>
                     <ReactMarkdown>{button.title || buttonKey}</ReactMarkdown>
                   </Text>

--- a/web/src/features/menu/list/ListItem.tsx
+++ b/web/src/features/menu/list/ListItem.tsx
@@ -1,4 +1,4 @@
-import { Box, Group, Stack, Text, Progress } from '@mantine/core';
+import { Box, Group, Stack, Text, Progress, Image } from '@mantine/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { forwardRef } from 'react';
 import CustomCheckbox from './CustomCheckbox';
@@ -23,6 +23,10 @@ const useStyles = createStyles((theme, params: { iconColor?: string }) => ({
       backgroundColor: theme.colors.dark[4],
       outline: 'none',
     },
+  },
+  image: {
+    marginRight: '10px',
+    maxWidth: '50px',
   },
   buttonWrapper: {
     paddingLeft: 5,
@@ -77,9 +81,14 @@ const ListItem = forwardRef<Array<HTMLDivElement | null>, Props>(({ item, index,
       }}
     >
       <Group spacing={15} noWrap className={classes.buttonWrapper}>
-        {item.icon && (
+        {item.icon && !item.image && (
           <Box className={classes.iconContainer}>
             <FontAwesomeIcon icon={item.icon} className={classes.icon} fixedWidth />
+          </Box>
+        )}
+         {item.image && !item.icon && (
+          <Box className={classes.iconContainer}>
+            <Image src={item.image} className={classes.image} />
           </Box>
         )}
         {Array.isArray(item.values) ? (

--- a/web/src/features/menu/list/ListItem.tsx
+++ b/web/src/features/menu/list/ListItem.tsx
@@ -25,8 +25,7 @@ const useStyles = createStyles((theme, params: { iconColor?: string }) => ({
     },
   },
   image: {
-    marginRight: '10px',
-    maxWidth: '50px',
+    maxWidth: '33px',
   },
   buttonWrapper: {
     paddingLeft: 5,

--- a/web/src/features/menu/list/ListItem.tsx
+++ b/web/src/features/menu/list/ListItem.tsx
@@ -4,6 +4,8 @@ import React, { forwardRef } from 'react';
 import CustomCheckbox from './CustomCheckbox';
 import type { MenuItem } from '../../../typings';
 import { createStyles } from '@mantine/core';
+import { isIconUrl } from '../../../utils/isIconUrl';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 interface Props {
   item: MenuItem;
@@ -24,8 +26,8 @@ const useStyles = createStyles((theme, params: { iconColor?: string }) => ({
       outline: 'none',
     },
   },
-  image: {
-    maxWidth: '33px',
+  iconImage: {
+    maxWidth: 32,
   },
   buttonWrapper: {
     paddingLeft: 5,
@@ -35,6 +37,8 @@ const useStyles = createStyles((theme, params: { iconColor?: string }) => ({
   iconContainer: {
     display: 'flex',
     alignItems: 'center',
+    width: 32,
+    height: 32,
   },
   icon: {
     fontSize: 24,
@@ -80,14 +84,13 @@ const ListItem = forwardRef<Array<HTMLDivElement | null>, Props>(({ item, index,
       }}
     >
       <Group spacing={15} noWrap className={classes.buttonWrapper}>
-        {item.icon && !item.image && (
+        {item.icon && (
           <Box className={classes.iconContainer}>
-            <FontAwesomeIcon icon={item.icon} className={classes.icon} fixedWidth />
-          </Box>
-        )}
-         {item.image && !item.icon && (
-          <Box className={classes.iconContainer}>
-            <Image src={item.image} className={classes.image} />
+            {typeof item.icon === 'string' && isIconUrl(item.icon) ? (
+              <img src={item.icon} alt="Missing image" className={classes.iconImage} />
+            ) : (
+              <FontAwesomeIcon icon={item.icon as IconProp} className={classes.icon} fixedWidth />
+            )}
           </Box>
         )}
         {Array.isArray(item.values) ? (

--- a/web/src/typings/context.ts
+++ b/web/src/typings/context.ts
@@ -6,7 +6,7 @@ export interface Option {
   description?: string;
   arrow?: boolean;
   image?: string;
-  icon?: IconProp;
+  icon?: IconProp | string;
   iconColor?: string;
   progress?: number;
   colorScheme?: string;

--- a/web/src/typings/menu.ts
+++ b/web/src/typings/menu.ts
@@ -3,6 +3,7 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core';
 export type MenuPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
 export interface MenuItem {
+  image?: string;
   label: string;
   progress?: number;
   colorScheme?: string;

--- a/web/src/typings/menu.ts
+++ b/web/src/typings/menu.ts
@@ -10,7 +10,7 @@ export interface MenuItem {
   checked?: boolean;
   values?: Array<string | { label: string; description: string }>;
   description?: string;
-  icon?: IconProp;
+  icon?: IconProp | string;
   iconColor?: string;
   defaultIndex?: number;
   close?: boolean;

--- a/web/src/utils/isIconUrl.ts
+++ b/web/src/utils/isIconUrl.ts
@@ -1,0 +1,1 @@
+export const isIconUrl = (icon: string) => icon.includes('://') || icon.includes('.png') || icon.includes('.webp');


### PR DESCRIPTION
in my server. ox_lib is heavily used.
most of sample use cases for this is.
Food image,
Ingredients,
Vehicle Parts,
etc..

i believe font awesome is not enough for some use cases.

i did suggest this on v3 pending PR.
but it seems gets ignored.

here i am gonna try to push this PR.

to use this.
icon must be not existing in the options.

if both icon and image is in options, nothing will appear.

image in metadata will still appear normaly.

Sample:

![image](https://user-images.githubusercontent.com/82306584/219871876-602e7180-9743-4cc2-9ac6-76c8093f601f.png)
![image](https://user-images.githubusercontent.com/82306584/219871901-9b971c2e-ea3d-467d-b258-e2062e4c6ce6.png)

sample usage:
```
				image = 'nui://ox_inventory/web/images/engine.png',
```