### PR TITLE
feat: added lib.print to print different log levels to console

### DIFF
--- a/imports/print/shared.lua
+++ b/imports/print/shared.lua
@@ -16,7 +16,7 @@ local levelPrefixes = {
 }
 
 local resourcePrintLevel = printLevel[GetConvar('ox:printlevel:' .. cache.resource, GetConvar('ox:printlevel', 'info'))]
-local template = ('^5[%s] %s %s^7'):format(cache.resource)
+local template = ('^5[%s] %%s %%s^7'):format(cache.resource)
 local jsonOptions = { sort_keys = true, indent = true }
 
 ---Prints to console conditionally based on what ox:printlevel is.
@@ -25,7 +25,7 @@ local jsonOptions = { sort_keys = true, indent = true }
 ---@param pattern string
 ---@param ... any
 local function libPrint(level, pattern, ...)
-    if level < resourcePrintLevel then return end
+    if level > resourcePrintLevel then return end
 
     local formattedArgs = {}
     for i = 1,select('#', ...) do

--- a/imports/print/shared.lua
+++ b/imports/print/shared.lua
@@ -1,0 +1,37 @@
+local printLevelConvar = GetConvar('ox:printlevel', 'info')
+
+local PrintLevel = {
+    debug = {
+        level = 1,
+        prefix = '^6[DEBUG] ',
+    },
+    info = {
+        level = 2,
+        prefix = '^7[INFO] ',
+    },
+    warn = {
+        level = 3,
+        prefix = '^3[WARN] ',
+    },
+    error = {
+        level = 4,
+        prefix = '^1[ERROR] ',
+    },
+}
+
+---Prints to console conditionally based on what ox:printlevel is.
+---Any print with a level more severe will also print. If ox:printlevel is info, then warn and error prints will appear as well, but debug prints will not.
+---@param level 'debug' | 'info' | 'warn' | 'error'
+---@param message any
+function lib.print(level, message)
+    local printLevel = PrintLevel[level]
+    if printLevel.level < PrintLevel[printLevelConvar].level then return end
+    message = type(message) == "string" and message or json.encode(message)
+
+    -- server prints are forwarded to the client from the chat resource, so this lets clients see the original resource.
+    local resourceName = IsDuplicityVersion() and '^5[' .. cache.resource .. '] ' or '' 
+
+    print(string.format('^5%s%s%s^1', resourceName, printLevel.prefix, message))
+end
+
+return lib.print

