### PR TITLE
feat(imports): cron scheduling

### DIFF
--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -178,15 +178,44 @@ end
 local function parseCron(value, unit)
     if not value or value == '*' then return end
 
+    local num = tonumber(value)
+
+    if num then return num end
+
+    if unit == 'wday' then
+        if value == 'sun' then return 1 end
+        if value == 'mon' then return 2 end
+        if value == 'tue' then return 3 end
+        if value == 'wed' then return 4 end
+        if value == 'thu' then return 5 end
+        if value == 'fri' then return 6 end
+        if value == 'sat' then return 7 end
+    end
+
+    if unit == 'month' then
+        if value == 'jan' then return 1 end
+        if value == 'feb' then return 2 end
+        if value == 'mar' then return 3 end
+        if value == 'apr' then return 4 end
+        if value == 'may' then return 5 end
+        if value == 'jun' then return 6 end
+        if value == 'jul' then return 7 end
+        if value == 'aug' then return 8 end
+        if value == 'sep' then return 9 end
+        if value == 'oct' then return 10 end
+        if value == 'nov' then return 11 end
+        if value == 'dec' then return 12 end
+    end
+
     if getTimeUnit(value, unit) then return value end
 
-    return tonumber(value) or error(("syntax '%s' is not supported (only numbers and * are currently supported)"):format(value))
+    error(("^1invalid cron expression. '%s' is not supported for %s^0"):format(value, unit), 3)
 end
 
 ---@param expression string
 ---@param cb fun(task: OxTask, date: osdate)
 function lib.cron.new(expression, cb)
