### PR TITLE
feat(notify): add option to show duration

### DIFF
--- a/package/client/resource/interface/notify.ts
+++ b/package/client/resource/interface/notify.ts
@@ -18,6 +18,7 @@ interface NotifyProps {
   title?: string;
   description?: string;
   duration?: number;
+  showDuration?: boolean;
   position?: NotificationPosition;
   type?: NotificationType;
   style?: Sx;

--- a/resource/interface/client/notify.lua
+++ b/resource/interface/client/notify.lua
@@ -7,6 +7,7 @@
 ---@field title? string
 ---@field description? string
 ---@field duration? number
+---@field showDuration? boolean
 ---@field position? NotificationPosition
 ---@field type? NotificationType
 ---@field style? { [string]: any }

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "react-hot-toast": "^2.4.0",
     "react-markdown": "^8.0.1",
     "remark-gfm": "^3.0.1",
+    "tinycolor2": "^1.6.0",
     "typescript": "^4.6.3",
     "vite": "^5.0.13",
     "web-vitals": "^2.1.4"
@@ -41,6 +42,7 @@
     "@types/node": "^20.9.0",
     "@types/react": "^18.0.24",
     "@types/react-dom": "^18.0.8",
+    "@types/tinycolor2": "^1.4.6",
     "autoprefixer": "^10.0.2",
     "cross-env": "^7.0.3",
     "csstype": "^3.0.10",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -70,6 +70,9 @@ dependencies:
   remark-gfm:
     specifier: ^3.0.1
     version: 3.0.1
+  tinycolor2:
+    specifier: ^1.6.0
+    version: 1.6.0
   typescript:
     specifier: ^4.6.3
     version: 4.9.5
@@ -99,6 +102,9 @@ devDependencies:
   '@types/react-dom':
     specifier: ^18.0.8
     version: 18.0.10
+  '@types/tinycolor2':
+    specifier: ^1.4.6
+    version: 1.4.6
   autoprefixer:
     specifier: ^10.0.2
     version: 10.4.13(postcss@8.4.31)
@@ -1394,6 +1400,10 @@ packages:
   /@types/scheduler@0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
 
+  /@types/tinycolor2@1.4.6:
+    resolution: {integrity: sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==}
+    dev: true
+
   /@types/unist@2.0.6:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
     dev: false
@@ -2630,6 +2640,10 @@ packages:
 
   /tabbable@6.0.1:
     resolution: {integrity: sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA==}
+    dev: false
+
+  /tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
     dev: false
 
   /to-fast-properties@2.0.0:

--- a/web/src/features/dev/debug/notification.ts
+++ b/web/src/features/dev/debug/notification.ts
@@ -37,20 +37,7 @@ export const debugCustomNotification = () => {
         description: 'Notification description',
         type: 'success',
         icon: 'microchip',
-      },
-    },
-  ]);
-  debugData<NotificationProps>([
-    {
-      action: 'notify',
-      data: {
-        title: 'Custom show duration',
-        duration: 5000,
-        showDuration: true,
-        icon: 'eye',
-        iconColor: 'violet',
-        iconAnimation: 'spin',
-        description: 'Notification description',
+        showDuration: false,
       },
     },
   ]);

--- a/web/src/features/dev/debug/notification.ts
+++ b/web/src/features/dev/debug/notification.ts
@@ -40,4 +40,18 @@ export const debugCustomNotification = () => {
       },
     },
   ]);
+  debugData<NotificationProps>([
+    {
+      action: 'notify',
+      data: {
+        title: 'Custom show duration',
+        duration: 5000,
+        showDuration: true,
+        icon: 'eye',
+        iconColor: 'violet',
+        iconAnimation: 'spin',
+        description: 'Notification description',
+      },
+    },
+  ]);
 };

--- a/web/src/features/notifications/NotificationWrapper.tsx
+++ b/web/src/features/notifications/NotificationWrapper.tsx
@@ -1,8 +1,9 @@
 import { useNuiEvent } from '../../hooks/useNuiEvent';
 import { toast, Toaster } from 'react-hot-toast';
 import ReactMarkdown from 'react-markdown';
-import { Avatar, Box, Center, createStyles, Group, keyframes, RingProgress, Stack, Text, ThemeIcon } from '@mantine/core';
+import { Box, Center, createStyles, Group, keyframes, RingProgress, Stack, Text, ThemeIcon } from '@mantine/core';
 import React from 'react';
+import tinycolor from 'tinycolor2';
 import type { NotificationProps } from '../../typings';
 import MarkdownComponents from '../../config/MarkdownComponents';
 import LibIcon from '../../components/LibIcon';
@@ -108,10 +109,6 @@ const durationCircle = keyframes({
   '100%': { strokeDasharray: `${15.1 * 2 * Math.PI}, 0` },
 });
 
