### PR TITLE
feat(client/notification): add support for native audio sounds

### DIFF
--- a/imports/requestAudioBank/client.lua
+++ b/imports/requestAudioBank/client.lua
@@ -6,6 +6,7 @@ function lib.requestAudioBank(audioBank, timeout)
     RequestScriptAudioBank(audioBank, false)
 
     if not coroutine.isyieldable() then return true end
+
     return lib.waitFor(function()
         if RequestScriptAudioBank(audioBank, false) then return true end
     end, ("failed to load audiobank '%s'"):format(audioBank), timeout or 500)

--- a/imports/requestAudioBank/client.lua
+++ b/imports/requestAudioBank/client.lua
@@ -1,0 +1,14 @@
+---Loads audio bank 
+---@param audioBank string
+---@param timeout number?
+---@return boolean
+function lib.requestAudioBank(audioBank, timeout)
+    RequestScriptAudioBank(audioBank, false)
+
+    if not coroutine.isyieldable() then return true end
+    return lib.waitFor(function()
+        if RequestScriptAudioBank(audioBank, false) then return true end
+    end, ("failed to load audiobank '%s'"):format(audioBank), timeout or 500)
+end
+
+return lib.requestAudioBank

--- a/resource/interface/client/notify.lua
+++ b/resource/interface/client/notify.lua
@@ -12,11 +12,23 @@
 ---@field icon? string | {[1]: IconProp, [2]: string};
 ---@field iconColor? string;
 ---@field alignIcon? 'top' | 'center';
+---@field sound? {bank?: string, set: string, name: string}
 
 ---`client`
 ---@param data NotifyProps
 ---@diagnostic disable-next-line: duplicate-set-field
 function lib.notify(data)
+    if data.sound then
+        if data.sound?.bank then
+            lib.requestAudioBank(data.sound.bank)
+        end
+        local soundId = GetSoundId()
+        PlaySoundFrontend(soundId, data.sound.name, data.sound.set, true)
+        ReleaseSoundId(soundId)
+        if data.sound?.bank then
+            ReleaseNamedScriptAudioBank(data.sound.bank)            
+        end
+    end
     SendNUIMessage({
         action = 'notify',
         data = data

--- a/resource/interface/client/notify.lua
+++ b/resource/interface/client/notify.lua
@@ -18,6 +18,11 @@
 ---@param data NotifyProps
 ---@diagnostic disable-next-line: duplicate-set-field
 function lib.notify(data)
+    SendNUIMessage({
+        action = 'notify',
+        data = data
+    })
+    if GetConvar('ox:enableSound', "false") == "true" then return end
     if data.sound then
         if data.sound?.bank then
             lib.requestAudioBank(data.sound.bank)
@@ -26,13 +31,9 @@ function lib.notify(data)
         PlaySoundFrontend(soundId, data.sound.name, data.sound.set, true)
         ReleaseSoundId(soundId)
         if data.sound?.bank then
-            ReleaseNamedScriptAudioBank(data.sound.bank)            
+            ReleaseNamedScriptAudioBank(data.sound.bank)
         end
     end
-    SendNUIMessage({
-        action = 'notify',
-        data = data
-    })
 end
 
 ---@class DefaultNotifyProps

--- a/resource/interface/client/notify.lua
+++ b/resource/interface/client/notify.lua
@@ -14,6 +14,8 @@
 ---@field alignIcon? 'top' | 'center';
 ---@field sound? {bank?: string, set: string, name: string}
 
+local enableSound = GetConvar('ox:enableSound', 'true') == 'true'
+
 ---`client`
 ---@param data NotifyProps
 ---@diagnostic disable-next-line: duplicate-set-field
@@ -22,7 +24,7 @@ function lib.notify(data)
         action = 'notify',
         data = data
     })
-    if GetConvar('ox:enableSound', "false") == "true" then return end
+    if not enableSound then return end
     if data.sound then
         if data.sound?.bank then
             lib.requestAudioBank(data.sound.bank)


### PR DESCRIPTION
As requested by luke, #362 and #441. Adds support for an additional table value to be passed in to play sounds 

Example:
```lua
lib.notify({
   title = 'Info', 
   description = 'my text.',
   position = 'top',
   duration = 5000, 
   sound = {--[[bank = "BANKNAME",]] name = "Near_Miss_Counter_Reset", set = "GTAO_FM_Events_Soundset"}, 
   type = 'success'
})
```