### PR TITLE
fix(radial): go back to correct more page when going back from sub

### DIFF
--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -19,7 +19,7 @@ local menus = {}
 ---@type RadialMenuItem[]
 local menuItems = {}
 
----@type table<{id: string, label: string}>
+---@type table<{id: string, option: string}>
 local menuHistory = {}
 
 ---@type RadialMenuProps?
@@ -27,8 +27,8 @@ local currentRadial = nil
 
 ---Open a the global radial menu or a registered radial submenu with the given id.
 ---@param id string?
----@param label number?
-local function showRadial(id, label)
+---@param option number?
+local function showRadial(id, option)
     local radial = id and menus[id]
 
     if id and not radial then
@@ -53,7 +53,7 @@ local function showRadial(id, label)
         data = {
             items = radial and radial.items or menuItems,
             sub = radial and true or nil,
-            label = label
+            option = option
         }
     })
 end
@@ -183,7 +183,7 @@ RegisterNUICallback('radialClick', function(index, cb)
     end
 
     if item.menu then
-        menuHistory[#menuHistory + 1] = { id = currentRadial and currentRadial.id, label = item.label }
+        menuHistory[#menuHistory + 1] = { id = currentRadial and currentRadial.id, option = item.menu }
         showRadial(item.menu)
     else
         lib.hideRadial()
@@ -211,7 +211,7 @@ RegisterNUICallback('radialBack', function(_, cb)
     menuHistory[numHistory] = nil
 
     if lastMenu.id then
-        return showRadial(lastMenu.id, lastMenu.label)
+        return showRadial(lastMenu.id, lastMenu.option)
     end
 
     currentRadial = nil
@@ -231,7 +231,7 @@ RegisterNUICallback('radialBack', function(_, cb)
         action = 'openRadialMenu',
         data = {
             items = menuItems,
-            label = lastMenu.label
+            option = lastMenu.option
         }
     })
 end)

--- a/web/src/features/menu/radial/index.tsx
+++ b/web/src/features/menu/radial/index.tsx
@@ -87,9 +87,13 @@ const RadialMenu: React.FC = () => {
     setMenuItems(items);
   }, [menu.items, menu.page]);
 
-  useNuiEvent('openRadialMenu', async (data: { items: RadialMenuItem[]; sub?: boolean } | false) => {
+  useNuiEvent('openRadialMenu', async (data: { items: RadialMenuItem[]; sub?: boolean, label?: string } | false) => {
     if (!data) return setVisible(false);
-    setMenu({ ...data, page: 1 });
+    let initialPage = 1;
+    if (data.label) {
+      data.items.findIndex((item, index) => item.label == data.label && (initialPage = Math.floor(index / PAGE_ITEMS) + 1));
+    }
+    setMenu({ ...data, page: initialPage });
     setVisible(true);
   });
 

--- a/web/src/features/menu/radial/index.tsx
+++ b/web/src/features/menu/radial/index.tsx
@@ -87,11 +87,11 @@ const RadialMenu: React.FC = () => {
     setMenuItems(items);
   }, [menu.items, menu.page]);
 
-  useNuiEvent('openRadialMenu', async (data: { items: RadialMenuItem[]; sub?: boolean, label?: string } | false) => {
+  useNuiEvent('openRadialMenu', async (data: { items: RadialMenuItem[]; sub?: boolean, option?: string } | false) => {
     if (!data) return setVisible(false);
     let initialPage = 1;
-    if (data.label) {
-      data.items.findIndex((item, index) => item.label == data.label && (initialPage = Math.floor(index / PAGE_ITEMS) + 1));
+    if (data.option) {
+      data.items.findIndex((item, index) => item.menu == data.option && (initialPage = Math.floor(index / PAGE_ITEMS) + 1));
     }
     setMenu({ ...data, page: initialPage });
     setVisible(true);

--- a/web/src/typings/radial.ts
+++ b/web/src/typings/radial.ts
@@ -4,4 +4,5 @@ export interface RadialMenuItem {
   icon: IconProp;
   label: string;
   isMore?: boolean;
+  menu?: string;
 }


### PR DESCRIPTION
Fixes https://github.com/overextended/ox_lib/issues/242

Since items lack an id, I'm storing the item label on `menuHistory` alongside the id. Also added the global radial menu to the `menuHistory` with id = nil.

added an option label parameter to `showRadial`  that gets passed to the NUI and used to find the page where that item will be