### PR TITLE
Add clearAllRadialItems

### DIFF
--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -182,6 +182,15 @@ function lib.removeRadialItem(id)
     refreshRadial(id)
 end
 
+---Removes all items from the global radial menu.
+function lib.clearAllRadialItems()
+    if isOpen then
+        lib.hideRadial()
+    end
+
+    table.wipe(menuItems)
+end
+
 RegisterNUICallback('radialClick', function(index, cb)
     cb(1)
 

--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -183,12 +183,13 @@ function lib.removeRadialItem(id)
 end
 
 ---Removes all items from the global radial menu.
-function lib.clearAllRadialItems()
-    if isOpen then
-        lib.hideRadial()
-    end
-
+function lib.clearRadialItems()
     table.wipe(menuItems)
+
+    if isOpen then
+        refreshRadial()
+    end
+    
 end
 
 RegisterNUICallback('radialClick', function(index, cb)


### PR DESCRIPTION
I used this for our conversion from qb-radialmenu to clear the menu then only add a "call for help" option or similar. Figured it could be useful in other niche situations