### PR TITLE
fix(imports/require): Fix resource source extraction in `getModuleInfo`

### DIFF
--- a/imports/require/shared.lua
+++ b/imports/require/shared.lua
@@ -25,7 +25,7 @@ local function getModuleInfo(modpath, modname)
 
             if di then
                 if not di.short_src:find('^@ox_lib/imports/require') and not di.short_src:find('^%[C%]') and not di.short_src:find('^citizen') and di.short_src ~= '?' then
-                    resourceSrc = di.short_src:gsub('^@(.-)/.+', '%1')
+					resourceSrc = di.source:gsub('^%@+([^/]+)/.+', '%1')
                     break
                 end
             else

--- a/imports/require/shared.lua
+++ b/imports/require/shared.lua
@@ -25,7 +25,7 @@ local function getModuleInfo(modpath, modname)
 
             if di then
                 if not di.short_src:find('^@ox_lib/imports/require') and not di.short_src:find('^%[C%]') and not di.short_src:find('^citizen') and di.short_src ~= '?' then
-					resourceSrc = di.source:gsub('^%@+([^/]+)/.+', '%1')
+                    resourceSrc = di.source:gsub('^%@+([^/]+)/.+', '%1')
                     break
                 end
             else


### PR DESCRIPTION
# Fix resource source extraction in `getModuleInfo`

This PR addresses the issue where the resource source extraction in the `getModuleInfo` function was not working as expected due to the `short_src` field being truncated when the calling Lua file is located inside a folder with a long path. This led to errors when calling `LoadResourceFile`.

## Changes Made
- Updated the `getModuleInfo` function in `ox_lib/imports/require/shared.lua` to use the `source` field instead of `short_src` when extracting the resource source.
- Modified the regex pattern to properly capture the resource source from the `source` field, ensuring compatibility with long file paths.

## Details
- `short_src` doesn't match `source` on the call stack when calling require inside a lua file with a long nested path, which was causing the regex to not work as expected.
- The issue was due to the Lua API truncating the `short_src` field for files with long paths.
- By using the `source` field on the call stack and updating the regex pattern accordingly, we ensure correct extraction of the resource source even with long file paths.

## Testing
- Tested the updated `getModuleInfo` function with Lua files in various paths of differing lengths.
- Confirmed that the resource source is properly extracted without errors.

### Related C LUA API implementation

```C
LUALIB_API void luaL_traceback (lua_State *L, lua_State *L1,
                                const char *msg, int level) {
  lua_Debug ar;
  int top = lua_gettop(L);
  int numlevels = countlevels(L1);
  int mark = (numlevels > LEVELS1 + LEVELS2) ? LEVELS1 : 0;
  if (msg) lua_pushfstring(L, "%s\n", msg);
  lua_pushliteral(L, "stack traceback:");
  while (lua_getstack(L1, level++, &ar)) {
    if (level == mark) {  /* too many levels? */
      lua_pushliteral(L, "\n\t...");  /* add a '...' */
      level = numlevels - LEVELS2;  /* and skip to last ones */
    }
    else {
      lua_getinfo(L1, "Slnt", &ar);
      lua_pushfstring(L, "\n\t%s:", ar.short_src);
      if (ar.currentline > 0)
        lua_pushfstring(L, "%d:", ar.currentline);
      lua_pushliteral(L, " in ");
      pushfuncname(L, &ar);
      if (ar.istailcall)
        lua_pushliteral(L, "\n\t(...tail calls...)");
      lua_concat(L, lua_gettop(L) - top);
    }
  }
  lua_concat(L, lua_gettop(L) - top);
}
```
