### PR TITLE
Fixing and Adding new properties to the vehicleProperties/client.lua

### DIFF
--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -122,8 +122,8 @@ function lib.getVehicleProperties(vehicle)
         local colorPrimary, colorSecondary = GetVehicleColours(vehicle)
         local pearlescentColor, wheelColor = GetVehicleExtraColours(vehicle)
 
-        local paint1, p1_color, p1_pearlescentColor = GetVehicleModColor_1(vehicle)
-        local paint2, p1_color2 = GetVehicleModColor_2(vehicle)
+        local modColor1 = { GetVehicleModColor_1(vehicle) }
+        local modColor2 = { GetVehicleModColor_2(vehicle) }
 
         if GetIsVehiclePrimaryColourCustom(vehicle) then
             colorPrimary = { GetVehicleCustomPrimaryColour(vehicle) }
@@ -196,8 +196,8 @@ function lib.getVehicleProperties(vehicle)
             fuelLevel = math.floor(GetVehicleFuelLevel(vehicle) + 0.5),
             oilLevel = math.floor(GetVehicleOilLevel(vehicle) + 0.5),
             dirtLevel = math.floor(GetVehicleDirtLevel(vehicle) + 0.5),
-            paint1 = paint1,
-            paint2 = paint2,
+            paint1 = modColor1[1],
+            paint2 = modColor2[1],
             color1 = colorPrimary,
             color2 = colorSecondary,
             pearlescentColor = pearlescentColor,
@@ -335,7 +335,7 @@ function lib.setVehicleProperties(vehicle, props)
             ClearVehicleCustomPrimaryColour(vehicle)
             SetVehicleColours(vehicle, props.color1 --[[@as number]], colorSecondary --[[@as number]])
         else
-            if type(props.paint1) == 'number' then SetVehicleModColor_1(vehicle, props.paint1, colorPrimary, pearlescentColor) end
+            if props.paint1 then SetVehicleModColor_1(vehicle, props.paint[1], colorPrimary, pearlescentColor) end
             SetVehicleCustomPrimaryColour(vehicle, props.color1[1], props.color1[2], props.color1[3])
         end
     end
@@ -345,7 +345,7 @@ function lib.setVehicleProperties(vehicle, props)
             ClearVehicleCustomSecondaryColour(vehicle)
             SetVehicleColours(vehicle, props.color1 or colorPrimary --[[@as number]], props.color2 --[[@as number]])
         else
-            if type(props.paint2) == 'number' then SetVehicleModColor_2(vehicle, props.paint2, colorSecondary) end
+            if props.paint2 then SetVehicleModColor_2(vehicle, props.paint2, colorSecondary) end
             SetVehicleCustomSecondaryColour(vehicle, props.color2[1], props.color2[2], props.color2[3])
         end
     end

--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -10,6 +10,8 @@ if cache.game == 'redm' then return end
 ---@field fuelLevel? number
 ---@field oilLevel? number
 ---@field dirtLevel? number
+---@field paint1? number
+---@field paint2? number
 ---@field color1? number | number[]
 ---@field color2? number | number[]
 ---@field pearlescentColor? number
@@ -120,6 +122,9 @@ function lib.getVehicleProperties(vehicle)
         local colorPrimary, colorSecondary = GetVehicleColours(vehicle)
         local pearlescentColor, wheelColor = GetVehicleExtraColours(vehicle)
 
+        local paint1, p1_color, p1_pearlescentColor = GetVehicleModColor_1(vehicle)
+        local paint2, p1_color2 = GetVehicleModColor_2(vehicle)
+
         if GetIsVehiclePrimaryColourCustom(vehicle) then
             colorPrimary = { GetVehicleCustomPrimaryColour(vehicle) }
         end
@@ -191,6 +196,8 @@ function lib.getVehicleProperties(vehicle)
             fuelLevel = math.floor(GetVehicleFuelLevel(vehicle) + 0.5),
             oilLevel = math.floor(GetVehicleOilLevel(vehicle) + 0.5),
             dirtLevel = math.floor(GetVehicleDirtLevel(vehicle) + 0.5),
