### PR TITLE
feat(radial): Move default key to a convar

### DIFF
--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -256,7 +256,7 @@ end)
 lib.addKeybind({
     name = 'ox_lib-radial',
     description = 'Open radial menu',
-    defaultKey = 'z',
+    defaultKey = GetConvar('ox_lib:defaultRadialkey', 'z'),
     onPressed = function()
         if isOpen then
             return lib.hideRadial()


### PR DESCRIPTION
Saw someone on discord mentioning 'Z' key was conflicting with other resources that use it. Kept the same name convention as ox_target

Can also make a pr to the docs if this gets accepted