### PR TITLE
feat(logger/loki): Support for tenants when running Loki in multi-tenant mode

### DIFF
--- a/imports/logger/server.lua
+++ b/imports/logger/server.lua
@@ -131,6 +131,7 @@ if service == 'loki' then
     local lokiUser = GetConvar('loki:user', '')
     local lokiPassword = GetConvar('loki:password', GetConvar('loki:key', ''))
     local lokiEndpoint = GetConvar('loki:endpoint', '')
+    local lokiTenant = GetConvar('loki:tenant', '')
     local startingPattern = '^http[s]?://'
     local headers = {
         ['Content-Type'] = 'application/json'
@@ -138,6 +139,10 @@ if service == 'loki' then
 
     if lokiUser ~= '' then
         headers['Authorization'] = getAuthorizationHeader(lokiUser, lokiPassword)
+    end
+
+    if lokiTenant ~= '' then
+        headers['X-Scope-OrgID'] = lokiTenant
     end
 
     if not lokiEndpoint:find(startingPattern) then


### PR DESCRIPTION
For environments running Loki in multi_tenant mode, it is required to provide an explicit tenant to where the logs should go in Loki. The "Tenant" feature allows for data abstraction at a "DS (Datasource)" level in Grafana. 
This PR just adds the required headers to allow for those Loki clusters to ingest the logs.

Reference documentation that explains why / when its needed: https://grafana.com/docs/loki/latest/operations/authentication/#authentication

I'l also create follow-up PR to the docs which adds the convar