### PR TITLE
feat: add duration bar option in notifications, as well as timeout and confirm options in alert dialog

### DIFF
--- a/web/src/features/dev/debug/alert.ts
+++ b/web/src/features/dev/debug/alert.ts
@@ -9,9 +9,11 @@ export const debugAlert = () => {
         header: 'Hello there',
         content: 'General kenobi  \n Markdown works',
         centered: true,
+        timeout: 5000,
         size: 'lg',
         overflow: true,
         cancel: true,
+        confirm: true,
         // labels: {
         //   confirm: 'Ok',
         //   cancel: 'Not ok',

--- a/web/src/features/dev/debug/notification.ts
+++ b/web/src/features/dev/debug/notification.ts
@@ -23,6 +23,24 @@ export const debugCustomNotification = () => {
     {
       action: 'notify',
       data: {
+        title: 'Success',
+        description: 'Notification description',
+        type: 'success',
+        id: 'pogdurationbar',
+        duration: 10000,
+        durationBar: true,
+        style: {
+          '.description': {
+            color: 'blue',
+          },
+        },
+      },
+    },
+  ]);
+  debugData<NotificationProps>([
+    {
+      action: 'notify',
+      data: {
         title: 'Error',
         description: 'Notification description',
         type: 'error',
@@ -37,6 +55,7 @@ export const debugCustomNotification = () => {
         description: 'Notification description',
         type: 'success',
         icon: 'microchip',
+        durationBar: true,
       },
     },
   ]);

--- a/web/src/features/dialog/AlertDialog.tsx
+++ b/web/src/features/dialog/AlertDialog.tsx
@@ -1,5 +1,5 @@
 import { Button, createStyles, Group, Modal, Stack, useMantineTheme } from '@mantine/core';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useNuiEvent } from '../../hooks/useNuiEvent';
 import { fetchNui } from '../../utils/fetchNui';
@@ -7,6 +7,7 @@ import { useLocales } from '../../providers/LocaleProvider';
 import remarkGfm from 'remark-gfm';
 import type { AlertProps } from '../../typings';
 import MarkdownComponents from '../../config/MarkdownComponents';
