### PR TITLE
feat(imports/waitFor): add function callback for timeouts

### DIFF
--- a/imports/waitFor/shared.lua
+++ b/imports/waitFor/shared.lua
@@ -1,11 +1,11 @@
 ---Yields the current thread until a non-nil value is returned by the function.
 ---@generic T
 ---@param cb fun(): T?
----@param errMessage string?
+---@param onTimeout string | fun()?
 ---@param timeout number? Error out after `~x` ms. Defaults to 1000, unless set to `false`.
 ---@return T?
 ---@async
-function lib.waitFor(cb, errMessage, timeout)
+function lib.waitFor(cb, onTimeout, timeout)
     local value = cb()
 
     if value ~= nil then return value end
@@ -30,7 +30,13 @@ function lib.waitFor(cb, errMessage, timeout)
             i += 1
 
             if i > timeout then
-                return error(('%s (waited %.1fms)'):format(errMessage or 'failed to resolve callback', (GetGameTimer() - start) / 1000), 2)
+                if type(onTimeout) == "function" then
+                    onTimeout()
+                else
+                    error(('%s (waited %.1fms)'):format(onTimeout or 'failed to resolve callback', (GetGameTimer() - start) / 1000), 2)
+                end
+
+                return
             end
         end
 


### PR DESCRIPTION
This feature change allows developers to execute a function if the waitFor times out. It refactors the variable `errMessage` to `onTimeout` to reflect the change and to prevent it from breaking old code. 

The default usage of waitFor that prints an error message if it times out.
```lua
  return lib.waitFor(function()
      -- ...
  end, "it timed out", 500)
```

The new alternative usage of waitFor that can either print an error message or call a function if it times out.
```lua
  return lib.waitFor(function()
      -- ...
  end, function()
      -- It timed out, execute the code here.
  end, 500)
```

These features have been tested and all appear to be working as intended with newly written code using this and old code using the `errMessage` variable.