### PR TITLE
feat(imports/addKeybind): Support for RedM

### DIFF
--- a/imports/addKeybind/client.lua
+++ b/imports/addKeybind/client.lua
@@ -1,4 +1,46 @@
-if cache.game == 'redm' then return end
+if cache.game == 'redm' then
+    local keybinds = {}
+
+    local IsPauseMenuActive = IsPauseMenuActive
+    local IsControlJustPressed = IsControlJustPressed
+    local IsControlJustReleased = IsControlJustReleased
+
+    CreateThread(function()
+        while true do
+            Wait(0)
+            if not IsPauseMenuActive() then
+                for i = 1, #keybinds do
+                    local keybind = keybinds[i]
+
+                    if keybind.onPressed and IsControlJustPressed(0, keybind.defaultKey) then
+                        keybind.onPressed()
+                    end
+                    if keybind.onReleased and IsControlJustReleased(0, keybind.defaultKey) then
+                        keybind.onReleased()
+                    end
+                end
+            end
+        end
+    end)
+
+    ---@param data KeybindProps
+    ---@return CKeybind
+
+    function lib.addKeybind(data)
+        local keybind = {
+            index = #keybinds + 1,
+            name = data.name,
+            defaultKey = tonumber(data.defaultKey),
+            onPressed = data.onPressed,
+            onReleased = data.onReleased
+        }
+
+        keybinds[keybind.index] = keybind
+        return keybind --[[@as CKeybind]]
+    end
+
+    return lib.addKeybind
+end
 
 ---@class KeybindProps
 ---@field name string


### PR DESCRIPTION
For some reason this was removed in [018112b](https://github.com/overextended/ox_lib/pull/162/commits/018112b345e31a29dbe58ff31c5223ad87a19d82). 
I believe this workaround should be kept until RegisterKeyMapping is implemented in RedM, so there is some compatibility with resources that use addKeybind.

[RegisterKeyMapping RedM](https://github.com/citizenfx/fivem/issues/1779)