### PR TITLE
External module support for require

### DIFF
--- a/imports/require/shared.lua
+++ b/imports/require/shared.lua
@@ -31,15 +31,35 @@ function lib.require(modname)
             return result
         end
 
+        local idx, resourceSrc = 1
+
+        while true do
+            local di = debug.getinfo(idx, 'S')
+
+            if not di or di.short_src:find('^@' .. cache.resource) then
+                resourceSrc = cache.resource
+                break
+            elseif di.short_src:find('^citizen') then
+                resourceSrc = idx == 2 and cache.resource or debug.getinfo(idx - 1, 'S').short_src:gsub('^@(.-)/.+', '%1')
+                break
+            end
+
+            idx += 1
+        end
+
         local modpath = modname:gsub('%.', '/')
 
         for path in package.path:gmatch('[^;]+') do
             local scriptPath = path:gsub('?', modpath):gsub('%.+%/+', '')
-            local resourceFile = LoadResourceFile(cache.resource, scriptPath)
+            local resourceFile = LoadResourceFile(resourceSrc, scriptPath)
+
+            if resourceSrc ~= cache.resource then
+                modname = ('@%s.%s'):format(resourceSrc, modname)
+            end
 
             if resourceFile then
                 loaded[modname] = false
-                scriptPath = ('@@%s/%s'):format(cache.resource, scriptPath)
+                scriptPath = ('@@%s/%s'):format(resourceSrc, scriptPath)
 
                 local chunk, err = load(resourceFile, scriptPath)
 


### PR DESCRIPTION
Consider this file structure for below examples.
```
- resources/
  - mylib/
    - import.lua
    - module.lua (required by import)
  - myresource/
    - server.lua
```

### Improved module resolution for imported files
- myresouce uses fxmanifest.lua to import a file from mylib i.e. `server_script '@mylib/import.lua'`
- `mylib/import.lua` includes `require 'module'`
- module is loaded in the context of myresource, and tries to load `myresource/module.lua` instead of `mylib/module.lua`

With this change, modules will now load from the correct resource.

### External module paths
- allows you to load files from another resource using `require`, the same way you would in fxmanifest
- `server_script '@mylib/import.lua'` can be replaced with `require '@mylib.import'`

Though you don't get the benefits of IntelliSense when using LLS, you can at least gain the other benefits of require
- controlled file loading order and error handling
- files cannot be loaded more than once
- optional file loading (i.e. frameworks and other dependencies)
- deferred file loading (lazy-loading)
- reduced global variables