### PR TITLE
feat: TTL cache for client and server

### DIFF
--- a/resource/cache/client.lua
+++ b/resource/cache/client.lua
@@ -54,6 +54,25 @@ CreateThread(function()
 	end
 end)
 
+
+
 function lib.cache(key)
 	return cache[key]
+end
+
+
+---@type table<any, {gameTime: number, value: any}>
+local ttlCache = {}
+
+---@param key any uniquely identifies a cached value
+---@param func function returns the value to cache
+---@param maxStalenessMs number values older than maxStaleness are re-computed. Milliseconds
+---@return any
+function lib.cache.ttl(key, func, maxStalenessMs)
+	local gameTime = GetGameTimer()
+	if ttlCache[key].gameTime + maxStalenessMs < gameTime then
+		ttlCache[key].gameTime = gameTime
+		ttlCache[key].value = func()
+	end
+	return ttlCache[key].value
 end

--- a/resource/cache/client.lua
+++ b/resource/cache/client.lua
@@ -70,7 +70,7 @@ local ttlCache = {}
 ---@return any
 function lib.cache.ttl(key, func, maxStalenessMs)
 	local gameTime = GetGameTimer()
-	if ttlCache[key].gameTime + maxStalenessMs < gameTime then
+	if not ttlCache[key] or ttlCache[key].gameTime + maxStalenessMs < gameTime then
 		ttlCache[key].gameTime = gameTime
 		ttlCache[key].value = func()
 	end

--- a/resource/cache/server.lua
+++ b/resource/cache/server.lua
@@ -7,7 +7,7 @@ local ttlCache = {}
 ---@return any
 function lib.cache.ttl(key, func, maxStalenessMs)
 	local gameTime = GetGameTimer()
-	if ttlCache[key].gameTime + maxStalenessMs < gameTime then
+	if not ttlCache[key] or ttlCache[key].gameTime + maxStalenessMs < gameTime then
 		ttlCache[key].gameTime = gameTime
 		ttlCache[key].value = func()
 	end

--- a/resource/cache/server.lua
+++ b/resource/cache/server.lua
@@ -1,0 +1,15 @@
+---@type table<any, {gameTime: number, value: any}>
+local ttlCache = {}
+
+---@param key any uniquely identifies a cached value
+---@param func function returns the value to cache
+---@param maxStalenessMs number values older than maxStaleness are re-computed. Milliseconds
+---@return any
+function lib.cache.ttl(key, func, maxStalenessMs)
+	local gameTime = GetGameTimer()
+	if ttlCache[key].gameTime + maxStalenessMs < gameTime then
+		ttlCache[key].gameTime = gameTime
+		ttlCache[key].value = func()
+	end
+	return ttlCache[key].value
+end


### PR DESCRIPTION
- Introduced a cache for on-demand value lookup to reduce compute costs. Identical cache code on both server and client.
- This isn't actually a traditional TTL cache, which would involve storing the TTL on the cache and evicting it after that time. Instead, the cache stores the game time for when it was last computed, and the caller specifies a max staleness to determine whether the value is recomputed or returned from cache. I think this gives callers more control as two different use cases for the same cached value may have different TTL requirements.
- The downside of this approach is that items are never evicted from the cache, so memory will only grow over time. This would be bad if a significant number of values are stored in the cache. One potential solution is to introduce an eviction function, so that callers can clear values from the cache. Another solution is to limit the size of the cache to prevent misuse. Or both.
- I didn't integrate directly with the existing global space cache, because I'm not too knowledgeable about metatables or the ramifications of a dynamic cache within true global space
- This is untested