### PR TITLE
fix(progressbar): spamming cancel issue

### DIFF
--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -147,13 +147,13 @@ local function startProgress(data)
     end
 
     playerState.invBusy = false
-    local cancel = progress == false
-    progress = nil
 
-    if cancel then
+    if progress == false then
         SendNUIMessage({ action = 'progressCancel' })
         return false
     end
+
+    progress = nil
 
     return true
 end

--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -150,12 +150,9 @@ local function startProgress(data)
 
     if progress == false then
         SendNUIMessage({ action = 'progressCancel' })
-        return false
     end
 
-    progress = nil
-
-    return true
+    return progress == true
 end
 
 ---@param data ProgressProps


### PR DESCRIPTION
Issue:
Spamming starting and cancelling progress bar would sometimes result in prog bar returning true eventhough all are cancelled. I believe it is due to wrong condition race.

Repro: Bind prog bar to a key and spam cancel, if youre quick enough, you can cancel prog bar and start another one before the first one finished.

It's minor bug but I'd like to see this patched. I tested it on my seatbelt script and worked fine.

Linden mentioned it doesnt make sense or whatever, I didn't mess too much with the code, I only removed local variable and moved progress = nil below cancel check.