### PR TITLE
Fix(context): ResetNUI Focus

### DIFF
--- a/resource/interface/client/context.lua
+++ b/resource/interface/client/context.lua
@@ -101,6 +101,7 @@ RegisterNUICallback('clickContext', function(id, cb)
     openContextMenu = nil
 
     SendNUIMessage({ action = 'hideContext' })
+    lib.resetNuiFocus()
 
     if data.onSelect then data.onSelect(data.args) end
     if data.event then TriggerEvent(data.event, data.args) end


### PR DESCRIPTION
After a recent update from @thelindat NUI focus was not reset, meaning that the user would get stuck, when trying to access a third party UI such as inventory.

Yes obviously I know u cant open the drop like this but Still got me stuck, and this PR seems to fix it did some testing with opening multiple context menus to make sure I didnt mess up somewhere and it seems to work as intended now
```lua
RegisterCommand('testshit', function()
    lib.registerContext({
        id = 'dadlover69420',
        title = 'Test inventory stuff',
        position = 'top-right',
        options = {
            {
                title = "teststuff",
                arrow = true,
                icon = 'turn-up',
                onSelect = function()
                    ox_inventory:openInventory('drop', '')
                end,
            },
        }
    })

    lib.showContext("dadlover69420")
end, false)
```