### PR TITLE
feat(input) : Support onChange callbacks

### DIFF
--- a/resource/interface/client/input.lua
+++ b/resource/interface/client/input.lua
@@ -1,5 +1,4 @@
 local input
-
 ---@class InputDialogRowProps
 ---@field type 'input' | 'number' | 'checkbox' | 'select' | 'slider' | 'multi-select' | 'date' | 'date-range' | 'time' | 'textarea'
 ---@field label string
@@ -27,7 +26,8 @@ local input
 ---@param rows string[] | InputDialogRowProps[]
 ---@param options InputDialogOptionsProps[]
 ---@return string[] | number[] | boolean[] | nil
-function lib.inputDialog(heading, rows, options)
+local callback = function() return end
+function lib.inputDialog(heading, rows, options,fn)
     if input then return end
     input = promise.new()
 
@@ -37,7 +37,9 @@ function lib.inputDialog(heading, rows, options)
             rows[i] = { type = 'input', label = rows[i] --[[@as string]] }
         end
     end
-
+    if fn then
+        callback = fn
+    end
     SetNuiFocus(true, true)
     SendNUIMessage({
         action = 'openDialog',
@@ -47,7 +49,7 @@ function lib.inputDialog(heading, rows, options)
             options = options
         }
     })
-
+    
     return Citizen.Await(input)
 end
 
@@ -59,6 +61,7 @@ function lib.closeInputDialog()
     SendNUIMessage({
         action = 'closeInputDialog'
     })
+    callback = function() return end
 end
 
 RegisterNUICallback('inputData', function(data, cb)
@@ -67,4 +70,10 @@ RegisterNUICallback('inputData', function(data, cb)
     local promise = input
     input = nil
     promise:resolve(data)
+    callback = function() return end
+end)
+
+RegisterNUICallback('inputCallback', function(data, cb)
+    cb(1)
+    callback(data)
 end)

--- a/web/src/features/dialog/InputDialog.tsx
+++ b/web/src/features/dialog/InputDialog.tsx
@@ -114,6 +114,7 @@ const InputDialog: React.FC = () => {
                       register={form.register(`test.${index}.value`, { required: row.required })}
                       row={row}
                       index={index}
+                      control={form.control}
                     />
                   )}
                   {row.type === 'checkbox' && (

--- a/web/src/features/dialog/components/fields/input.tsx
+++ b/web/src/features/dialog/components/fields/input.tsx
@@ -3,11 +3,15 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import { IInput } from '../../../../typings/dialog';
 import { UseFormRegisterReturn } from 'react-hook-form';
+import { fetchNui } from '../../../../utils/fetchNui';
+import { Control, useController } from 'react-hook-form';
+import { FormValues } from '../../InputDialog';
 
 interface Props {
   register: UseFormRegisterReturn;
   row: IInput;
   index: number;
+  control: Control<FormValues>;
 }
 
 const useStyles = createStyles((theme) => ({
@@ -18,7 +22,16 @@ const useStyles = createStyles((theme) => ({
 
 const InputField: React.FC<Props> = (props) => {
   const { classes } = useStyles();
-
+  const HandleChange = (change?: any, data?: any) => {
+    fetchNui('inputCallback', data);
+    return change
+  }; 
+  const controller = useController({
+    name: `test.${props.index}.value`,
+    control: props.control,
+    defaultValue: props.row.default,
+    rules: { required: props.row.required },
+  });
   return (
     <>
       {!props.row.password ? (
@@ -26,6 +39,7 @@ const InputField: React.FC<Props> = (props) => {
           {...props.register}
           defaultValue={props.row.default}
           label={props.row.label}
+          onChange={HandleChange(controller.field.onChange,{index: props.index, value: controller.field.value})}
           description={props.row.description}
           icon={props.row.icon && <FontAwesomeIcon icon={props.row.icon} fixedWidth />}
           placeholder={props.row.placeholder}

--- a/web/src/features/dialog/components/fields/number.tsx
+++ b/web/src/features/dialog/components/fields/number.tsx
@@ -3,6 +3,7 @@ import { INumber } from '../../../../typings/dialog';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Control, useController } from 'react-hook-form';
 import { FormValues } from '../../InputDialog';
+import { fetchNui } from '../../../../utils/fetchNui';
 
 interface Props {
   row: INumber;
@@ -17,14 +18,17 @@ const NumberField: React.FC<Props> = (props) => {
     defaultValue: props.row.default,
     rules: { required: props.row.required },
   });
-
+  const HandleChange = (change?: any, data?: any) => {
+    fetchNui('inputCallback', data);
+    return change
+  }; 
   return (
     <NumberInput
       value={controller.field.value}
       name={controller.field.name}
       ref={controller.field.ref}
       onBlur={controller.field.onBlur}
-      onChange={controller.field.onChange}
+      onChange={HandleChange(controller.field.onChange,{index: props.index, value: controller.field.value})}
       label={props.row.label}
       description={props.row.description}
       defaultValue={props.row.default}

--- a/web/src/features/dialog/components/fields/slider.tsx
+++ b/web/src/features/dialog/components/fields/slider.tsx
@@ -1,6 +1,7 @@
 import { Box, Slider, Text } from '@mantine/core';
 import { ISlider } from '../../../../typings/dialog';
 import { Control, useController } from 'react-hook-form';
+import { fetchNui } from '../../../../utils/fetchNui';
 import { FormValues } from '../../InputDialog';
 
 interface Props {
@@ -10,12 +11,16 @@ interface Props {
 }
 
 const SliderField: React.FC<Props> = (props) => {
+  const HandleChange = (change?: any, data?: any) => {
+    fetchNui('inputCallback', data);
+    return change
+  }; 
   const controller = useController({
     name: `test.${props.index}.value`,
     control: props.control,
     defaultValue: props.row.default || props.row.min || 0,
   });
-
+  
   return (
     <Box>
       <Text sx={{ fontSize: 14, fontWeight: 500 }}>{props.row.label}</Text>
@@ -25,7 +30,7 @@ const SliderField: React.FC<Props> = (props) => {
         name={controller.field.name}
         ref={controller.field.ref}
         onBlur={controller.field.onBlur}
-        onChange={controller.field.onChange}
+        onChange={HandleChange(controller.field.onChange,{index: props.index, value: controller.field.value})}
         defaultValue={props.row.default || props.row.min || 0}
         min={props.row.min}
         max={props.row.max}


### PR DESCRIPTION
not sure if this is the proper way to implement:

4th parameter in Input Dialog supports cb that returns any changed value.

Return Data is:
![image](https://user-images.githubusercontent.com/82306584/221170423-5255fc65-7d45-414a-a47e-27f55f144ef6.png)

Supports only: Input, Slider, Number.
Usage:

```
        local input = lib.inputDialog('Police locker', {
		{ type = "slider", label = "Ignition Timing", min = -0.5, max = 1.5 , step = 0.001, default = 1.0},
		{ type = "number", label = "Camber Alignment", default = 1 },
		{ type = "input", label = "Gear Ratio", default = '3.251' },
		}, {}, function(data)
		print(json.encode(data, {indent = true}),'data')
	end)
```

This will be usefull on some cases that needs to see the real time change before applying.