### PR TITLE
TS support for addCommand

### DIFF
--- a/package/server/resource/addCommand/index.ts
+++ b/package/server/resource/addCommand/index.ts
@@ -1,133 +1,140 @@
-import { addAce } from "../acl";
+import { addAce } from '../acl';
 
-type OxCommandArguments = Record<(string|number), string | number | boolean>;
+type OxCommandArguments = Record<string | number, string | number | boolean>;
 
 interface OxCommandParams {
-    name: string;
-    help?: string;
-    paramType?: 'number' | 'playerId' | 'string';
-    optional?: boolean;
+  name: string;
+  help?: string;
+  paramType?: 'number' | 'playerId' | 'string';
+  optional?: boolean;
 }
 
 interface OxCommandProperties {
-    name?: string;
-    help?: string;
-    params?: OxCommandParams[];
-    restricted?: boolean | string | string[];
+  name?: string;
+  help?: string;
+  params?: OxCommandParams[];
+  restricted?: boolean | string | string[];
 }
 
-let registeredCommmands: OxCommandProperties[] = [];
+const registeredCommmands: OxCommandProperties[] = [];
 let shouldSendCommands = false;
 
 setTimeout(() => {
-    shouldSendCommands = true;
-    emitNet('chat:addSuggestions', -1, registeredCommmands);
-}, 1000)
+  shouldSendCommands = true;
+  emitNet('chat:addSuggestions', -1, registeredCommmands);
+}, 1000);
 
 on('playerJoining', (source: number) => {
-    emitNet('chat:addSuggestions', source, registeredCommmands);
-})
+  emitNet('chat:addSuggestions', source, registeredCommmands);
+});
 
