### PR TITLE
feat(checkDependency): minimum version optional

### DIFF
--- a/package/shared/resource/version/index.ts
+++ b/package/shared/resource/version/index.ts
@@ -1,2 +1,2 @@
-export const checkDependency = (resource: string, minimumVersion: string, printMessage?: boolean) =>
+export const checkDependency = (resource: string, minimumVersion?: string, printMessage?: boolean) =>
   exports.ox_lib.checkDependency(resource, minimumVersion, printMessage);

--- a/resource/version/shared.lua
+++ b/resource/version/shared.lua
@@ -1,6 +1,6 @@
 function lib.checkDependency(resource, minimumVersion, printMessage)
 	local currentVersion = GetResourceMetadata(resource, 'version', 0)
-    if not minimumVersion and currentVersion then return true end
+    if not minimumVersion then return currentVersion ~= nil end
     currentVersion = currentVersion and currentVersion:match('%d+%.%d+%.%d+') or 'unknown'
 
 	if currentVersion ~= minimumVersion then

--- a/resource/version/shared.lua
+++ b/resource/version/shared.lua
@@ -1,5 +1,6 @@
 function lib.checkDependency(resource, minimumVersion, printMessage)
 	local currentVersion = GetResourceMetadata(resource, 'version', 0)
+    if not minimumVersion and currentVersion then return true end
     currentVersion = currentVersion and currentVersion:match('%d+%.%d+%.%d+') or 'unknown'
 
 	if currentVersion ~= minimumVersion then


### PR DESCRIPTION
Made minimum version an optional parameter of checkVersion so that it can be used to check for the existence of a dependency, as an alternative to fxmanifest dependencies, which have possibly undesired side effects such as stopping a resource when one of its' dependencies is stopped.