### PR TITLE
feat(interface): set default keybind keys using convars

### DIFF
--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -219,4 +219,4 @@ RegisterCommand('cancelprogress', function()
     if progress?.canCancel then progress = false end
 end)
 
-RegisterKeyMapping('cancelprogress', 'Cancel current progress bar', 'keyboard', 'x')
+RegisterKeyMapping('cancelprogress', 'Cancel current progress bar', 'keyboard', GetConvar('ox:cancelProgressKey', 'x'))

--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -300,7 +300,7 @@ end
 lib.addKeybind({
     name = 'ox_lib-radial',
     description = 'Open radial menu',
-    defaultKey = 'z',
+    defaultKey = GetConvar('ox:openRadialMenuKey', 'z'),
     onPressed = function()
         if isDisabled then return end
 


### PR DESCRIPTION
Added convars to set default keys for _cancel progress_ and _open radial menu_ keybinds.