+            paint1 = paint1,
+            paint2 = paint2,
             color1 = colorPrimary,
             color2 = colorSecondary,
             pearlescentColor = pearlescentColor,
@@ -328,6 +335,7 @@ function lib.setVehicleProperties(vehicle, props)
             ClearVehicleCustomPrimaryColour(vehicle)
             SetVehicleColours(vehicle, props.color1 --[[@as number]], colorSecondary --[[@as number]])
         else
+            if type(props.paint1 == 'number') then SetVehicleModColor_1(vehicle, paint1, colorPrimary, pearlescentColor) end
             SetVehicleCustomPrimaryColour(vehicle, props.color1[1], props.color1[2], props.color1[3])
         end
     end
@@ -337,6 +345,7 @@ function lib.setVehicleProperties(vehicle, props)
             ClearVehicleCustomPrimaryColour(vehicle)
             SetVehicleColours(vehicle, props.color1 or colorPrimary --[[@as number]], props.color2 --[[@as number]])
         else
+            if type(props.paint2 == 'number') then SetVehicleModColor_2(vehicle, paint2, colorSecondary) end
             SetVehicleCustomSecondaryColour(vehicle, props.color2[1], props.color2[2], props.color2[3])
         end
     end

--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -335,7 +335,7 @@ function lib.setVehicleProperties(vehicle, props)
             ClearVehicleCustomPrimaryColour(vehicle)
             SetVehicleColours(vehicle, props.color1 --[[@as number]], colorSecondary --[[@as number]])
         else
-            if type(props.paint1 == 'number') then SetVehicleModColor_1(vehicle, props.paint1, colorPrimary, pearlescentColor) end
+            if type(props.paint1) == 'number' then SetVehicleModColor_1(vehicle, props.paint1, colorPrimary, pearlescentColor) end
             SetVehicleCustomPrimaryColour(vehicle, props.color1[1], props.color1[2], props.color1[3])
         end
     end
@@ -345,7 +345,7 @@ function lib.setVehicleProperties(vehicle, props)
             ClearVehicleCustomSecondaryColour(vehicle)
             SetVehicleColours(vehicle, props.color1 or colorPrimary --[[@as number]], props.color2 --[[@as number]])
         else
-            if type(props.paint2 == 'number') then SetVehicleModColor_2(vehicle, props.paint2, colorSecondary) end
+            if type(props.paint2) == 'number' then SetVehicleModColor_2(vehicle, props.paint2, colorSecondary) end
             SetVehicleCustomSecondaryColour(vehicle, props.color2[1], props.color2[2], props.color2[3])
         end
     end

--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -10,8 +10,8 @@ if cache.game == 'redm' then return end
 ---@field fuelLevel? number
 ---@field oilLevel? number
 ---@field dirtLevel? number
----@field paint1? number
----@field paint2? number
+---@field paintType1? number
+---@field paintType2? number
 ---@field color1? number | number[]
 ---@field color2? number | number[]
 ---@field pearlescentColor? number
@@ -121,9 +121,8 @@ function lib.getVehicleProperties(vehicle)
         ---@type number | number[], number | number[]
         local colorPrimary, colorSecondary = GetVehicleColours(vehicle)
         local pearlescentColor, wheelColor = GetVehicleExtraColours(vehicle)
-
-        local modColor1 = { GetVehicleModColor_1(vehicle) }
-        local modColor2 = { GetVehicleModColor_2(vehicle) }
+        local paintType1 = GetVehicleModColor_1(vehicle)
+        local paintType2 = GetVehicleModColor_2(vehicle)
 
         if GetIsVehiclePrimaryColourCustom(vehicle) then
             colorPrimary = { GetVehicleCustomPrimaryColour(vehicle) }