-const isValidHexColor = (hex: string) => {
-  return /^#[0-9A-F]{6}$/i.test(hex)
-}
-
 const Notifications: React.FC = () => {
   const { classes } = useStyles();
 
@@ -120,6 +117,8 @@ const Notifications: React.FC = () => {
 
     let iconColor: string;
     let duration = data.duration || 3000;
+
+    data.showDuration = data.showDuration !== undefined ? data.showDuration : true;
 
     // Backwards compat with old notifications
     let position = data.position;
@@ -150,20 +149,20 @@ const Notifications: React.FC = () => {
     if (!data.iconColor) {
       switch (data.type) {
         case 'error':
-          iconColor = 'red';
+          iconColor = 'red.6';
           break;
         case 'success':
-          iconColor = 'teal';
+          iconColor = 'teal.6';
           break;
         case 'warning':
-          iconColor = 'yellow';
+          iconColor = 'yellow.6';
           break;
         default:
-          iconColor = 'blue';
+          iconColor = 'blue.6';
           break;
       }
     } else {
-      iconColor = data.iconColor;
+      iconColor = tinycolor(data.iconColor).toRgbString();
     }
     toast.custom(
       (t) => (
@@ -193,7 +192,7 @@ const Notifications: React.FC = () => {
                   <RingProgress
                     size={38}
                     thickness={2}
-                    sections={[{ value: 100, color: iconColor}]}
+                    sections={[{ value: 100, color: iconColor }]}
                     style={{ alignSelf: !data.alignIcon || data.alignIcon === 'center' ? 'center' : 'start' }}
                     styles={{
                       root: {
@@ -207,45 +206,36 @@ const Notifications: React.FC = () => {
                     label={
                       <Center>
                         <ThemeIcon
-                          variant="light"
                           color={iconColor}
                           radius="xl"
                           size={32}
+                          variant={tinycolor(iconColor).getAlpha() === 0 ? undefined : 'light'}
                         >
-                          {!data.iconColor || !isValidHexColor(data.iconColor) ? (
-                            <LibIcon icon={data.icon} fixedWidth animation={data.iconAnimation} />
-                          ) : (
-                            <LibIcon
-                              icon={data.icon}
-                              fixedWidth
-                              color={iconColor}
-                              animation={data.iconAnimation}
-                            />
-                          )}
+                          <LibIcon
+                            icon={data.icon}
+                            fixedWidth
+                            color={iconColor}
+                            animation={data.iconAnimation}
+                          />
                         </ThemeIcon>
                       </Center>
                     }
                   />
-                ) : !data.iconColor ? (
-                  <Avatar
+                ) : (
+                  <ThemeIcon
                     color={iconColor}
-                    style={{ alignSelf: !data.alignIcon || data.alignIcon === 'center' ? 'center' : 'start' }}
                     radius="xl"
                     size={32}
+                    variant={tinycolor(iconColor).getAlpha() === 0 ? undefined : 'light'}
+                    style={{ alignSelf: !data.alignIcon || data.alignIcon === 'center' ? 'center' : 'start' }}
                   >
-                    <LibIcon icon={data.icon} fixedWidth size="lg" animation={data.iconAnimation} />
-                  </Avatar>
-                ) : (
-                  <LibIcon
-                    icon={data.icon}
-                    animation={data.iconAnimation}
-                    style={{
-                      color: iconColor,
-                      alignSelf: !data.alignIcon || data.alignIcon === 'center' ? 'center' : 'start',
-                    }}
-                    fixedWidth
-                    size="lg"
-                  />
+                    <LibIcon
+                      icon={data.icon}
+                      fixedWidth
+                      color={iconColor}
+                      animation={data.iconAnimation}
+                    />
+                  </ThemeIcon>
                 )}
               </>
             )}

--- a/web/src/features/notifications/NotificationWrapper.tsx
+++ b/web/src/features/notifications/NotificationWrapper.tsx
@@ -1,7 +1,7 @@
 import { useNuiEvent } from '../../hooks/useNuiEvent';
 import { toast, Toaster } from 'react-hot-toast';
 import ReactMarkdown from 'react-markdown';
-import { Avatar, Box, Center, createStyles, Group, keyframes, RingProgress, Stack, Text } from '@mantine/core';
+import { Avatar, Box, Center, createStyles, Group, keyframes, RingProgress, Stack, Text, ThemeIcon } from '@mantine/core';
 import React from 'react';
 import type { NotificationProps } from '../../typings';
 import MarkdownComponents from '../../config/MarkdownComponents';
@@ -108,6 +108,10 @@ const durationCircle = keyframes({
   '100%': { strokeDasharray: `${15.1 * 2 * Math.PI}, 0` },
 });
 
+const isValidHexColor = (hex: string) => {
+  return /^#[0-9A-F]{6}$/i.test(hex)
+}
+
 const Notifications: React.FC = () => {
   const { classes } = useStyles();
 
@@ -202,13 +206,23 @@ const Notifications: React.FC = () => {
                     }}
                     label={
                       <Center>
-                        <Avatar
+                        <ThemeIcon
+                          variant="light"
                           color={iconColor}
                           radius="xl"
                           size={32}
                         >
-                          <LibIcon icon={data.icon} fixedWidth size="lg" animation={data.iconAnimation} />
-                        </Avatar>
+                          {!data.iconColor || !isValidHexColor(data.iconColor) ? (
+                            <LibIcon icon={data.icon} fixedWidth animation={data.iconAnimation} />
+                          ) : (
+                            <LibIcon
+                              icon={data.icon}
+                              fixedWidth
+                              color={iconColor}
+                              animation={data.iconAnimation}
+                            />
+                          )}
+                        </ThemeIcon>
                       </Center>
                     }
                   />

--- a/web/src/typings/notifications.ts
+++ b/web/src/typings/notifications.ts
@@ -8,6 +8,7 @@ export interface NotificationProps {
   description?: string;
   title?: string;
   duration?: number;
+  showDuration?: boolean;
   icon?: IconProp;
   iconColor?: string;
   iconAnimation?: IconAnimation;


### PR DESCRIPTION
**lib.notify New Option**
```typescript
showDuration?: boolean -- Option to show duration bar
```

**Example:**
```lua
lib.notify({
    title = 'Custom',
    description = 'Custom',
    showDuration = true,
    icon = 'eye',
    iconColor = '#C53030'
})
```

**Preview:**

![Screenshot 2024-04-08 231022](https://github.com/overextended/ox_lib/assets/58100226/e1dae61d-e765-418c-be3f-04dc3241b70b)