### PR TITLE
feat(zones): new zone type: interior

### DIFF
--- a/imports/zones/server.lua
+++ b/imports/zones/server.lua
@@ -103,6 +103,21 @@ lib.zones = {
         return data
     end,
 
+    ---@return CZone
+    interior = function(data)
+        data.id = #Zones + 1
+        data.type = 'interior'
+        data.remove = removeZone
+        data.debug = nil
+        data.debugColour = nil
+        data.inside = nil
+        data.onEnter = nil
+        data.onExit = nil
+
+        Zones[data.id] = data
+        return data
+    end,
+
     getAllZones = function() return Zones end,
 }
 


### PR DESCRIPTION
I was creating a resource using ox_lib zones and I was thinking, why do I need to create a poly zone or a box for an interior when I can use the native to verify that my player is inside of it?

Using the native [GetInteriorFromEntity](https://docs.fivem.net/natives/?_0x2107BA504071A6BB) I can get the interior id of the interior in which the player is located and thanks to it I can check if the player enters or leaves the the zone.

Using the native [GetInteriorAtCoords](https://docs.fivem.net/natives/?_0xB0F7F8663821D9C3) I can get the interior id at certain coordinates and using this thing I can check if a point is inside the zone by comparing the interior id obtained from the native with the interior id of the zone.

Unfortunately, on the **server side**, it is not possible to check if certain coordinates are part of a interior because there is no native to verify this / obtain the interior id at determinate coordinates.