@@ -196,8 +195,8 @@ function lib.getVehicleProperties(vehicle)
             fuelLevel = math.floor(GetVehicleFuelLevel(vehicle) + 0.5),
             oilLevel = math.floor(GetVehicleOilLevel(vehicle) + 0.5),
             dirtLevel = math.floor(GetVehicleDirtLevel(vehicle) + 0.5),
-            paint1 = modColor1[1],
-            paint2 = modColor2[1],
+            paintType1 = paintType1,
+            paintType2 = paintType2,
             color1 = colorPrimary,
             color2 = colorSecondary,
             pearlescentColor = pearlescentColor,
@@ -335,7 +334,8 @@ function lib.setVehicleProperties(vehicle, props)
             ClearVehicleCustomPrimaryColour(vehicle)
             SetVehicleColours(vehicle, props.color1 --[[@as number]], colorSecondary --[[@as number]])
         else
-            if props.paint1 then SetVehicleModColor_1(vehicle, props.paint[1], colorPrimary, pearlescentColor) end
+            if props.paintType1 then SetVehicleModColor_1(vehicle, props.paintType1, colorPrimary, pearlescentColor) end
+
             SetVehicleCustomPrimaryColour(vehicle, props.color1[1], props.color1[2], props.color1[3])
         end
     end
@@ -345,7 +345,8 @@ function lib.setVehicleProperties(vehicle, props)
             ClearVehicleCustomSecondaryColour(vehicle)
             SetVehicleColours(vehicle, props.color1 or colorPrimary --[[@as number]], props.color2 --[[@as number]])
         else
-            if props.paint2 then SetVehicleModColor_2(vehicle, props.paint2, colorSecondary) end
+            if props.paintType2 then SetVehicleModColor_2(vehicle, props.paintType2, colorSecondary) end
+
             SetVehicleCustomSecondaryColour(vehicle, props.color2[1], props.color2[2], props.color2[3])
         end
     end

--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -335,17 +335,17 @@ function lib.setVehicleProperties(vehicle, props)
             ClearVehicleCustomPrimaryColour(vehicle)
             SetVehicleColours(vehicle, props.color1 --[[@as number]], colorSecondary --[[@as number]])
         else
-            if type(props.paint1 == 'number') then SetVehicleModColor_1(vehicle, paint1, colorPrimary, pearlescentColor) end
+            if type(props.paint1 == 'number') then SetVehicleModColor_1(vehicle, props.paint1, colorPrimary, pearlescentColor) end
             SetVehicleCustomPrimaryColour(vehicle, props.color1[1], props.color1[2], props.color1[3])
         end
     end
 
     if props.color2 then
         if type(props.color2) == 'number' then
-            ClearVehicleCustomPrimaryColour(vehicle)
+            ClearVehicleCustomSecondaryColour(vehicle)
             SetVehicleColours(vehicle, props.color1 or colorPrimary --[[@as number]], props.color2 --[[@as number]])
         else
-            if type(props.paint2 == 'number') then SetVehicleModColor_2(vehicle, paint2, colorSecondary) end
+            if type(props.paint2 == 'number') then SetVehicleModColor_2(vehicle, props.paint2, colorSecondary) end
             SetVehicleCustomSecondaryColour(vehicle, props.color2[1], props.color2[2], props.color2[3])
         end
     end


### PR DESCRIPTION
Fixed incorrect usage of the `ClearVehicleCustomPrimaryColour()` function on the secondary color.

Added new properties
- paint1 
- paint2 

These 2 functions (get and set) were missing custom paint properties.

The following FiveM natives only work if there is a "RGB coating" applied to the vehicle
```lua
SetVehicleModColor_1()
SetVehicleModColor_2()
```

This "coating" I am referring to is applied when using 
```lua
SetVehicleCustomPrimaryColour()
SetVehicleCustomSecondaryColour()
```
and they can be removed by using
```lua
ClearVehicleCustomPrimaryColour()
ClearVehicleCustomSecondaryColour()
```

I hope this clarifies some doubts around these messy natives.