### PR TITLE
fix(client/vehicleProperties): Fix error on gamebuilds below 2372

### DIFF
--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -114,6 +114,8 @@ AddStateBagChangeHandler('setVehicleProperties', '', function(bagName, _, value)
 end)
 ]]
 
+local gameBuild = GetGameBuildNumber()
+
 ---@param vehicle number
 ---@return VehicleProperties?
 function lib.getVehicleProperties(vehicle)
@@ -269,7 +271,7 @@ function lib.getVehicleProperties(vehicle)
             doors = damage.doors,
             tyres = damage.tyres,
             bulletProofTyres = GetVehicleTyresCanBurst(vehicle),
-            driftTyres = GetDriftTyresEnabled(vehicle),
+            driftTyres = gameBuild >= 2372 and GetDriftTyresEnabled(vehicle),
             -- no setters?
             -- leftHeadlight = GetIsLeftVehicleHeadlightDamaged(vehicle),
             -- rightHeadlight = GetIsRightVehicleHeadlightDamaged(vehicle),
@@ -633,7 +635,7 @@ function lib.setVehicleProperties(vehicle, props, fixVehicle)
         SetVehicleTyresCanBurst(vehicle, props.bulletProofTyres)
     end
 
-    if props.driftTyres then
+    if gameBuild >= 2372 and props.driftTyres then
         SetDriftTyresEnabled(vehicle, true)
     end
 


### PR DESCRIPTION
The native GetDriftTyresEnabled throws an error when used on gamebuilds below 2372 which makes lib.getVehicleProperties unusable.