### PR TITLE
fix(version): match major versions with multiple digits

### DIFF
--- a/resource/version/server.lua
+++ b/resource/version/server.lua
@@ -4,7 +4,7 @@ function lib.versionCheck(repository)
 	local currentVersion = GetResourceMetadata(resource, 'version', 0)
 
 	if currentVersion then
-		currentVersion = currentVersion:match('%d%.%d+%.%d+')
+		currentVersion = currentVersion:match('%d+%.%d+%.%d+')
 	end
 
 	if not currentVersion then return print(("^1Unable to determine current resource version for '%s' ^0"):format(resource)) end
@@ -16,7 +16,7 @@ function lib.versionCheck(repository)
 			response = json.decode(response)
 			if response.prerelease then return end
 
-			local latestVersion = response.tag_name:match('%d%.%d+%.%d+')
+			local latestVersion = response.tag_name:match('%d+%.%d+%.%d+')
 			if not latestVersion or latestVersion == currentVersion then return end
 
             local cv = { string.strsplit('.', currentVersion) }

--- a/resource/version/shared.lua
+++ b/resource/version/shared.lua
@@ -1,5 +1,5 @@
 function lib.checkDependency(resource, minimumVersion, printMessage)
-	local currentVersion = GetResourceMetadata(resource, 'version', 0):match('%d%.%d+%.%d+')
+	local currentVersion = GetResourceMetadata(resource, 'version', 0):match('%d+%.%d+%.%d+')
 
 	if currentVersion ~= minimumVersion then
 		local cv = { string.strsplit('.', currentVersion) }


### PR DESCRIPTION
Match major versions (`X.y.z`) with multiple digits.

Previously versions like `10.0.0` would get matched as `0.0.0` and the rest of the major version would be ignored.
I haven't actually tested this in a server but the issue seems pretty clear and easy to fix.