-function parseArguments(source: number, args: OxCommandArguments, raw: string, params?: OxCommandParams[]): OxCommandArguments | undefined {
-    if (!params) {
-        return args;
+function parseArguments(
+  source: number,
+  args: OxCommandArguments,
+  raw: string,
+  params?: OxCommandParams[]
+): OxCommandArguments | undefined {
+  if (!params) { return args; }
+
+  const result = params.every((param, index) => {
+    const arg = args[index];
+    let value;
+
+    switch (param.paramType) {
+      case 'number':
+        value = +arg;
+        break;
+
+      case 'string':
+        value = !Number(arg) ? arg : false;
+        break;
+
+      case 'playerId':
+        value = arg === 'me' ? source : +arg;
+        if (!value || !GetPlayerGuid(value.toString())) {
+          value = false;
+        }
+        break;
+
+      default:
+        value = arg;
+        break;
     }
 
-    let paramMissing = false
-
-    params.every((param, index) => {
-        let arg = args[index]
-        let value: any
-
-        switch (param.paramType) {
-            case 'number':
-                value = Number(arg);
-                break;
-
-            case 'string':
-                value = !Number(arg) ? arg : false;
-                break;
-
-            case 'playerId':
-                value = arg === 'me' ? source : Number(arg);
-                if (!value || !GetPlayerGuid(value)) {
-                    value = false;
-                }
-                break;
-
-            default:
-                value = arg;
-                break;
-        }
-
-        if (!value && (!param.optional || param.optional && arg)) {
-            paramMissing = true
-            return Citizen.trace(`^1command '${raw.split(' ') || raw}' received an invalid ${param.paramType} for argument ${index} (${param.name}), received '${arg}'^0`);
-        }
-
-        arg = value;
-
-        args[param.name] = arg;
-        delete(args[index]);
-    })
-
-    return !paramMissing ? args : undefined;
-};
-
-export function addCommand(commandName: string | string[], cb: (source: number, args: object, raw: string) => any, properties?: OxCommandProperties) {
-    let restricted = properties?.restricted;
-    let params = properties?.params;
-
-    if (params) {
-        params.forEach((param) => {
-            if (param.paramType) {
-                param.help = (param.help) ? `${param.help} (type: ${param.paramType})` : `(type: ${param.paramType})`;
-            }
-        })
+    if (!value && (!param.optional || (param.optional && arg))) {
+      return Citizen.trace(
+        `^1command '${raw.split(' ') || raw}' received an invalid ${param.paramType} for argument ${index} (${
+          param.name
+        }), received '${arg}'^0`
+      );
     }
 
-    let commands = typeof commandName !== 'object' ? [ commandName ] : commandName;
-    let numCommands = commands.length;
+    args[param.name] = value;
+    delete args[index];
 
-    const commandHandler = (source: number, args: OxCommandArguments, raw: string) => {
-        let parsed: OxCommandArguments | undefined = parseArguments(source, args, raw, params);
-        if (!parsed) {
-            return;
-        }
+    return true;
+  });
 
-        cb(source, parsed, raw)
+  return result ? args : undefined;
+}
+
+export function addCommand(
+  commandName: string | string[],
+  cb: (source: number, args: object, raw: string) => any,
+  properties?: OxCommandProperties
+) {
+  const restricted = properties?.restricted;
+  const params = properties?.params;
+
+  if (params) {
+    params.forEach((param) => {
+      if (param.paramType) {
+        param.help = param.help ? `${param.help} (type: ${param.paramType})` : `(type: ${param.paramType})`;
+      }
+    });
+  }
+
+  const commands = typeof commandName !== 'object' ? [commandName] : commandName;
+  const numCommands = commands.length;
+
+  const commandHandler = (source: number, args: OxCommandArguments, raw: string) => {
+    const parsed = parseArguments(source, args, raw, params);
+    if (!parsed) { return; }
+
+    cb(source, parsed, raw);
+  };
+
+  commands.forEach((commandName, index) => {
+    RegisterCommand(commandName, commandHandler, restricted ? true : false);
+
+    if (restricted) {
+      const ace = `command.${commandName}`;
+      const restrictedType = typeof restricted;
+
+      if (restrictedType === 'string' && !IsPrincipalAceAllowed(restricted as string, ace)) {
+        addAce(restricted as string, ace, true);
+      } else if (restrictedType === 'object') {
+        const _restricted = restricted as string[];
+        _restricted.forEach((principal) => {
+          if (!IsPrincipalAceAllowed(principal, ace)) {
+            addAce(principal as string, ace, true);
+          }
+        });
+      }
     }
 
-    commands.forEach((commandName, index) => {
-        RegisterCommand(commandName, commandHandler, restricted ? true : false)
+    if (properties) {
+      properties.name = `/${commandName}`;
+      delete properties.restricted;
+      registeredCommmands.push(properties);
 
-        if (restricted) {
-            let ace = `command.${commandName}`;
-            let restrictedType = typeof restricted;
+      if (index !== numCommands && numCommands !== 1) {
+        properties = { ...properties };
+      }
 
-            if (restrictedType === 'string' && (!IsPrincipalAceAllowed(restricted as string, ace))) {
-                addAce(restricted as string, ace, true)
-            }
-            else if (restrictedType === 'object') {
-                let _restricted = restricted as string[];
-                _restricted.forEach((principal) => {
-                    if (!IsPrincipalAceAllowed(principal, ace)) {
-                        addAce(principal as string, ace, true)
-                    }
-                })
-            }
-        }
-
-        if (properties) {
-            properties.name = `/${commandName}`;
-            delete properties.restricted;
-            registeredCommmands.push(properties);
-
-            if (index !== numCommands && numCommands !== 1) {
-                properties = Object.assign({}, properties);
-            }
-
-            if (shouldSendCommands) { emitNet('chat:addSuggestions', -1, properties); }
-        }
-    })
-};
+      if (shouldSendCommands) {
+        emitNet('chat:addSuggestions', -1, properties);
+      }
+    }
+  });
+}

--- a/package/server/resource/addCommand/index.ts
+++ b/package/server/resource/addCommand/index.ts
@@ -1,0 +1,133 @@
+import { addAce } from "../acl";
+
+type OxCommandArguments = Record<(string|number), string | number | boolean>;
+
+interface OxCommandParams {
+    name: string;
+    help?: string;
+    paramType?: 'number' | 'playerId' | 'string';
+    optional?: boolean;
+}
+
+interface OxCommandProperties {
+    name?: string;
+    help?: string;
+    params?: OxCommandParams[];
+    restricted?: boolean | string | string[];
+}
+
+let registeredCommmands: OxCommandProperties[] = [];
+let shouldSendCommands = false;
+
+setTimeout(() => {
+    shouldSendCommands = true;
+    emitNet('chat:addSuggestions', -1, registeredCommmands);
+}, 1000)
+
+on('playerJoining', (source: number) => {
+    emitNet('chat:addSuggestions', source, registeredCommmands);
+})
+
+function parseArguments(source: number, args: OxCommandArguments, raw: string, params?: OxCommandParams[]): OxCommandArguments | undefined {
+    if (!params) {
+        return args;
+    }
+
+    let paramMissing = false
+
+    params.every((param, index) => {
+        let arg = args[index]
+        let value: any
+
+        switch (param.paramType) {
+            case 'number':
+                value = Number(arg);
+                break;
+
+            case 'string':
+                value = !Number(arg) ? arg : false;
+                break;
+
+            case 'playerId':
+                value = arg === 'me' ? source : Number(arg);
+                if (!value || !GetPlayerGuid(value)) {
+                    value = false;
+                }
+                break;
+
+            default:
+                value = arg;
+                break;
+        }
+
+        if (!value && (!param.optional || param.optional && arg)) {
+            paramMissing = true
+            return Citizen.trace(`^1command '${raw.split(' ') || raw}' received an invalid ${param.paramType} for argument ${index} (${param.name}), received '${arg}'^0`);
+        }
+
+        arg = value;
+
+        args[param.name] = arg;
+        delete(args[index]);
+    })
+
+    return !paramMissing ? args : undefined;
+};
+
+export function addCommand(commandName: string | string[], cb: (source: number, args: object, raw: string) => any, properties?: OxCommandProperties) {
+    let restricted = properties?.restricted;
+    let params = properties?.params;
+
+    if (params) {
+        params.forEach((param) => {
+            if (param.paramType) {
+                param.help = (param.help) ? `${param.help} (type: ${param.paramType})` : `(type: ${param.paramType})`;
+            }
+        })
+    }
+
+    let commands = typeof commandName !== 'object' ? [ commandName ] : commandName;
+    let numCommands = commands.length;
+
+    const commandHandler = (source: number, args: OxCommandArguments, raw: string) => {
+        let parsed: OxCommandArguments | undefined = parseArguments(source, args, raw, params);
+        if (!parsed) {
+            return;
+        }
+
+        cb(source, parsed, raw)
+    }
+
+    commands.forEach((commandName, index) => {
+        RegisterCommand(commandName, commandHandler, restricted ? true : false)
+
+        if (restricted) {
+            let ace = `command.${commandName}`;
+            let restrictedType = typeof restricted;
+
+            if (restrictedType === 'string' && (!IsPrincipalAceAllowed(restricted as string, ace))) {
+                addAce(restricted as string, ace, true)
+            }
+            else if (restrictedType === 'object') {
+                let _restricted = restricted as string[];
+                _restricted.forEach((principal) => {
+                    if (!IsPrincipalAceAllowed(principal, ace)) {
+                        addAce(principal as string, ace, true)
+                    }
+                })
+            }
+        }
+
+        if (properties) {
+            properties.name = `/${commandName}`;
+            delete properties.restricted;
+            registeredCommmands.push(properties);
+
+            if (index !== numCommands && numCommands !== 1) {
+                properties = Object.assign({}, properties);
+            }
+
+            if (shouldSendCommands) { emitNet('chat:addSuggestions', -1, properties); }
+        }
+    })
+};

--- a/package/server/resource/index.ts
+++ b/package/server/resource/index.ts
@@ -2,3 +2,4 @@ export * from './acl';
 export * from './locale';
 export * from './callback';
 export * from './version';
+export * from './addCommand';


### PR DESCRIPTION
I would like to mention in advance that I am completely new to TS and thanks to the transition of ox_core to TS I got the motivation to dive more into this and learn the language.

I looked at what is available in ox_lib for TS and addCommand came to me as one of the few must have functions that ox_lib currently lacks..

I am more than sure that this PR has flaws and I would appreciate any feedback and change requests

Tested with:
```
import { addCommand } from '@overextended/ox_lib/server'

addCommand('tscommand', (source: number, args: any, raw: string) => {
    console.log(`player ${source} executed comand (${raw})`)
}, {help: 'TypeScript addCommand', params: [{name: 'target', paramType: 'playerId', help: 'playerId or "me"', optional: true}], restricted: ['group.typescript', 'group.typescript2'] } )
```