+import ShowDurationBar from '../utils/ShowDurationBar';
 
 const useStyles = createStyles((theme) => ({
   contentStack: {
@@ -36,6 +37,16 @@ const AlertDialog: React.FC = () => {
 
   useNuiEvent('closeAlertDialog', () => {
     setOpened(false);
+  });
+
+  useEffect(() => {
+    if (dialogData.timeout) {
+      const timer = setTimeout(() => {
+        closeAlert('cancel');
+      }, dialogData.timeout);
+
+      return () => clearTimeout(timer);
+    }
   });
 
   return (
@@ -72,16 +83,19 @@ const AlertDialog: React.FC = () => {
                 {dialogData.labels?.cancel || locale.ui.cancel}
               </Button>
             )}
-            <Button
-              uppercase
-              variant={dialogData.cancel ? 'light' : 'default'}
-              color={dialogData.cancel ? theme.primaryColor : undefined}
-              onClick={() => closeAlert('confirm')}
-            >
-              {dialogData.labels?.confirm || locale.ui.confirm}
-            </Button>
+            {dialogData.confirm && (
+              <Button
+                uppercase
+                variant={dialogData.cancel ? 'light' : 'default'}
+                color={dialogData.cancel ? theme.primaryColor : undefined}
+                onClick={() => closeAlert('confirm')}
+              >
+                {dialogData.labels?.confirm || locale.ui.confirm}
+              </Button>
+            )}
           </Group>
         </Stack>
+        {dialogData.timeout && (<ShowDurationBar duration={dialogData.timeout} marginTop={15} />)}
       </Modal>
     </>
   );

--- a/web/src/features/notifications/NotificationWrapper.tsx
+++ b/web/src/features/notifications/NotificationWrapper.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import type { NotificationProps } from '../../typings';
 import MarkdownComponents from '../../config/MarkdownComponents';
 import LibIcon from '../../components/LibIcon';
+import ShowDurationBar from '../utils/ShowDurationBar';
 
 const useStyles = createStyles((theme) => ({
   container: {
@@ -108,6 +109,9 @@ const Notifications: React.FC = () => {
 
   useNuiEvent<NotificationProps>('notify', (data) => {
     if (!data.title && !data.description) return;
+
+    let duration = data.duration || 3000;
+
     // Backwards compat with old notifications
     let position = data.position;
     switch (position) {
@@ -201,11 +205,12 @@ const Notifications: React.FC = () => {
               )}
             </Stack>
           </Group>
+          {data.durationBar && (<ShowDurationBar duration={duration} />)}
         </Box>
       ),
       {
         id: data.id?.toString(),
-        duration: data.duration || 3000,
+        duration: duration,
         position: position || 'top-right',
       }
     );

--- a/web/src/features/utils/ShowDurationBar.tsx
+++ b/web/src/features/utils/ShowDurationBar.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { Box, createStyles } from '@mantine/core';
+import ScaleFade from '../../transitions/ScaleFade';
+
+const useStyles = createStyles((theme) => ({
+  container: {
+    width: '100%',
+    height: 5,
+		marginTop: 7,
+    borderRadius: theme.radius.sm,
+    backgroundColor: theme.colors.dark[5],
+    overflow: 'hidden',
+  },
+  bar: {
+    height: '100%',
+    backgroundColor: theme.colors[theme.primaryColor][theme.fn.primaryShade()],
+  },
+}));
+
+const ShowDurationBar: React.FC<{ duration: number; marginTop?: number; height?: number }> = ({
+	duration,
+  marginTop,
+  height
+}) => {
+  const { classes } = useStyles();
+	const [visible, setVisible] = useState(true);
+
+  return (
+    <>
+      <ScaleFade visible={visible}>
+        <Box
+          className={classes.container}
+          sx={{
+            height: height || 5,
+            marginTop: marginTop || 7,
+          }}
+        >
+          <Box
+            className={classes.bar}
+            onAnimationEnd={() => setVisible(false)}
+            sx={{
+              animation: 'progress-bar linear',
+              animationDirection: 'reverse',
+              animationFillMode: 'forwards',
+              animationDuration: `${duration}ms`
+            }}
+          >
+          </Box>
+        </Box>
+      </ScaleFade>
+    </>
+  );
+};
+
+export default ShowDurationBar;

--- a/web/src/typings/alert.ts
+++ b/web/src/typings/alert.ts
@@ -2,9 +2,11 @@ export interface AlertProps {
   header: string;
   content: string;
   centered?: boolean;
+  timeout?: number;
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   overflow?: boolean;
   cancel?: boolean;
+  confirm?: boolean;
   labels?: {
     cancel?: string;
     confirm?: string;

--- a/web/src/typings/notifications.ts
+++ b/web/src/typings/notifications.ts
@@ -8,6 +8,7 @@ export interface NotificationProps {
   description?: string;
   title?: string;
   duration?: number;
+  durationBar?: boolean;
   icon?: IconProp;
   iconColor?: string;
   iconAnimation?: IconAnimation;


### PR DESCRIPTION
https://github.com/overextended/ox_lib/assets/58100226/20f06da3-f35e-4bf3-b020-878f5cf80012

New option in Notifications
```
durationBar?: boolean -- Option to show duration bar
```

Example Notification:
```
lib.notify({
    id = 'some_identifier',
    title = 'Notification title',
    description = 'Notification description',
    position = 'top',
    durationBar = true, -- This one has been added
    style = {
        backgroundColor = '#141517',
        color = '#C1C2C5',
        ['.description'] = {
          color = '#909296'
        }
    },
    icon = 'ban',
    iconColor = '#C53030'
})
```

New option in Alert Dialogs
```
timeout?: number -- When there is a number here it will show the duration bar
confirm?: boolean -- Option to show confirm button
```

Example Alert Dialog:
```
lib.alertDialog({
    header = 'Hello there',
    content = 'General Kenobi  \n Markdown support!',
    timeout = 5000, -- This one has been added
    centered = true,
    cancel = true,
    confirm = true -- This one has been added
})
```