### PR TITLE
fix(client/vehicleproperties): vehicle must be fixed for extras to apply visually

### DIFF
--- a/package/client/resource/vehicleProperties/index.ts
+++ b/package/client/resource/vehicleProperties/index.ts
@@ -8,6 +8,8 @@ interface VehicleProperties {
   fuelLevel: number;
   oilLevel: number;
   dirtLevel: number;
+  paintType1: number;
+  paintType2: number;
   color1: number | [number, number, number];
   color2: number | [number, number, number];
   pearlescentColor: number;
@@ -90,5 +92,5 @@ interface VehicleProperties {
 export const getVehicleProperties = (vehicle: number): VehicleProperties =>
   exports.ox_lib.getVehicleProperties(vehicle);
 
-export const setVehicleProperties = (vehicle: number, props: Partial<VehicleProperties>): boolean =>
+export const setVehicleProperties = (vehicle: number, props: Partial<VehicleProperties>, fixVehicle?: boolean): boolean =>
   exports.ox_lib.setVehicleProperties(vehicle, props);

--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -277,11 +277,13 @@ end
 ---@param props VehicleProperties
 ---@return boolean?
 function lib.setVehicleProperties(vehicle, props)
-    if not DoesEntityExist(vehicle) then error(("Unable to set vehicle properties for '%s' (entity does not exist)"):
-            format(vehicle))
+    if not DoesEntityExist(vehicle) then
+        error(("Unable to set vehicle properties for '%s' (entity does not exist)"):
+        format(vehicle))
     end
 
-    if NetworkGetEntityIsNetworked(vehicle) and NetworkGetEntityOwner(vehicle) ~= cache.playerId then error((
+    if NetworkGetEntityIsNetworked(vehicle) and NetworkGetEntityOwner(vehicle) ~= cache.playerId then
+        error((
             "Unable to set vehicle properties for '%s' (client is not entity owner)"):format(vehicle))
     end
 
@@ -290,6 +292,13 @@ function lib.setVehicleProperties(vehicle, props)
 
     SetVehicleModKit(vehicle, 0)
     SetVehicleAutoRepairDisabled(vehicle, true)
+
+    if props.extras then
+        for id, disable in pairs(props.extras) do
+            SetVehicleExtra(vehicle, tonumber(id) --[[@as number]], disable == 1)
+        end
+        SetVehicleFixed(vehicle)
+    end
 
     if props.plate then
         SetVehicleNumberPlateText(vehicle, props.plate)
@@ -372,12 +381,6 @@ function lib.setVehicleProperties(vehicle, props)
     if props.neonEnabled then
         for i = 1, #props.neonEnabled do
             SetVehicleNeonLightEnabled(vehicle, i - 1, props.neonEnabled[i])
-        end
-    end
-
-    if props.extras then
-        for id, disable in pairs(props.extras) do
-            SetVehicleExtra(vehicle, tonumber(id) --[[@as number]], disable == 1)
         end
     end
 

--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -275,8 +275,9 @@ end
 
 ---@param vehicle number
 ---@param props VehicleProperties
+---@param fixVehicle? boolean
 ---@return boolean?
-function lib.setVehicleProperties(vehicle, props)
+function lib.setVehicleProperties(vehicle, props, fixVehicle)
     if not DoesEntityExist(vehicle) then
         error(("Unable to set vehicle properties for '%s' (entity does not exist)"):
         format(vehicle))
@@ -297,7 +298,6 @@ function lib.setVehicleProperties(vehicle, props)
         for id, disable in pairs(props.extras) do
             SetVehicleExtra(vehicle, tonumber(id) --[[@as number]], disable == 1)
         end
-        SetVehicleFixed(vehicle)
     end
 
     if props.plate then
@@ -625,6 +625,10 @@ function lib.setVehicleProperties(vehicle, props)
 
     if props.driftTyres then
         SetDriftTyresEnabled(vehicle, true)
+    end
+
+    if fixVehicle then
+        SetVehicleFixed(vehicle)
     end
 
     return true

--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -275,7 +275,7 @@ end
 
 ---@param vehicle number
 ---@param props VehicleProperties
----@param fixVehicle? boolean
+---@param fixVehicle? boolean Fix the vehicle after props have been set. Usually required when adding extras.
 ---@return boolean?
 function lib.setVehicleProperties(vehicle, props, fixVehicle)
     if not DoesEntityExist(vehicle) then


### PR DESCRIPTION
When using SetVehicleAutoRepairDisabled, you need to repair the vehicle for the applied extras to be visible.