### PR TITLE
fix(lib.waitFor): Improved Timeout Calculation and Error Message Formatting

### DIFF
--- a/imports/waitFor/shared.lua
+++ b/imports/waitFor/shared.lua
@@ -10,15 +10,12 @@ function lib.waitFor(cb, errMessage, timeout)
 
     if value ~= nil then return value end
 
+    if type(timeout) ~= 'number' then timeout = 1000 end
 
-    if timeout or timeout == nil then
-        if type(timeout) ~= 'number' then timeout = 1000 end
-
-        if IsDuplicityVersion() then
-            timeout /= 50;
-        else
-            timeout -= GetFrameTime() * 1000;
-        end
+    if IsDuplicityVersion() then
+        timeout /= 50;
+    else
+        timeout /= (GetFrameTime() * 1000)
     end
 
 
@@ -30,7 +27,7 @@ function lib.waitFor(cb, errMessage, timeout)
             i += 1
 
             if i > timeout then
-                return error(('%s (waited %.1fms)'):format(errMessage or 'failed to resolve callback', (GetGameTimer() - start) / 1000), 2)
+                return error(('%s (waited %dms)'):format(errMessage or 'failed to resolve callback', (GetGameTimer() - start)), 2)
             end
         end
 


### PR DESCRIPTION
## Description
This PR includes some minor fixess to the `lib.waitFor` function. The changes aim to improve code clarity and accuracy in handling timeout calculations and error message formatting.

## Changes Made
- Removed the redundant if condition checking for `timeout` truthiness or nil value.
- Fixed the calculation of the timeout on the client-side to ensure accurate representation in milliseconds.
- Adjusted the error message formatting to accurately represent milliseconds.

## Previous Behaviour
- When running the `lib.waitFor` function with timeout value of 1000:
  - On the server, the function times out after approximately 1 second, but the error message incorrectly prints "1.0ms" instead of "1000ms".
  - On the client, the function does not only print the incorrect error message, but also won't time out until after approximately 10 seconds.
 
 ## Current Behaviour (Following the fix)
  - On both the server and client, the `lib.waitFor` function now correctly displays the error message with the accurate timeout in milliseconds. Additionally, the function now consistently times out after the correct duration.


## Proposed Changes
```lua
---Yields the current thread until a non-nil value is returned by the function.
---@generic T
---@param cb fun(): T
---@param errMessage string?
---@param timeout? number | false Error out after `~x` ms. Defaults to 1000, unless set to `false`.
---@return T
---@async
function lib.waitFor(cb, errMessage, timeout)
    local value = cb()

    if value ~= nil then return value end

    if type(timeout) ~= 'number' then timeout = 1000 end

    if IsDuplicityVersion() then
        timeout /= 50;
    else
        timeout /= (GetFrameTime() * 1000)
    end

    local start = GetGameTimer()
    local i = 0

    while value == nil do
        if timeout then
            i += 1

            if i > timeout then
                return error(('%s (waited %dms)'):format(errMessage or 'failed to resolve callback', (GetGameTimer() - start)), 2)
            end
        end

        Wait(0)
        value = cb()
    end

    return value
end

return lib.waitFor
