### PR TITLE
Add returnString field to date and date-range type in input

### DIFF
--- a/package/client/resource/interface/input.ts
+++ b/package/client/resource/interface/input.ts
@@ -29,6 +29,7 @@ interface InputDialogRowProps {
   step?: number;
   required?: boolean;
   format?: string;
+  useFormat?: boolean;
   description?: string;
 }
 

--- a/package/client/resource/interface/input.ts
+++ b/package/client/resource/interface/input.ts
@@ -29,7 +29,7 @@ interface InputDialogRowProps {
   step?: number;
   required?: boolean;
   format?: string;
-  useFormat?: boolean;
+  returnString?: boolean;
   description?: string;
 }
 

--- a/resource/interface/client/input.lua
+++ b/resource/interface/client/input.lua
@@ -17,7 +17,7 @@ local input
 ---@field autosize? boolean
 ---@field required? boolean
 ---@field format? string
----@field useFormat? boolean
+---@field returnString? boolean
 ---@field clearable? string
 ---@field description? string
 

--- a/resource/interface/client/input.lua
+++ b/resource/interface/client/input.lua
@@ -17,6 +17,7 @@ local input
 ---@field autosize? boolean
 ---@field required? boolean
 ---@field format? string
+---@field useFormat? boolean
 ---@field clearable? string
 ---@field description? string
 

--- a/web/src/features/dialog/InputDialog.tsx
+++ b/web/src/features/dialog/InputDialog.tsx
@@ -14,7 +14,8 @@ import ColorField from './components/fields/color';
 import DateField from './components/fields/date';
 import TextareaField from './components/fields/textarea';
 import TimeField from './components/fields/time';
-import type { InputProps } from '../../typings';
+import type { IDateInput, InputProps } from '../../typings';
+import dayjs from 'dayjs';
 
 export type FormValues = {
   test: {
@@ -27,6 +28,7 @@ const InputDialog: React.FC = () => {
     heading: '',
     rows: [{ type: 'input', label: '' }],
   });
+  const [dateIndexes, setDateIndexes] = React.useState<number[]>([]);
   const [visible, setVisible] = React.useState(false);
   const { locale } = useLocales();
 
@@ -62,6 +64,10 @@ const InputDialog: React.FC = () => {
           !option.label ? { ...option, label: option.value } : option
         ) as Array<OptionValue>;
       }
+      if (row.type === 'date' || row.type === 'date-range') {
+        dateIndexes.push(index);
+        setDateIndexes(dateIndexes);
+      }
     });
   });
 
@@ -80,6 +86,12 @@ const InputDialog: React.FC = () => {
   const onSubmit = form.handleSubmit(async (data) => {
     setVisible(false);
     const values: any[] = [];
+    for (let i = 0; i < dateIndexes.length; i++) {
+      const row = fields.rows[i] as IDateInput;
+      if (row.returnString && data.test[i]) {
+        data.test[i].value = dayjs(data.test[i].value).format(row.format || 'DD/MM/YYYY').toString();
+      }
+    }
     Object.values(data.test).forEach((obj: { value: any }) => values.push(obj.value));
     await new Promise((resolve) => setTimeout(resolve, 200));
     form.reset();

--- a/web/src/features/dialog/InputDialog.tsx
+++ b/web/src/features/dialog/InputDialog.tsx
@@ -28,7 +28,6 @@ const InputDialog: React.FC = () => {
     heading: '',
     rows: [{ type: 'input', label: '' }],
   });
-  const [dateIndexes, setDateIndexes] = React.useState<number[]>([]);
   const [visible, setVisible] = React.useState(false);
   const { locale } = useLocales();
 
@@ -64,10 +63,6 @@ const InputDialog: React.FC = () => {
           !option.label ? { ...option, label: option.value } : option
         ) as Array<OptionValue>;
       }
-      if (row.type === 'date' || row.type === 'date-range') {
-        dateIndexes.push(index);
-        setDateIndexes(dateIndexes);
-      }
     });
   });
 
