### PR TITLE
fix(client/vehicleproperties): extras & fix(web): heading props

### DIFF
--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -277,11 +277,13 @@ end
 ---@param props VehicleProperties
 ---@return boolean?
 function lib.setVehicleProperties(vehicle, props)
-    if not DoesEntityExist(vehicle) then error(("Unable to set vehicle properties for '%s' (entity does not exist)"):
-            format(vehicle))
+    if not DoesEntityExist(vehicle) then
+        error(("Unable to set vehicle properties for '%s' (entity does not exist)"):
+        format(vehicle))
     end
 
-    if NetworkGetEntityIsNetworked(vehicle) and NetworkGetEntityOwner(vehicle) ~= cache.playerId then error((
+    if NetworkGetEntityIsNetworked(vehicle) and NetworkGetEntityOwner(vehicle) ~= cache.playerId then
+        error((
             "Unable to set vehicle properties for '%s' (client is not entity owner)"):format(vehicle))
     end
 
@@ -290,6 +292,13 @@ function lib.setVehicleProperties(vehicle, props)
 
     SetVehicleModKit(vehicle, 0)
     SetVehicleAutoRepairDisabled(vehicle, true)
+
+    if props.extras then
+        for id, disable in pairs(props.extras) do
+            SetVehicleExtra(vehicle, tonumber(id) --[[@as number]], disable == 1)
+        end
+        SetVehicleFixed(vehicle)
+    end
 
     if props.plate then
         SetVehicleNumberPlateText(vehicle, props.plate)
@@ -372,12 +381,6 @@ function lib.setVehicleProperties(vehicle, props)
     if props.neonEnabled then
         for i = 1, #props.neonEnabled do
             SetVehicleNeonLightEnabled(vehicle, i - 1, props.neonEnabled[i])
-        end
-    end
-
-    if props.extras then
-        for id, disable in pairs(props.extras) do
-            SetVehicleExtra(vehicle, tonumber(id) --[[@as number]], disable == 1)
         end
     end
 

--- a/web/src/config/markdowncomponents.tsx
+++ b/web/src/config/markdowncomponents.tsx
@@ -1,0 +1,8 @@
+import { Title } from '@mantine/core';
+import { Components } from 'react-markdown';
+
+export const markdownComponents: Components = {
+  h1: ({ node, ...props }) => <Title {...props} />,
+  h2: ({ node, ...props }) => <Title order={2} {...props} />,
+  h3: ({ node, ...props }) => <Title order={3} {...props} />,
+};

--- a/web/src/features/dialog/AlertDialog.tsx
+++ b/web/src/features/dialog/AlertDialog.tsx
@@ -6,6 +6,7 @@ import { fetchNui } from '../../utils/fetchNui';
 import { useLocales } from '../../providers/LocaleProvider';
 import remarkGfm from 'remark-gfm';
 import type { AlertProps } from '../../typings';
+import { markdownComponents } from '../../config/markdowncomponents';
 
 const AlertDialog: React.FC = () => {
   const { locale } = useLocales();
@@ -46,12 +47,13 @@ const AlertDialog: React.FC = () => {
         overlayOpacity={0.5}
         exitTransitionDuration={150}
         transition="fade"
-        title={<ReactMarkdown>{dialogData.header}</ReactMarkdown>}
+        title={<ReactMarkdown components={markdownComponents}>{dialogData.header}</ReactMarkdown>}
       >
         <Stack>
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             components={{
+              ...markdownComponents,
               img: ({ ...props }) => <img style={{ maxWidth: '100%', maxHeight: '100%' }} {...props} />,
             }}
           >

--- a/web/src/features/menu/context/ContextMenu.tsx
+++ b/web/src/features/menu/context/ContextMenu.tsx
@@ -7,6 +7,7 @@ import { fetchNui } from '../../../utils/fetchNui';
 import ReactMarkdown from 'react-markdown';
 import HeaderButton from './components/HeaderButton';
 import ScaleFade from '../../../transitions/ScaleFade';
+import { markdownComponents } from '../../../config/markdowncomponents';
 
 const openMenu = (id: string | undefined) => {
   fetchNui<ContextMenuProps>('openContext', { id: id, back: true });
@@ -92,8 +93,8 @@ const ContextMenu: React.FC = () => {
           )}
           <Box className={classes.titleContainer}>
             <Text className={classes.titleText}>
-              <ReactMarkdown>{contextMenu.title}</ReactMarkdown>
-            </Text>
+              <ReactMarkdown components={markdownComponents}>{contextMenu.title}</ReactMarkdown>
+            </Title>
           </Box>
           <HeaderButton icon="xmark" canClose={contextMenu.canClose} iconSize={18} handleClick={closeContext} />
         </Flex>

--- a/web/src/features/menu/context/components/ContextButton.tsx
+++ b/web/src/features/menu/context/components/ContextButton.tsx
@@ -5,6 +5,7 @@ import { Option, ContextMenuProps } from '../../../../typings';
 import { fetchNui } from '../../../../utils/fetchNui';
 import { isIconUrl } from '../../../../utils/isIconUrl';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { markdownComponents } from '../../../../config/markdowncomponents';
 
 const openMenu = (id: string | undefined) => {
   fetchNui<ContextMenuProps>('openContext', { id: id, back: false });
@@ -108,12 +109,12 @@ const ContextButton: React.FC<{
                     </Stack>
                   )}
                   <Text className={classes.buttonTitleText}>
-                    <ReactMarkdown>{button.title || buttonKey}</ReactMarkdown>
+                    <ReactMarkdown components={markdownComponents}>{button.title || buttonKey}</ReactMarkdown>
                   </Text>
                 </Group>
                 {button.description && (
                   <Text className={classes.description}>
-                    <ReactMarkdown>{button.description}</ReactMarkdown>
+                    <ReactMarkdown components={markdownComponents}>{button.description}</ReactMarkdown>
                   </Text>
                 )}
                 {button.progress !== undefined && (

--- a/web/src/features/notifications/NotificationWrapper.tsx
+++ b/web/src/features/notifications/NotificationWrapper.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import { Avatar, createStyles, Group, Stack, Box, Text, keyframes, Sx } from '@mantine/core';
 import React from 'react';
 import type { NotificationProps } from '../../typings';
+import { markdownComponents } from '../../config/markdowncomponents';
 
 const useStyles = createStyles((theme) => ({
   container: {
@@ -181,7 +182,10 @@ const Notifications: React.FC = () => {
             <Stack spacing={0}>
               {data.title && <Text className={classes.title}>{data.title}</Text>}
               {data.description && (
-                <ReactMarkdown className={`${!data.title ? classes.descriptionOnly : classes.description} description`}>
+                <ReactMarkdown
+                  components={markdownComponents}
+                  className={`${!data.title ? classes.descriptionOnly : classes.description} description`}
+                >
                   {data.description}
                 </ReactMarkdown>
               )}

--- a/web/src/features/textui/TextUI.tsx
+++ b/web/src/features/textui/TextUI.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import ScaleFade from '../../transitions/ScaleFade';
 import remarkGfm from 'remark-gfm';
 import type { TextUiProps, TextUiPosition } from '../../typings';
+import { markdownComponents } from '../../config/markdowncomponents';
 
 const useStyles = createStyles((theme, params: { position?: TextUiPosition }) => ({
   wrapper: {
@@ -52,7 +53,9 @@ const TextUI: React.FC = () => {
           <Box style={data.style} className={classes.container}>
             <Group spacing={12}>
               {data.icon && <FontAwesomeIcon icon={data.icon} fixedWidth size="lg" style={{ color: data.iconColor }} />}
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{data.text}</ReactMarkdown>
+              <ReactMarkdown components={markdownComponents} remarkPlugins={[remarkGfm]}>
+                {data.text}
+              </ReactMarkdown>
             </Group>
           </Box>
         </ScaleFade>


### PR DESCRIPTION
Vehicle Properties: When using `SetVehicleAutoRepairDisabled`, you need to repair the vehicle for applied extras to be visible.

Interface: Fixed weird heading margins when using markdown heading props.
![August06 - 03 24 - 2641](https://github.com/overextended/ox_lib/assets/20498875/607aeb97-6e30-4136-88ad-f8864114633a)

Sorry for 2 commits per pull, I couldn't figure out how to separate them.