-    local minute, hour, day, month, weekday = string.strsplit(' ', expression)
+    local minute, hour, day, month, weekday = string.strsplit(' ', string.lower(expression))
 
     ---@type OxTask
     local task = setmetatable({
@@ -201,6 +230,8 @@ function lib.cron.new(expression, cb)
     tasks[task.id] = task
 
     task:run()
+
+    return task
 end
 
 -- update the currentDate every minute

--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -71,7 +71,7 @@ function OxTask:scheduleTask()
     if self.isActive then
         self:cb(currentDate)
 
-        Wait(60000)
+        Wait(30000)
 
         return true
     end

--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -1,0 +1,145 @@
+lib.cron = {}
+local currentDate = os.date('*t') --[[@as osdate]]
+currentDate.sec = 0
+
+---@class OxTaskProperties
+---@field minute number?
+---@field hour number?
+---@field day number?
+---@field month number?
+---@field weekday number?
+---@field cb fun(task: OxTask, date: osdate)
+---@field isActive boolean
+---@field id number
+---@field getNextTime function
+
+---@class OxTask : OxTaskProperties
+local OxTask = {}
+OxTask.__index = OxTask
+
+---Get a timestamp for the next time to run the task today.
+---@return number?
+function OxTask:getNextTime()
+    if not self.isActive then return end
+    if self.day and self.day ~= currentDate.day then return end
+    if self.month and self.month ~= currentDate.month then return end
+    if self.weekday and self.weekday ~= currentDate.wday then return end
+
+    return os.time({
+        hour = self.hour or currentDate.hour,
+        min = self.minute or currentDate.min,
+        year = currentDate.year,
+        month = self.month or currentDate.month,
+        day = self.day or currentDate.day,
+    })
+end
+
+---@type OxTask[]
+local tasks = {}
+
+function OxTask:scheduleTask()
+    local runAt = self:getNextTime()
+
+    if not runAt then
+        return self:stop()
+    end
+
+    local currentTime = os.time()
+    local sleep = runAt - currentTime
+
+    if sleep < 0 then
+        if self.day or self.weekday then
+            return self:stop()
+        end
+
+        if self.hour then
+            sleep += 86400
+        elseif self.minute then
+            sleep += 3600
+        end
+
+        if sleep < 0 then
+            sleep += 60
+            runAt += 60
+        end
+    end
+
+    print(('running task %s in %d seconds (%0.2f minutes or %0.2f hours)'):format(self.id, sleep, sleep / 60, sleep / 60 / 60))
+
+    if sleep > 0 then Wait(sleep * 1000) end
+
+    if self.isActive then
+        self:cb(currentDate)
+
+        Wait(60000)
+
+        return true
+    end
+end
+
+---Start an inactive task.
+function OxTask:run()
+    if self.isActive then return end
+
+    self.isActive = true
+
+    CreateThread(function()
+        while self:scheduleTask() do end
+    end)
+end
+
+function OxTask:stop()
+    self.isActive = false
+end
+
+---@param value string
+---@return number | nil
+---@todo support proper cron expressions (lists, ranges, step values)
+---@todo "*/5 * * * *" to run every 5 minutes would be cool
+local function parseCron(value)
+    if not value or value == '*' then return end
+
+    return tonumber(value) or error(("syntax '%s' is not supported (only numbers and * are currently supported)"):format(value))
+end
+
+---@param expression string
+---@param cb fun(task: OxTask, date: osdate)
+function lib.cron.new(expression, cb)
+    local minute, hour, day, month, weekday = string.strsplit(' ', expression)
+
+    ---@type OxTask
+    local task = setmetatable({
+        minute = parseCron(minute),
+        hour = parseCron(hour),
+        day = parseCron(day),
+        month = parseCron(month),
+        weekday = parseCron(weekday),
+        cb = cb,
+        id = #tasks + 1
+    }, OxTask)
+    tasks[task.id] = task
+
+    task:run()
+end
+
+-- update the currentDate every minute
+lib.cron.new('* * * * *', function()
+    currentDate.min += 1
+
+    if currentDate.min > 59 then
+        currentDate = os.date('*t') --[[@as osdate]]
+    end
+end)
+
+-- reschedule any dead tasks on a new day
+lib.cron.new('0 0 * * *', function()
+    for i = 1, #tasks do
+        local task = tasks[i]
+
+        if not task.isActive then
+            task:run()
+        end
+    end
+end)
+
+return lib.cron


### PR DESCRIPTION
Testing and feedback appreciated. Doesn't support proper cron expressions yet™️.

```lua
---@param task OxTask
---@param date osdate
---@param msg string
local function debug(task, date, msg)
    print(('(%s/%s/%s %s:%s) ran task %s - %s'):format(date.year, date.month, date.day, date.hour, date.min, task.id, msg))
    print()
end

lib.cron.new('* * * * *', function(task, date)
    debug(task, date, 'every minute')
end)

lib.cron.new('30 * * * *', function(task, date)
    debug(task, date, 'every 30th minute')
end)

lib.cron.new('0 * * * *', function(task, date)
    debug(task, date, 'every hour')
end)

lib.cron.new('0 0 * * *', function(task, date)
    debug(task, date, 'at midnight')
end)

lib.cron.new('0 0 * * 6', function(task, date)
    debug(task, date, 'at midnight on friday')
end)

lib.cron.new('0 0 7 * *', function(task, date)
    debug(task, date, 'at midnight on the 7th day of the month')
end)

lib.cron.new('0 0 7 4 *', function(task, date)
    debug(task, date, 'at midnight on the 7th day of april')
end)
```

```
[         script:test] running task 1 in 43 seconds (0.72 minutes or 0.01 hours)
[         script:test] running task 2 in 25483 seconds (424.72 minutes or 7.08 hours)
[         script:test] running task 3 in 43 seconds (0.72 minutes or 0.01 hours)
[         script:test] running task 4 in 2083 seconds (34.72 minutes or 0.58 hours)
[         script:test] running task 5 in 283 seconds (4.72 minutes or 0.08 hours)
[         script:test] running task 6 in 25483 seconds (424.72 minutes or 7.08 hours)
...
[         script:test] (2023/4/7 16:56) ran task 3 - every minute
[         script:test]
[         script:test] running task 1 in 0 seconds (0.00 minutes or 0.00 hours)
[         script:test] running task 3 in 0 seconds (0.00 minutes or 0.00 hours)
[         script:test] (2023/4/7 16:57) ran task 3 - every minute
[         script:test]
[         script:test] running task 1 in 0 seconds (0.00 minutes or 0.00 hours)
[         script:test] running task 3 in 0 seconds (0.00 minutes or 0.00 hours)
[         script:test] (2023/4/7 16:58) ran task 3 - every minute
[         script:test]
[         script:test] running task 1 in 0 seconds (0.00 minutes or 0.00 hours)
[         script:test] running task 3 in 0 seconds (0.00 minutes or 0.00 hours)
[         script:test] (2023/4/7 16:59) ran task 3 - every minute
[         script:test]
[         script:test] (2023/4/7 16:59) ran task 5 - every hour
[         script:test]
[         script:test] running task 1 in 0 seconds (0.00 minutes or 0.00 hours)
[         script:test] running task 3 in 0 seconds (0.00 minutes or 0.00 hours)
[         script:test] (2023/4/7 17:0) ran task 3 - every minute
```