--- a/imports/print/shared.lua
+++ b/imports/print/shared.lua
@@ -23,15 +23,22 @@ local PrintLevel = {
 ---Any print with a level more severe will also print. If ox:printlevel is info, then warn and error prints will appear as well, but debug prints will not.
 ---@param level 'debug' | 'info' | 'warn' | 'error'
 ---@param message any
-function lib.print(level, message)
+function Print(level, message)
+    message = type(message) == "string" and message or json.encode(message)
     local printLevel = PrintLevel[level]
     if printLevel.level < PrintLevel[printLevelConvar].level then return end
-    message = type(message) == "string" and message or json.encode(message)
 
     -- server prints are forwarded to the client from the chat resource, so this lets clients see the original resource.
-    local resourceName = IsDuplicityVersion() and '^5[' .. cache.resource .. '] ' or '' 
 
+    local resourceName = IsDuplicityVersion() and '^5[' .. cache.resource .. '] ' or ''
     print(string.format('^5%s%s%s^1', resourceName, printLevel.prefix, message))
 end
+
+lib.print = {
+    debug = function(message) Print('debug', message) end,
+    info = function(message) Print('info', message) end,
+    warn = function(message) Print('warn', message) end,
+    error = function(message) Print('error', message) end,
+}
 
 return lib.print

--- a/imports/print/shared.lua
+++ b/imports/print/shared.lua
@@ -1,29 +1,23 @@
 ---@enum PrintLevel
 local printLevel = {
-    debug = 1,
-    info = 2,
-    warn = 3,
-    error = 4,
+    error = 1,
+    warn = 2,
+    info = 3,
+    verbose = 4,
+    debug = 5,
 }
 
 local levelPrefixes = {
-    [1] = '^6[DEBUG]',
-    [2] = '^7[INFO]',
-    [3] = '^3[WARN]',
-    [4] = '^1[ERROR]',
+    '^1[ERROR]',
+    '^3[WARN]',
+    '^7[INFO]',
+    '^4[VERBOSE]',
+    '^6[DEBUG]',
 }
 
----@alias PrintLevelLabel 'debug' | 'info' | 'warn' | 'error'
-
----@type PrintLevelLabel
-local globalPrintLevel = GetConvar('ox:printlevel', 'info')
-
----@type PrintLevelLabel
-local resourcePrintLevelConvar = GetConvar('ox:printlevel:' .. cache.resource, globalPrintLevel)
-local resourcePrintLevel = printLevel[resourcePrintLevelConvar]
-
-local template = ('^5[%s] %s %s^1'):format(cache.resource)
-local jsonOptions = {sort_keys = true, indent = true}
+local resourcePrintLevel = printLevel[GetConvar('ox:printlevel:' .. cache.resource, GetConvar('ox:printlevel', 'info'))]
+local template = ('^5[%s] %s %s^7'):format(cache.resource)
+local jsonOptions = { sort_keys = true, indent = true }
 
 ---Prints to console conditionally based on what ox:printlevel is.
 ---Any print with a level more severe will also print. If ox:printlevel is info, then warn and error prints will appear as well, but debug prints will not.

--- a/imports/print/shared.lua
+++ b/imports/print/shared.lua
@@ -22,27 +22,26 @@ local jsonOptions = { sort_keys = true, indent = true }
 ---Prints to console conditionally based on what ox:printlevel is.
 ---Any print with a level more severe will also print. If ox:printlevel is info, then warn and error prints will appear as well, but debug prints will not.
 ---@param level PrintLevel
----@param pattern string
 ---@param ... any
-local function libPrint(level, pattern, ...)
+local function libPrint(level, ...)
     if level > resourcePrintLevel then return end
 
-    local formattedArgs = {}
-    for i = 1,select('#', ...) do
-        local arg = select(i, ...)
-        arg = type(arg) == 'table' and json.encode(arg, jsonOptions) or tostring(arg)
-        formattedArgs[#formattedArgs+1] = arg
+    local args = { ... }
+
+    for i = 1, #args do
+        local arg = args[i]
+        args[i] = type(arg) == 'table' and json.encode(arg, jsonOptions) or tostring(arg)
     end
 
-    local message = pattern:format(table.unpack(formattedArgs))
-    print(template:format(levelPrefixes[level], message))
+    print(template:format(levelPrefixes[level], table.concat(args, '\t')))
 end
 
 lib.print = {
-    debug = function(pattern, ...) libPrint(printLevel.debug, pattern, ...) end,
-    info = function(pattern, ...) libPrint(printLevel.info, pattern, ...) end,
-    warn = function(pattern, ...) libPrint(printLevel.warn, pattern, ...) end,
-    error = function(pattern, ...) libPrint(printLevel.error, pattern, ...) end,
+    error = function(...) libPrint(printLevel.error, ...) end,
+    warn = function(...) libPrint(printLevel.warn, ...) end,
+    info = function(...) libPrint(printLevel.info, ...) end,
+    verbose = function(...) libPrint(printLevel.verbose, ...) end,
+    debug = function(...) libPrint(printLevel.debug, ...) end,
 }
 
 return lib.print


### PR DESCRIPTION
- added convar 'ox:printlevel'
- can override the global setting on a per-resource basis with 'ox:printlevel:<resourceName>'
- supported levels are debug, info, warn, and error. Considered adding trace and severe, but think that might just be overkill
- Examples:

Client:
![image](https://github.com/overextended/ox_lib/assets/3579092/f22669ea-c468-4a53-8d1b-5fd6c353c729)

Server: Unfortunately duplicating the resource name seems necessary so that when chat forwards the print, the client can see the original resource.
![image](https://github.com/overextended/ox_lib/assets/3579092/ed982ae9-1154-4623-9f40-c162a68d7c6f)

Server forwarded print to client through Chat resource:
![image](https://github.com/overextended/ox_lib/assets/3579092/e939f23e-a1f4-476c-a9ab-303bd972fc50)

