### PR TITLE
Normal to rotation

### DIFF
--- a/imports/math/shared.lua
+++ b/imports/math/shared.lua
@@ -74,6 +74,21 @@ function math.tovector(input, min, max, round)
     error(('cannot convert %s to a vector value'):format(inputType), 2)
 end
 
+---Tries to convert a surface Normal to a Rotation.
+---@param input vector3
+---@return vector3
+function math.normaltorotation(input)
+    local inputType = type(input)
+
+    if inputType == 'vector3' then
+        local pitch = -math.asin(input.y) * (180.0 / math.pi)
+        local yaw = math.atan(input.x, input.z) * (180.0 / math.pi)
+        return vec3(pitch, yaw, 0.0)
+    end
+
+    error(('cannot convert type %s to a rotation vector'):format(inputType), 2)
+end
+
 ---Tries to convert its argument to a vector.
 ---@param input string | table
 ---@return number | vector2 | vector3 | vector4


### PR DESCRIPTION
this small addition allows developers to pass in a surface normal and get a rotation vector in return. this function has been useful in object placement, spray paints, decals, etc. 

docs are done as well [here](https://github.com/overextended/overextended.github.io/pull/156)

```lua
RegisterCommand("testnormalrot", function()
  lib.requestModel(`prop_mp_cone_01`)

  local playerCoords = GetEntityCoords(cache.ped)

  local object = CreateObject(`prop_mp_cone_01`, playerCoords.x, playerCoords.y, playerCoords.z, false, false, false)

  SetEntityAlpha(object, 200)
  SetEntityRotation(object, rot.x, rot.y, rot.z, 1)
  DisableCamCollisionForEntity(object)
  SetEntityCollision(object, false, false)
  SetEntityDrawOutlineColor(10, 170, 210, 200)
  SetEntityDrawOutlineShader(0)
  SetEntityDrawOutline(object, true)
  while true do
      _, _, endCoords, surfaceNormal = lib.raycast.cam()
      rot = lib.math.normaltorotation(surfaceNormal)
      SetEntityCoords(object, endCoords)
      SetEntityRotation(object, rot.x, rot.y, rot.z, 1)

      if IsControlJustPressed(0, 18) then
          return
      end
  end
end)
```