### PR TITLE
fix(requestScaleformMovie): use scaleform handle

### DIFF
--- a/imports/requestScaleformMovie/client.lua
+++ b/imports/requestScaleformMovie/client.lua
@@ -1,13 +1,17 @@
 ---Load a scaleform movie. When called from a thread, it will yield until it has loaded.
 ---@param scaleformName string
 ---@param timeout number? Approximate milliseconds to wait for the scaleform movie to load. Default is 1000.
----@return number scaleform
+---@return number? scaleform
 function lib.requestScaleformMovie(scaleformName, timeout)
     if type(scaleformName) ~= 'string' then
         error(("expected scaleformName to have type 'string' (received %s)"):format(type(scaleformName)))
     end
 
-    return lib.streamingRequest(RequestScaleformMovie, HasScaleformMovieLoaded, 'scaleformMovie', scaleformName, timeout)
+    local scaleform = RequestScaleformMovie(scaleformName)
+
+    return lib.waitFor(function()
+        if HasScaleformMovieLoaded(scaleform) then return scaleform end
+    end, ("failed to load scaleformMovie '%s'"):format(scaleformName), timeout)
 end
 
 return lib.requestScaleformMovie


### PR DESCRIPTION
`HasScaleformMovieLoaded` requires scaleform handle, not scaleform name.
Because of that, the generic `lib.streamingRequest` can't be used.