### PR TITLE
feat(streaming): RequestWeaponAsset

### DIFF
--- a/imports/requestWeaponAsset/client.lua
+++ b/imports/requestWeaponAsset/client.lua
@@ -1,16 +1,29 @@
 ---Load a weapon asset. When called from a thread, it will yield until it has loaded.
 ---@param weaponHash string | number
 ---@param timeout number? Number of ticks to wait for the asset to load. Default is 500.
+---@param p1 number? Unknown. Default is 31.
+---@param p2 number? Unknown. Default is 0.
 ---@return string | number? weaponHash
-function lib.requestWeaponAsset(weaponHash, timeout)
+function lib.requestWeaponAsset(weaponHash, timeout, p1, p2)
     if HasWeaponAssetLoaded(weaponHash) then return weaponHash end
 
     local weaponHashType = type(weaponHash)
     if weaponHashType ~= 'string' and weaponHashType ~= "number" then
-        error(("expected weaponHash to have type 'string' (received %s)"):format(weaponHashType))
+        error(("expected weaponHash to have type 'string' or 'number' (received %s)"):format(weaponHashType))
     end
 
-    RequestWeaponAsset(weaponHash, 31, 0)
+    p1 = p1 or 31
+    p2 = p2 or 0
+
+    if type(p1) ~= 'number' then
+        error(("expected p1 to have type 'number' (received %s)"):format(type(p1)))
+    end
+
+    if type(p2) ~= 'number' then
+        error(("expected p2 to have type 'number' (received %s)"):format(type(p2)))
+    end
+
+    RequestWeaponAsset(weaponHash, p1, p2)
 
     if coroutine.running() then
         timeout = tonumber(timeout) or 500

--- a/imports/requestWeaponAsset/client.lua
+++ b/imports/requestWeaponAsset/client.lua
@@ -1,0 +1,32 @@
+---Load a weapon asset. When called from a thread, it will yield until it has loaded.
+---@param weaponHash string | number
+---@param timeout number? Number of ticks to wait for the asset to load. Default is 500.
+---@return string | number? weaponHash
+function lib.requestWeaponAsset(weaponHash, timeout)
+    if HasWeaponAssetLoaded(weaponHash) then return weaponHash end
+
+    local weaponHashType = type(weaponHash)
+    if weaponHashType ~= 'string' and weaponHashType ~= "number" then
+        error(("expected weaponHash to have type 'string' (received %s)"):format(weaponHashType))
+    end
+
+    RequestWeaponAsset(weaponHash, 31, 0)
+
+    if coroutine.running() then
+        timeout = tonumber(timeout) or 500
+
+        for _ = 1, timeout do
+            if HasWeaponAssetLoaded(weaponHash) then
+                return weaponHash
+            end
+
+            Wait(0)
+        end
+
+        print(("failed to load weaponHash '%s' after %s ticks"):format(weaponHash, timeout))
+    end
+
+    return weaponHash
+end
+
+return lib.requestWeaponAsset

--- a/package/client/resource/streaming/index.ts
+++ b/package/client/resource/streaming/index.ts
@@ -3,12 +3,13 @@ function streamingRequest(
   hasLoaded: Function,
   assetType: string,
   asset: any,
-  timeout?: number
+  timeout?: number,
+  ...args: any
 ): Promise<any> {
   return new Promise((resolve, reject) => {
     if (hasLoaded(asset)) resolve(asset);
 
-    request(asset);
+    request(asset, ...args);
 
     if (typeof timeout !== 'number') timeout = 500;
 
@@ -46,5 +47,9 @@ export const requestStreamedTextureDict = (textureDict: string, timeout?: number
 export const requestNamedPtfxAsset = (ptFxName: string, timeout?: number): Promise<string> =>
   streamingRequest(RequestNamedPtfxAsset, HasNamedPtfxAssetLoaded, 'ptFxName', ptFxName, timeout);
 
-export const requestWeaponAsset = (weaponHash: string | number, timeout?: number): Promise<string | number> =>
-  streamingRequest(RequestWeaponAsset, HasWeaponAssetLoaded, 'weaponHash', weaponHash, timeout);
+export const requestWeaponAsset = (weaponHash: string | number, timeout?: number, p1?: number, p2?: number): Promise<string | number> => {
+  p1 = p1 || 31;
+  p2 = p2 || 0;
+
+  return streamingRequest(RequestWeaponAsset, HasWeaponAssetLoaded, 'weaponHash', weaponHash, timeout, p1, p2);
+}

--- a/package/client/resource/streaming/index.ts
+++ b/package/client/resource/streaming/index.ts
@@ -45,3 +45,6 @@ export const requestStreamedTextureDict = (textureDict: string, timeout?: number
 
 export const requestNamedPtfxAsset = (ptFxName: string, timeout?: number): Promise<string> =>
   streamingRequest(RequestNamedPtfxAsset, HasNamedPtfxAssetLoaded, 'ptFxName', ptFxName, timeout);
+
+export const requestWeaponAsset = (weaponHash: string | number, timeout?: number): Promise<string | number> =>
+  streamingRequest(RequestWeaponAsset, HasWeaponAssetLoaded, 'weaponHash', weaponHash, timeout);


### PR DESCRIPTION
Adds [RequestWeaponAsset](https://docs.fivem.net/natives/?_0x5443438F033E29C3) to the lib.

Added p1 as 31 and p2 as 0 for the lua version.

Regarding the npm package I used the generic function so p1 and p2 weren't included but was able to use [CreateWeaponObject](https://docs.fivem.net/natives/?_0x9541D3CF0D398F36) and [ShootSingleBulletBetweenCoords](https://docs.fivem.net/natives/?_0x867654CBC7606F2C) without issues when testing.
