### PR TITLE
tweak(server/cron): getNextTime param to return time for any day

### DIFF
--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -12,10 +12,11 @@ currentDate.sec = 0
 ---@field isActive boolean
 ---@field id number
 ---@field getNextTime function
+---@field getAbsoluteNextTime function
 ---@field debug? boolean
 
 ---@class OxTask : OxTaskProperties
----@field private scheduleTask fun(self: OxTask)
+---@field private scheduleTask fun(self: OxTask): boolean?
 local OxTask = {}
 OxTask.__index = OxTask
 
@@ -114,6 +115,44 @@ function OxTask:getNextTime()
         day = day or currentDate.day,
         month = month or currentDate.month,
         year = currentDate.year,
+    })
+end
+
+-- Get timestamp for next time to run task at any day.
+---@return number
+function OxTask:getAbsoluteNextTime()
+    local minute = getTimeUnit(self.minute, 'min')
+
+    local hour = getTimeUnit(self.hour, 'hour')
+
+    local day = getTimeUnit(self.day, 'day')
+
+    -- To avoid modifying getTimeUnit function, the day is adjusted here if needed.
+    if self.day then
+        if currentDate.hour < hour or (currentDate.hour == hour and currentDate.min < minute) then
+            day = day - 1
+        end 
+    else
+        if currentDate.hour > hour or (currentDate.hour == hour and currentDate.min >= minute) then
+            day = day + 1
+        end
+    end
+    
+    local month = getTimeUnit(self.month, 'month')
+
+    local year = getTimeUnit(self.year, 'year')
+
+    -- Check if time will be in next year.
+    if os.time({year=year, month=month, day=day, hour=hour, min=minute}) < os.time() then
+        year = year and year + 1 or currentDate.year + 1
+    end
+
+    return os.time({
+        min = minute < 60 and minute or 0,
+        hour = hour < 24 and hour or 0,
+        day = day or currentDate.day,
+        month = month or currentDate.month,
+        year = year or currentDate.year,
     })
 end
 


### PR DESCRIPTION
This allows `getNextTime` to return an absolute next time (ignoring if it's today or not) to be returned. Can be useful in some scenarios.