### PR TITLE
fix(interface/radial): SetNuiFocusKeepInput to true

### DIFF
--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -314,7 +314,7 @@ lib.addKeybind({
             }
         })
 
-        lib.setNuiFocus(false)
+        lib.setNuiFocus(true)
         SetCursorLocation(0.5, 0.5)
 
         while isOpen do


### PR DESCRIPTION
Radialmenu ran into a issue with keep closing when onReleased = lib.hideRadial was uncommented.

Looking back at the commit history this used to be set to true aswel not sure why that was changed but this fixed onReleased issue.