### PR TITLE
timer module

### DIFF
--- a/imports/timer/shared.lua
+++ b/imports/timer/shared.lua
@@ -1,17 +1,31 @@
+---@class TimerPrivateProps
+---@field onEnd? fun() cb function triggered when the timer finishes
+---@field async? boolean wether the timer should run asynchronously or not
+---@field startTime number the gametimer stamp of when the timer starts. changes when paused and played
+---@field triggerOnEnd boolean set in the forceEnd method using the optional param. wether or not the onEnd function is triggered when force ending the timer early
+---@field currentTime number current timer length
+---@field tickActive boolean or not the tick is running
+
 ---@class CTimer : OxClass
+---@field private TimerPrivateProps
+---@field constructor fun(self: self, time: number, onEnd: fun(), async: boolean)
+---@field start fun(self: self) starts the timer
+---@field tick fun(self: self) handles the tick of the timer. not for use externally
+---@field forceEnd fun(self: self, triggerOnEnd: boolean) end timer early and optionally trigger the onEnd function still
+---@field pause fun(self: self) pauses the timer until play method is called
+---@field play fun(self: self) resumes the timer if paused
+---@field getTimeLeft fun(self: self): number returns the time left on the timer in milliseconds
 local timer = lib.class('CTimer')
 
----@param time number
----@param onEnd? fun(data: CTimer)
----@param async? boolean
 function timer:constructor(time, onEnd, async)
-    if not time then
-        return lib.print.error('No time was provided to the timer')
-    end
+    assert(type(time) == "number" and time > 0, "Time must be a positive number")
+    assert(onEnd == nil or type(onEnd) == "function", "onEnd must be a function or nil")
+    assert(type(async) == "boolean" or async == nil, "async must be a boolean or nil")
 
     self.time = time
     self.paused = false
 
+    self.private.currentTime = time
     self.private.onEnd = onEnd
     self.private.async = async
     self.private.startTime = 0
@@ -35,41 +49,58 @@ function timer:start()
 end
 
 function timer:tick()
-    if not debug.getinfo(2, 'S').short_src:find('@ox_lib/imports/timer') then lib.print.warn('the tick method is only called interally') return end
+    if not debug.getinfo(2, 'S').short_src:find('@ox_lib/imports/timer') then
+        lib.print.warn('the tick method is only called interally')
+        return
+    end
+
+    self.private.tickActive = true
 
     while true do
         if self.paused then
-            self.time -= (GetGameTimer() - self.private.startTime)
             while self.paused do
                 Wait(0)
             end
-            self.private.startTime = GetGameTimer()
         end
-        if GetGameTimer() - self.private.startTime >= self.time then
+
+        if GetGameTimer() - self.private.startTime >= self.private.currentTime then
             break
         end
+
         Wait(0)
     end
+
+    self.private.tickActive = false
+
     if self.private.triggerOnEnd and self.private.onEnd then
         self.private:onEnd()
     end
-
-    self = nil
 end
 
 function timer:forceEnd(triggerOnEnd)
     self.private.triggerOnEnd = triggerOnEnd
-    self.time = 0
+    self.private.currentTime = 0
 end
 
 function timer:pause()
     if self.paused then return end
+    self.private.currentTime = self:getTimeLeft()
     self.paused = true
 end
 
 function timer:play()
     if not self.paused then return end
+    self.private.startTime = GetGameTimer()
     self.paused = false
