### PR TITLE
Added searchable prop to select and multi-select input types

### DIFF
--- a/package/client/resource/interface/input.ts
+++ b/package/client/resource/interface/input.ts
@@ -63,6 +63,7 @@ interface SelectProps extends BaseInput {
   disabled?: boolean;
   default?: string | string[];
   clearable?: boolean;
+  searchable?: boolean;
 }
 
 interface SliderProps extends BaseInput {

--- a/resource/interface/client/input.lua
+++ b/resource/interface/client/input.lua
@@ -19,6 +19,7 @@ local input
 ---@field format? string
 ---@field returnString? boolean
 ---@field clearable? boolean
+---@field searchable? boolean
 ---@field description? string
 
 ---@class InputDialogOptionsProps

--- a/web/src/features/dialog/components/fields/select.tsx
+++ b/web/src/features/dialog/components/fields/select.tsx
@@ -32,6 +32,7 @@ const SelectField: React.FC<Props> = (props) => {
           description={props.row.description}
           withAsterisk={props.row.required}
           clearable={props.row.clearable}
+          searchable={props.row.searchable}
           icon={props.row.icon && <LibIcon icon={props.row.icon} fixedWidth />}
         />
       ) : (
@@ -49,6 +50,7 @@ const SelectField: React.FC<Props> = (props) => {
               description={props.row.description}
               withAsterisk={props.row.required}
               clearable={props.row.clearable}
+              searchable={props.row.searchable}
               icon={props.row.icon && <LibIcon icon={props.row.icon} fixedWidth />}
             />
           )}

--- a/web/src/typings/dialog.ts
+++ b/web/src/typings/dialog.ts
@@ -37,6 +37,7 @@ export type OptionValue = { value: string; label?: string };
 export interface ISelect extends BaseField<'select' | 'multi-select', string | string[]> {
   options: Array<OptionValue>;
   clearable?: boolean;
+  searchable?: boolean;
 }
 
 export interface INumber extends BaseField<'number', number> {


### PR DESCRIPTION
As title mentions, this PR just adds the possibility to set the searchable prop to the 'select' and 'multi-select' input dialogs.
It's just an already existing feature in Mantine that is very helpful when the options list is too large.