### PR TITLE
points: fix thread performance

### DIFF
--- a/imports/points/client.lua
+++ b/imports/points/client.lua
@@ -35,8 +35,8 @@ CreateThread(function()
 			goto continue
 		end
 		
-		do 
-       	if nearbyCount ~= 0 then
+		do
+        	if nearbyCount ~= 0 then
 				table.wipe(nearbyPoints)
 				nearbyCount = 0
 			end
@@ -44,9 +44,9 @@ CreateThread(function()
 			local coords = GetEntityCoords(cache.ped)
 			cache.coords = coords
 
-       	if closestPoint and #(coords - closestPoint.coords) > closestPoint.distance then
-       	    closestPoint = nil
-       	end
+        	if closestPoint and #(coords - closestPoint.coords) > closestPoint.distance then
+        	    closestPoint = nil
+        	end
 
 			for _, point in pairs(points) do
 				local distance = #(coords - point.coords)
@@ -54,19 +54,19 @@ CreateThread(function()
 				if distance <= point.distance then
 					point.currentDistance = distance
 
-       	        if closestPoint then
-       	            if distance < closestPoint.currentDistance then
-       	                closestPoint.isClosest = nil
-       	                point.isClosest = true
-       	                closestPoint = point
-       	            end
-       	        elseif distance < point.distance then
-       	            point.isClosest = true
-       	            closestPoint = point
-       	        end
+        	        if closestPoint then
+        	            if distance < closestPoint.currentDistance then
+        	                closestPoint.isClosest = nil
+        	                point.isClosest = true
+        	                closestPoint = point
+        	            end
+        	        elseif distance < point.distance then
+        	            point.isClosest = true
+        	            closestPoint = point
+        	        end
 
 					if point.nearby then
-       	            nearbyCount += 1
+        	            nearbyCount += 1
 						nearbyPoints[nearbyCount] = point
 					end
 
@@ -85,19 +85,19 @@ CreateThread(function()
 				if nearbyCount ~= 0 then
 					tick = SetInterval(function()
 						for i = 1, nearbyCount do
-       	                local point = nearbyPoints[i]
+        	                local point = nearbyPoints[i]
 
-       	                if point then
-       	                    point:nearby()
-       	                end
+        	                if point then
+        	                    point:nearby()
+        	                end
 						end
 					end)
 				end
 			elseif nearbyCount == 0 then
 				tick = ClearInterval(tick)
 			end
-
 		end
+
 		:: continue ::
 		Wait(300)
 	end

--- a/imports/points/client.lua
+++ b/imports/points/client.lua
@@ -31,65 +31,69 @@ end
 
 CreateThread(function()
 	while true do
-        if nearbyCount ~= 0 then
-			table.wipe(nearbyPoints)
-			nearbyCount = 0
-		end
-
-		local coords = GetEntityCoords(cache.ped)
-		cache.coords = coords
-
-        if closestPoint and #(coords - closestPoint.coords) > closestPoint.distance then
-            closestPoint = nil
-        end
-
-		for _, point in pairs(points) do
-			local distance = #(coords - point.coords)
-
-			if distance <= point.distance then
-				point.currentDistance = distance
-
-                if closestPoint then
-                    if distance < closestPoint.currentDistance then
-                        closestPoint.isClosest = nil
-                        point.isClosest = true
-                        closestPoint = point
-                    end
-                elseif distance < point.distance then
-                    point.isClosest = true
-                    closestPoint = point
-                end
-
-				if point.nearby then
-                    nearbyCount += 1
-					nearbyPoints[nearbyCount] = point
-				end
-
-				if point.onEnter and not point.inside then
-					point.inside = true
-					point:onEnter()
-				end
-			elseif point.currentDistance then
-				if point.onExit then point:onExit() end
-				point.inside = nil
-				point.currentDistance = nil
-			end
-		end
-
-		if not tick then
+		if #points > 0 then
 			if nearbyCount ~= 0 then
-				tick = SetInterval(function()
-					for i = 1, nearbyCount do
-                        local point = nearbyPoints[i]
-
-                        if point then
-                            point:nearby()
-                        end
-					end
-				end)
+				table.wipe(nearbyPoints)
+				nearbyCount = 0
 			end
-		elseif nearbyCount == 0 then
-			tick = ClearInterval(tick)
+	
+			local coords = GetEntityCoords(cache.ped)
+			cache.coords = coords
+	
+			if closestPoint and #(coords - closestPoint.coords) > closestPoint.distance then
+				closestPoint = nil
+			end
+	
+			for _, point in pairs(points) do
+				local distance = #(coords - point.coords)
+	
+				if distance <= point.distance then
+					point.currentDistance = distance
+	
+					if closestPoint then
+						if distance < closestPoint.currentDistance then
+							closestPoint.isClosest = nil
+							point.isClosest = true
+							closestPoint = point
+						end
+					elseif distance < point.distance then
+						point.isClosest = true
+						closestPoint = point
+					end
+	
+					if point.nearby then
+						nearbyCount += 1
+						nearbyPoints[nearbyCount] = point
+					end
+	
+					if point.onEnter and not point.inside then
+						point.inside = true
+						point:onEnter()
+					end
+				elseif point.currentDistance then
+					if point.onExit then point:onExit() end
+					point.inside = nil
+					point.currentDistance = nil
+				end
+			end
+	
+			if not tick then
+				if nearbyCount ~= 0 then
+					tick = SetInterval(function()
+						for i = 1, nearbyCount do
+							local point = nearbyPoints[i]
+	
+							if point then
+								point:nearby()
+							end
+						end
+					end)
+				end
+			elseif nearbyCount == 0 then
+				tick = ClearInterval(tick)
+			end
+		else
+			nearbyPoints = nil
 		end
 
 		Wait(300)

--- a/imports/points/client.lua
+++ b/imports/points/client.lua
@@ -31,41 +31,45 @@ end
 
 CreateThread(function()
 	while true do
-		if #points > 0 then
-			if nearbyCount ~= 0 then
+		if #points == 0 then
+			goto continue
+		end
+		
+		do 
+       	if nearbyCount ~= 0 then
 				table.wipe(nearbyPoints)
 				nearbyCount = 0
 			end
-	
+
 			local coords = GetEntityCoords(cache.ped)
 			cache.coords = coords
-	
-			if closestPoint and #(coords - closestPoint.coords) > closestPoint.distance then
-				closestPoint = nil
-			end
-	
+
+       	if closestPoint and #(coords - closestPoint.coords) > closestPoint.distance then
+       	    closestPoint = nil
+       	end
+
 			for _, point in pairs(points) do
 				local distance = #(coords - point.coords)
-	
+
 				if distance <= point.distance then
 					point.currentDistance = distance
-	
-					if closestPoint then
-						if distance < closestPoint.currentDistance then
-							closestPoint.isClosest = nil
-							point.isClosest = true
-							closestPoint = point
-						end
-					elseif distance < point.distance then
-						point.isClosest = true
-						closestPoint = point
-					end
-	
+
+       	        if closestPoint then
+       	            if distance < closestPoint.currentDistance then
+       	                closestPoint.isClosest = nil
+       	                point.isClosest = true
+       	                closestPoint = point
+       	            end
+       	        elseif distance < point.distance then
+       	            point.isClosest = true
+       	            closestPoint = point
+       	        end
+
 					if point.nearby then
-						nearbyCount += 1
+       	            nearbyCount += 1
 						nearbyPoints[nearbyCount] = point
 					end
-	
+
 					if point.onEnter and not point.inside then
 						point.inside = true
 						point:onEnter()
@@ -76,26 +80,25 @@ CreateThread(function()
 					point.currentDistance = nil
 				end
 			end
-	
+
 			if not tick then
 				if nearbyCount ~= 0 then
 					tick = SetInterval(function()
 						for i = 1, nearbyCount do
-							local point = nearbyPoints[i]
-	
-							if point then
-								point:nearby()
-							end
+       	                local point = nearbyPoints[i]
+
+       	                if point then
+       	                    point:nearby()
+       	                end
 						end
 					end)
 				end
 			elseif nearbyCount == 0 then
 				tick = ClearInterval(tick)
 			end
-		else
-			nearbyPoints = nil
-		end
 
+		end
+		:: continue ::
 		Wait(300)
 	end
 end)


### PR DESCRIPTION
I reported this on dc, although Linden said it was okay, it bothered me that the thread is active although no points should be active.

**Issue & repro**
Create a point will initialize a points thread, but upon removing all existing points, the thread will run still (although not needed), resulting in increased thread activity.

This commit skip the thread logic if there are no points active, resulting in slightly better prformance. If I got something wrong, feel free to write it so I can fix the PR.