### PR TITLE
fix(web/input): Blocks form submission with unclamped numbers

### DIFF
--- a/web/src/features/dialog/components/fields/number.tsx
+++ b/web/src/features/dialog/components/fields/number.tsx
@@ -15,7 +15,7 @@ const NumberField: React.FC<Props> = (props) => {
     name: `test.${props.index}.value`,
     control: props.control,
     defaultValue: props.row.default,
-    rules: { required: props.row.required },
+    rules: { required: props.row.required, min: props.row.min, max: props.row.max },
   });
 
   return (


### PR DESCRIPTION
Now if someone enters a number that is lower or higher than allowed and presses enter instead of the send button, it will send unclamped number.