### PR TITLE
feat(imports/logger): add fivemanage as logging option

### DIFF
--- a/imports/logger/server.lua
+++ b/imports/logger/server.lua
@@ -84,6 +84,53 @@ local function formatTags(source, tags)
     return tags
 end
 
+if service == 'fivemanage' then
+    local key = GetConvar('fivemanage:key', '')
+
+    if key ~= '' then
+        local endpoint = 'https://api.fivemanage.com/api/logs/batch'
+
+        local headers = {
+            ['Content-Type'] = 'application/json',
+            ['Authorization'] = key,
+            ['User-Agent'] = 'ox_lib'
+        }
+
+        function lib.logger(source, event, message, ...)
+            if not buffer then
+                buffer = {}
+
+                SetTimeout(500, function()
+                    PerformHttpRequest(endpoint, function(status, _, _, response)
+                        if status ~= 200 then 
+                            if type(response) == 'string' then
+                                response = json.decode(response) or response
+                                badResponse(endpoint, status, response)
+                            end
+                        end
+                    end, 'POST', json.encode(buffer), headers)
+
+                    buffer = nil
+                    bufferSize = 0
+                end)
+            end
+
+            bufferSize += 1
+            buffer[bufferSize] = {
+                level = "info",
+                message = message,
+                resource = cache.resource,
+                metadata = {
+                    hostname = hostname,
+                    service = event,
+                    source = source,
+                    tags = formatTags(source, ... and string.strjoin(',', string.tostringall(...)) or nil),
+                }
+            }
+        end
+    end
+end
+
 if service == 'datadog' then
     local key = GetConvar('datadog:key', ''):gsub("[\'\"]", '')
 


### PR DESCRIPTION
Proposal to add Fivemanage as a logging option to ox_lib logger import.

Didn't want to start modifying the parameters for the function, but if you want to, we can also alter it to instead just accept key/value data and level. Right now, everything is just "info".

Up to you guys to decide.