@@ -86,10 +81,12 @@ const InputDialog: React.FC = () => {
   const onSubmit = form.handleSubmit(async (data) => {
     setVisible(false);
     const values: any[] = [];
-    for (let i = 0; i < dateIndexes.length; i++) {
-      const row = fields.rows[i] as IDateInput;
-      if (row.returnString && data.test[i]) {
-        data.test[i].value = dayjs(data.test[i].value).format(row.format || 'DD/MM/YYYY').toString();
+    for (let i = 0; i < fields.rows.length; i++) {
+      const row = fields.rows[i];
+
+      if ((row.type === 'date' || row.type === 'date-range') && row.returnString) {
+        if (!data.test[i]) continue;
+        data.test[i].value = dayjs(data.test[i].value).format(row.format || 'DD/MM/YYYY');
       }
     }
     Object.values(data.test).forEach((obj: { value: any }) => values.push(obj.value));

--- a/web/src/features/dialog/components/fields/date.tsx
+++ b/web/src/features/dialog/components/fields/date.tsx
@@ -1,13 +1,20 @@
 import { IDateInput } from '../../../../typings/dialog';
 import { Control, useController } from 'react-hook-form';
 import { FormValues } from '../../InputDialog';
-import { DatePicker, DateRangePicker, TimeInput } from '@mantine/dates';
+import { DatePicker, DateRangePicker } from '@mantine/dates';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 interface Props {
   row: IDateInput;
   index: number;
   control: Control<FormValues>;
+}
+
+const convertDateToString = (date: Date, format: string): string => {
+  format.replace('DD', date.getDate().toString());
+  format.replace('MM', date.getMonth().toString());
+  format.replace('YYYY', date.getFullYear().toString());
+  return format;
 }
 
 const DateField: React.FC<Props> = (props) => {
@@ -26,7 +33,7 @@ const DateField: React.FC<Props> = (props) => {
           ref={controller.field.ref}
           onBlur={controller.field.onBlur}
           // Workaround to use timestamp instead of Date object in values
-          onChange={(date) => controller.field.onChange(date ? date.getTime() : null)}
+          onChange={(date) => controller.field.onChange(date ? (props.row.useFormat && props.row.format ? convertDateToString(date, props.row.format) : date.getTime()) : null)}
           label={props.row.label}
           description={props.row.description}
           placeholder={props.row.format}

--- a/web/src/features/dialog/components/fields/date.tsx
+++ b/web/src/features/dialog/components/fields/date.tsx
@@ -10,17 +10,6 @@ interface Props {
   control: Control<FormValues>;
 }
 
-const convertDateToString = (date: Date, format: string): string => {
-  format.replace('DD', date.getDate().toString());
-  format.replace('MM', date.getMonth().toString());
-  format.replace('YYYY', date.getFullYear().toString());
-  return format;
-}
-
-const handleDateChange = (date: Date | null, props: Props): string | number | null => {
-  return date ? (props.row.useFormat && props.row.format ? convertDateToString(date, props.row.format) : date.getTime()) : null;
-}
-
 const DateField: React.FC<Props> = (props) => {
   const controller = useController({
     name: `test.${props.index}.value`,
@@ -37,7 +26,7 @@ const DateField: React.FC<Props> = (props) => {
           ref={controller.field.ref}
           onBlur={controller.field.onBlur}
           // Workaround to use timestamp instead of Date object in values
-          onChange={(date) => controller.field.onChange(handleDateChange(date, props))}
+          onChange={(date) => controller.field.onChange(date ? date.getTime() : null)}
           label={props.row.label}
           description={props.row.description}
           placeholder={props.row.format}
@@ -62,7 +51,7 @@ const DateField: React.FC<Props> = (props) => {
           name={controller.field.name}
           ref={controller.field.ref}
           onBlur={controller.field.onBlur}
-          onChange={(dates) => controller.field.onChange(dates.map((date: Date | null) => handleDateChange(date, props)))}
+          onChange={(dates) => controller.field.onChange(dates.map((date: Date | null) => date ? date.getTime() : null))}
           label={props.row.label}
           description={props.row.description}
           placeholder={props.row.format}

--- a/web/src/features/dialog/components/fields/date.tsx
+++ b/web/src/features/dialog/components/fields/date.tsx
@@ -17,6 +17,10 @@ const convertDateToString = (date: Date, format: string): string => {
   return format;
 }
 
+const handleDateChange = (date: Date | null, props: Props): string | number | null => {
+  return date ? (props.row.useFormat && props.row.format ? convertDateToString(date, props.row.format) : date.getTime()) : null;
+}
+
 const DateField: React.FC<Props> = (props) => {
   const controller = useController({
     name: `test.${props.index}.value`,
@@ -33,7 +37,7 @@ const DateField: React.FC<Props> = (props) => {
           ref={controller.field.ref}
           onBlur={controller.field.onBlur}
           // Workaround to use timestamp instead of Date object in values
-          onChange={(date) => controller.field.onChange(date ? (props.row.useFormat && props.row.format ? convertDateToString(date, props.row.format) : date.getTime()) : null)}
+          onChange={(date) => controller.field.onChange(handleDateChange(date, props))}
           label={props.row.label}
           description={props.row.description}
           placeholder={props.row.format}
@@ -58,9 +62,7 @@ const DateField: React.FC<Props> = (props) => {
           name={controller.field.name}
           ref={controller.field.ref}
           onBlur={controller.field.onBlur}
-          onChange={(dates) =>
-            controller.field.onChange(dates.map((date: Date | null) => (date ? date.getTime() : null)))
-          }
+          onChange={(dates) => controller.field.onChange(dates.map((date: Date | null) => handleDateChange(date, props)))}
           label={props.row.label}
           description={props.row.description}
           placeholder={props.row.format}

--- a/web/src/typings/dialog.ts
+++ b/web/src/typings/dialog.ts
@@ -59,6 +59,7 @@ export interface IColorInput extends BaseField<'color', string> {
 export interface IDateInput
   extends Omit<BaseField<'date' | 'date-range', string | [string, string] | true>, 'placeholder'> {
   format?: string;
+  useFormat?: boolean;
   clearable?: boolean;
   min?: string;
   max?: string;

--- a/web/src/typings/dialog.ts
+++ b/web/src/typings/dialog.ts
@@ -59,7 +59,7 @@ export interface IColorInput extends BaseField<'color', string> {
 export interface IDateInput
   extends Omit<BaseField<'date' | 'date-range', string | [string, string] | true>, 'placeholder'> {
   format?: string;
-  useFormat?: boolean;
+  returnString?: boolean;
   clearable?: boolean;
   min?: string;
   max?: string;


### PR DESCRIPTION
returnString allows for a date to be returned as a string following the format if it is defined, otherwise returns to a default format.