+end
+
+function timer:restart()
+    self.private.startTime = 0
+    self:start()
+end
+
+function timer:getTimeLeft()
+    return self.private.currentTime - (GetGameTimer() - self.private.startTime)
 end
 
 lib.timer = {

--- a/imports/timer/shared.lua
+++ b/imports/timer/shared.lua
@@ -1,0 +1,87 @@
+---@class CTimer : OxClass
+local timer = lib.class('CTimer')
+
+---@param time number
+---@param onEnd? fun(data: CTimer)
+---@param async? boolean
+function timer:constructor(time, onEnd, async)
+    if not time then
+        return lib.print.error('No time was provided to the timer')
+    end
+
+    self.time = time
+    self.paused = false
+
+    self.private.onEnd = onEnd
+    self.private.async = async
+    self.private.startTime = 0
+    self.private.triggerOnEnd = true
+
+    self:start()
+end
+
+function timer:start()
+    if self.private.startTime > 0 then return end
+
+    self.private.startTime = GetGameTimer()
+
+    if self.private.async then
+        CreateThread(function()
+            self:tick()
+        end)
+    else
+        self:tick()
+    end
+end
+
+function timer:tick()
+    if not debug.getinfo(2, 'S').short_src:find('@ox_lib/imports/timer') then lib.print.warn('the tick method is only called interally') return end
+
+    while true do
+        if self.paused then
+            self.time -= (GetGameTimer() - self.private.startTime)
+            while self.paused do
+                Wait(0)
+            end
+            self.private.startTime = GetGameTimer()
+        end
+        if GetGameTimer() - self.private.startTime >= self.time then
+            break
+        end
+        Wait(0)
+    end
+    if self.private.triggerOnEnd and self.private.onEnd then
+        self.private:onEnd()
+    end
+
+    self = nil
+end
+
+function timer:forceEnd(triggerOnEnd)
+    self.private.triggerOnEnd = triggerOnEnd
+    self.time = 0
+end
+
+function timer:pause()
+    if self.paused then return end
+    self.paused = true
+end
+
+function timer:play()
+    if not self.paused then return end
+    self.paused = false
+end
+
+lib.timer = {
+    async = function(time, onEnd)
+        return timer:new(time, onEnd, true)
+    end
+}
+
+setmetatable(lib.timer, {
+    __call = function(t, time, onEnd)
+        return timer:new(time, onEnd)
+    end
+})
+
+return lib.timer

--- a/imports/timer/shared.lua
+++ b/imports/timer/shared.lua
@@ -1,20 +1,21 @@
 ---@class TimerPrivateProps
+---@field initialTime number the initial duration of the timer.
 ---@field onEnd? fun() cb function triggered when the timer finishes
 ---@field async? boolean wether the timer should run asynchronously or not
 ---@field startTime number the gametimer stamp of when the timer starts. changes when paused and played
 ---@field triggerOnEnd boolean set in the forceEnd method using the optional param. wether or not the onEnd function is triggered when force ending the timer early
----@field currentTime number current timer length
+---@field currentTimeLeft number current timer length
 ---@field paused boolean the pause state of the timer
 
 ---@class OxTimer : OxClass
 ---@field private TimerPrivateProps
 ---@field constructor fun(self: self, time: number, onEnd: fun(), async: boolean)
----@field start fun(self: self) starts the timer
----@field tick fun(self: self) handles the tick of the timer. not for use externally
+---@field start fun(self: self, async?: boolean) starts the timer
 ---@field forceEnd fun(self: self, triggerOnEnd: boolean) end timer early and optionally trigger the onEnd function still
+---@field isPaused fun(self: self): boolean returns wether the timer is paused or not
 ---@field pause fun(self: self) pauses the timer until play method is called
 ---@field play fun(self: self) resumes the timer if paused
----@field getTimeLeft fun(self: self): number returns the time left on the timer in milliseconds
+---@field getTimeLeft fun(self: self, format?: 'ms' | 's' | 'm' | 'h'): number | table returns the time left on the timer with the specified format rounded to 2 decimal places (miliseconds, seconds, minutes, hours). returns a table of all if not specified.
 local timer = lib.class('OxTimer')
 
 function timer:constructor(time, onEnd, async)
@@ -22,71 +23,72 @@ function timer:constructor(time, onEnd, async)
     assert(onEnd == nil or type(onEnd) == "function", "onEnd must be a function or nil")
     assert(type(async) == "boolean" or async == nil, "async must be a boolean or nil")
 
-    self.currentTime = time
-    self.startTime = 0
-
+    self.private.initialTime = time
+    self.private.currentTimeLeft = time
+    self.private.startTime = 0
     self.private.paused = false
     self.private.onEnd = onEnd
-    self.private.async = async
     self.private.triggerOnEnd = true
 
-    self:start()
+    self:start(async)
 end
 
----@param timerInstance OxTimer
-local function tick(timerInstance)
-    while true do
-        if timerInstance.paused then
-            while timerInstance.paused do
-                Wait(0)
-            end
-        end
-
-        if GetGameTimer() - timerInstance.startTime >= timerInstance.currentTime then
-            break
-        end
-
-        Wait(0)
-    end
-
-    timerInstance:onEnd()
-end
-
-function timer:start()
+function timer:start(async)
     if self.private.startTime > 0 then return end
 
     self.private.startTime = GetGameTimer()
 
-    if self.private.async then
-        CreateThread(function()
+    local function tick(instance)
+        while true do
+            while instance.private.paused do
+                Wait(0)
+            end
+
+            if instance:getTimeLeft('ms') <= 0 then
+                break
+            end
+
+            Wait(0)
+        end
+    end
+
+    if async then
+        Citizen.CreateThreadNow(function()
             tick(self)
+            self:onEnd()
         end)
     else
         tick(self)
+        self:onEnd()
     end
 end
 
 function timer:onEnd()
+    if self:getTimeLeft('ms') > 0 then return end
+
     if self.private.triggerOnEnd and self.private.onEnd then
         self.private:onEnd()
     end
 end
 
 function timer:forceEnd(triggerOnEnd)
+    if self:getTimeLeft('ms') <= 0 then return end
     self.private.triggerOnEnd = triggerOnEnd
-    self.private.currentTime = 0
+    self.private.paused = false
+    self.private.currentTimeLeft = 0
+    Wait(0)
 end
 
 function timer:pause()
-    if self.paused then return end
-    self.private.currentTime = self:getTimeLeft()
-    self.paused = true
+    if self.private.paused then return end
+    self.private.currentTimeLeft = self:getTimeLeft('ms') --[[@as number]]
+    self.private.paused = true
 end
 
 function timer:play()
-    if not self.paused then return end
+    if not self.private.paused then return end
     self.private.startTime = GetGameTimer()
-    self.paused = false
+    self.private.paused = false
 end
 
 function timer:isPaused()
@@ -94,12 +96,48 @@ function timer:isPaused()
 end
 
 function timer:restart()
+    self:forceEnd(false)
+    Wait(0)
+    self.private.currentTimeLeft = self.private.initialTime
     self.private.startTime = 0
     self:start()
 end
 
-function timer:getTimeLeft()
-    return self.private.currentTime - (GetGameTimer() - self.private.startTime)
+function timer:getTimeLeft(format)
+    local ms = self.private.currentTimeLeft - (GetGameTimer() - self.private.startTime)
+
+    local roundedfloat = function(value)
+        return tonumber(string.format('%.2f', value))
+    end
+
+    if format == 'ms' then
+        return roundedfloat(ms)
+    end
+
+    local s = ms / 1000
+
+    if format == 's' then
+        return roundedfloat(s)
+    end
+
+    local m = s / 60
+
+    if format == 'm' then
+        return roundedfloat(m)
+    end
+
+    local h = m / 60
+
+    if format == 'h' then
+        return roundedfloat(h)
+    end
+
+    return {
+        ms = roundedfloat(ms),
+        s = roundedfloat(s),
+        m = roundedfloat(m),
+        h = roundedfloat(h)
+    }
 end
 
 lib.timer = {


### PR DESCRIPTION
while looking throught the issues for ox_lib i saw that this module was a suggested feature #358 from a while ago. was bored so i decided to create it.

# lib.timer
 - create both async and sync timers to trigger delayed functions
 - pause and play timers after creation
 - force timers to end early and optionally trigger the onEnd cb function still
 
 this module aims reduce the amount of reused code for timers in resources as well as provide useful methods, extending the utility of the normal timers youd see:
 ```lua
 -- traditional timer in a resource
 local start = GetGameTimer()
 local timer = 1000

 while GetGameTimer() - start > timer do
     Wait(0)
 end
 
 -- do something
 ```

 
 ### lib.timer examples:
 
 ```lua
 --sync

print('before')

local timer = lib.timer(5000, function()
    print(GetGameTimer() - start)
end)

print('after')
 ```

```lua
-- async

local start = GetGameTimer()

local timer = lib.timer.async(5000, function()
    print(GetGameTimer() - start)
end)

timer:pause()

Wait(1000)

timer:play()
    
--timer finishes in 6 seconds rather than 5 because of the pause
```


```lua
RegisterCommand('testAllTimerFeatures', function(source, args, raw)
    -- Create and start a synchronous timer
    print('Sync timer started with 3 seconds')
    local syncTimer = lib.timer(3000, function()
        print('Sync timer on end')
    end)

    -- Create and start an asynchronous timer
    local start = GetGameTimer()
    local asyncTimer = lib.timer.async(5000, function()
        print('Async timer on end', GetGameTimer() - start)
    end)
    print('Async timer started with 5 seconds')

    Wait(1000)
    print('1 second elapsed')
    print('Is the async timer paused?', asyncTimer:isPaused(), asyncTimer:getTimeLeft('ms'))


    -- Check time left in different formats for the async timer
    print('Async timer time left (ms):', asyncTimer:getTimeLeft('ms'))
    print('Async timer time left (s):', asyncTimer:getTimeLeft('s'))

    -- Pause the asynchronous timer
    asyncTimer:pause()
    print('Async timer paused')

    Wait(2000)
    print('2 more seconds elapsed')

    -- Resume the asynchronous timer
    asyncTimer:play()
    print('Async timer resumed')
    print('Async timer time left (ms):', asyncTimer:getTimeLeft('ms'))
    print('Async timer time left (s):', asyncTimer:getTimeLeft('s'))

    Wait(1000)
    print('1 second after resume')

    -- Restart the asynchronous timer
    asyncTimer:restart()
    print('Async timer restarted')

    Wait(1000)
    print('1 second after restart')

    -- Print the time left in all formats for the asynchronous timer
    local timeLeft = asyncTimer:getTimeLeft()
    print(string.format('Time left - ms: %.2f, s: %.2f, m: %.2f, h: %.2f', timeLeft.ms, timeLeft.s, timeLeft.m, timeLeft.h))

    -- Finally force end the asynchronous timer without triggering the onEnd function
    asyncTimer:forceEnd(true)
    print('Async timer force ended with onEnd')
end)

```

will write the docs for it as well if it is approved. 