### PR TITLE
fix(interface): Add table<string, string> to icon typings

### DIFF
--- a/resource/interface/client/context.lua
+++ b/resource/interface/client/context.lua
@@ -4,7 +4,7 @@ local openContextMenu = nil
 ---@class ContextMenuItem
 ---@field title? string
 ---@field menu? string
----@field icon? string | table<string, string>
+---@field icon? string | {[1]: IconProp, [2]: string};
 ---@field iconColor? string
 ---@field onSelect? fun(args: any)
 ---@field arrow? boolean

--- a/resource/interface/client/context.lua
+++ b/resource/interface/client/context.lua
@@ -4,7 +4,7 @@ local openContextMenu = nil
 ---@class ContextMenuItem
 ---@field title? string
 ---@field menu? string
----@field icon? string
+---@field icon? string | table<string, string>
 ---@field iconColor? string
 ---@field onSelect? fun(args: any)
 ---@field arrow? boolean

--- a/resource/interface/client/input.lua
+++ b/resource/interface/client/input.lua
@@ -5,7 +5,7 @@ local input
 ---@field label string
 ---@field options? { value: string, label: string, default?: string }[]
 ---@field password? boolean
----@field icon? string
+---@field icon? string | table<string, string>
 ---@field iconColor? string
 ---@field placeholder? string
 ---@field default? string | number

--- a/resource/interface/client/input.lua
+++ b/resource/interface/client/input.lua
@@ -5,7 +5,7 @@ local input
 ---@field label string
 ---@field options? { value: string, label: string, default?: string }[]
 ---@field password? boolean
----@field icon? string | table<string, string>
+---@field icon? string | {[1]: IconProp, [2]: string};
 ---@field iconColor? string
 ---@field placeholder? string
 ---@field default? string | number

--- a/resource/interface/client/main.lua
+++ b/resource/interface/client/main.lua
@@ -1,3 +1,5 @@
+---@alias IconProp 'fas' | 'far' | 'fal' | 'fat' | 'fad' | 'fab' | 'fak' | 'fass'
+
 local keepInput = IsNuiFocusKeepingInput()
 
 function lib.setNuiFocus(allowInput, disableCursor)

--- a/resource/interface/client/menu.lua
+++ b/resource/interface/client/menu.lua
@@ -8,7 +8,7 @@ local openMenu
 
 ---@class MenuOptions
 ---@field label string
----@field icon? string | table<string, string>
+---@field icon? string | {[1]: IconProp, [2]: string};
 ---@field checked? boolean
 ---@field values? table<string | { label: string, description: string }>
 ---@field description? string

--- a/resource/interface/client/menu.lua
+++ b/resource/interface/client/menu.lua
@@ -8,7 +8,7 @@ local openMenu
 
 ---@class MenuOptions
 ---@field label string
----@field icon? string
+---@field icon? string | table<string, string>
 ---@field checked? boolean
 ---@field values? table<string | { label: string, description: string }>
 ---@field description? string

--- a/resource/interface/client/notify.lua
+++ b/resource/interface/client/notify.lua
@@ -9,7 +9,7 @@
 ---@field position? NotificationPosition
 ---@field type? NotificationType
 ---@field style? { [string]: any }
----@field icon? string;
+---@field icon? string | table<string, string>;
 ---@field iconColor? string;
 
 ---@param data NotifyProps

--- a/resource/interface/client/notify.lua
+++ b/resource/interface/client/notify.lua
@@ -9,7 +9,7 @@
 ---@field position? NotificationPosition
 ---@field type? NotificationType
 ---@field style? { [string]: any }
----@field icon? string | table<string, string>;
+---@field icon? string | {[1]: IconProp, [2]: string};
 ---@field iconColor? string;
 
 ---@param data NotifyProps

--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -1,6 +1,6 @@
 ---@class RadialMenuItem
 ---@field id string
----@field icon string
+---@field icon string | table<string, string>
 ---@field label string
 ---@field menu? string
 ---@field onSelect? fun(currentMenu: string | nil, itemIndex: number) | string

--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -1,6 +1,6 @@
 ---@class RadialMenuItem
 ---@field id string
----@field icon string | table<string, string>
+---@field icon string | {[1]: IconProp, [2]: string};
 ---@field label string
 ---@field menu? string
 ---@field onSelect? fun(currentMenu: string | nil, itemIndex: number) | string

--- a/resource/interface/client/textui.lua
+++ b/resource/interface/client/textui.lua
@@ -1,6 +1,6 @@
 ---@class TextUIOptions
 ---@field position? 'right-center' | 'left-center' | 'top-center';
----@field icon? string | table<string, string>;
+---@field icon? string | {[1]: IconProp, [2]: string};
 ---@field iconColor? string;
 ---@field style? string;
 

--- a/resource/interface/client/textui.lua
+++ b/resource/interface/client/textui.lua
@@ -1,6 +1,6 @@
 ---@class TextUIOptions
 ---@field position? 'right-center' | 'left-center' | 'top-center';
----@field icon? string;
+---@field icon? string | table<string, string>;
 ---@field iconColor? string;
 ---@field style? string;
 


### PR DESCRIPTION
`['far', 'heart']` is also a valid icon prop

I swear I read this on the docs, maybe on v2?

I can also update the docs if this gets merged