### PR TITLE
fix(client/vehicleproperties): fix vehicle fix ordering

### DIFF
--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -306,6 +306,10 @@ function lib.setVehicleProperties(vehicle, props, fixVehicle)
         end
     end
 
+    if fixVehicle then
+        SetVehicleFixed(vehicle)
+    end
+
     if props.plate then
         SetVehicleNumberPlateText(vehicle, props.plate)
     end
@@ -635,10 +639,6 @@ function lib.setVehicleProperties(vehicle, props, fixVehicle)
 
     if props.driftTyres then
         SetDriftTyresEnabled(vehicle, true)
-    end
-
-    if fixVehicle then
-        SetVehicleFixed(vehicle)
     end
 
     return true


### PR DESCRIPTION
Vehicle needs to be fixed before setting component healths or else it just resets them. Also needs to be after extras to have the extras appear visually.