### PR TITLE
fix(imports/require): return `false` when the code chunk returns `false`

### DIFF
--- a/imports/require/shared.lua
+++ b/imports/require/shared.lua
@@ -155,7 +155,8 @@ function lib.require(modname)
                     return error(err or ("unable to load module '%s'"):format(modname), 3)
                 end
 
-                module = chunk(modname) or true
+                local result = chunk(modname)
+                module = result or result == nil
                 loaded[modname] = module
 
                 return module


### PR DESCRIPTION
`true` should be the fallback value when the code chunk returns `nil`, but that should not be the case when it returns `false`.