### PR TITLE
chore(locale): update no.json

### DIFF
--- a/locales/no.json
+++ b/locales/no.json
@@ -6,11 +6,11 @@
     "confirm": "Bekreft",
     "more": "Mer..."
   },
-  "open_radial_menu": "Open radial menu",
-  "cancel_progress": "Cancel current progress bar",
-  "txadmin_announcement": "Server announcement by %s",
-  "txadmin_dm": "Direct Message from %s",
-  "txadmin_warn": "You have been warned by %s",
+  "open_radial_menu": "Åpne radial menyen",
+  "cancel_progress": "Avbryt den nåværende fremdriftsindikatoren",
+  "txadmin_announcement": "Server annonsering fra %s",
+  "txadmin_dm": "Direktemelding fra %s",
+  "txadmin_warn": "Du har fått en advarsel fra %s",
   "txadmin_warn_content": "%s  \nAction ID: %s",
-  "txadmin_scheduledrestart": "Scheduled Restart"
+  "txadmin_scheduledrestart": "Planlagt Omstart"
 }


### PR DESCRIPTION
Update the Norwegian translation file to include the txadmin locales and the new translatable keymapping descriptions.

It's worth noting that the translation for `cancel_progress` could be improved upon, as I could not find or figure out a good translation for "progressbar".