### PR TITLE
bugfix: force clear vehicle custom colors before applying colours

### DIFF
--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -303,6 +303,7 @@ function lib.setVehicleProperties(vehicle, props)
 
     if props.color1 then
         if type(props.color1) == 'number' then
+            ClearVehicleCustomPrimaryColour(vehicle)
             SetVehicleColours(vehicle, props.color1 --[[@as number]], colorSecondary --[[@as number]])
         else
             SetVehicleCustomPrimaryColour(vehicle, props.color1[1], props.color1[2], props.color1[3])
@@ -311,6 +312,7 @@ function lib.setVehicleProperties(vehicle, props)
 
     if props.color2 then
         if type(props.color2) == 'number' then
+            ClearVehicleCustomPrimaryColour(vehicle)
             SetVehicleColours(vehicle, props.color1 or colorPrimary --[[@as number]], props.color2 --[[@as number]])
         else
             SetVehicleCustomSecondaryColour(vehicle, props.color2[1], props.color2[2], props.color2[3])


### PR DESCRIPTION
In some cases setting predefined colour doesn't override custom colour, so it requires to clear it out additionaly.