### PR TITLE
Fix for table.concat nil

### DIFF
--- a/resource/zoneCreator/client.lua
+++ b/resource/zoneCreator/client.lua
@@ -57,7 +57,7 @@ end
 local function closeCreator(cancel)
 	if not cancel then
 		if zoneType == 'poly' then
-			points[#points + 1] = vec(xCoord, yCoord)
+			points[#points + 1] = vec(xCoord, yCoord, zCoord)
 		end
 
         ---@type string[]


### PR DESCRIPTION
While using creator after creating poly zone, I found out that the last point is always missing `zCoord` if not confirmed.