### PR TITLE
fix(require): plaster solution for escrowed scripts

### DIFF
--- a/imports/require/shared.lua
+++ b/imports/require/shared.lua
@@ -63,6 +63,8 @@ function lib.require(modname)
         if not resourceSrc then
             resourceSrc = modpath:gsub('^@(.-)/.+', '%1')
             modpath = modpath:sub(#resourceSrc + 3)
+        elseif resourceSrc == '?' then
+            resourceSrc = cache.resource
         end
 
         for path in package.path:gmatch('[^;]+') do

--- a/imports/require/shared.lua
+++ b/imports/require/shared.lua
@@ -38,7 +38,7 @@ function lib.require(modname)
             local di = debug.getinfo(idx, 'S')
 
             if di then
-                if not di.short_src:find('^@ox_lib/imports/require') and not di.short_src:find('^%[C%]') and not di.short_src:find('^citizen') then
+                if not di.short_src:find('^@ox_lib/imports/require') and not di.short_src:find('^%[C%]') and not di.short_src:find('^citizen') and di.short_src ~= '?' then
                     resourceSrc = di.short_src:gsub('^@(.-)/.+', '%1')
                     break
                 end
@@ -63,8 +63,6 @@ function lib.require(modname)
         if not resourceSrc then
             resourceSrc = modpath:gsub('^@(.-)/.+', '%1')
             modpath = modpath:sub(#resourceSrc + 3)
-        elseif resourceSrc == '?' then
-            resourceSrc = cache.resource
         end
 
         for path in package.path:gmatch('[^;]+') do


### PR DESCRIPTION
Currently if any part of the script is escrowed (tested on a couple of scripts) the resourceSrc would return ?

This is really the definition of a plaster solution feel free to close if you have a better way of doing this thanks.