### PR TITLE
fix(class): fixed private access in method calls

### DIFF
--- a/imports/class/shared.lua
+++ b/imports/class/shared.lua
@@ -85,7 +85,7 @@ function mixins.new(class, ...)
             __index = function(self, index)
                 local di = getinfo(2, 'n')
 
-                if di.namewhat == 'local' then return end
+                if di.namewhat ~= 'method' and di.namewhat ~= '' then return end
 
                 return private[index]
             end,

--- a/imports/class/shared.lua
+++ b/imports/class/shared.lua
@@ -92,7 +92,7 @@ function mixins.new(class, ...)
             __newindex = function(self, index, value)
                 local di = getinfo(2, 'n')
 
-                if di.namewhat ~= 'method' then
+                if di.namewhat ~= 'method' and di.namewhat ~= '' then
                     error(("cannot set value of private field '%s'"):format(index), 2)
                 end
 


### PR DESCRIPTION
I created issue (#549) about not expecting value from private table. Commit dcdfe6e4421d8016e6e707c0b1a88a1e5d119b76 partially fixed this, but it creates a new issue.

Now, class documentation has one error, actually `jesse.private.year` returns 3, not nill.

```
-- code from https://overextended.dev/ox_lib/Modules/Class/Shared#example

CreateThread(function()
    local jesse = Student:new('Jesse', 2)
 
    jesse:introduceSelf() -- Hi! I'm Jesse, and I'm in year 2.
    jesse:setYear(3)
    jesse:introduceSelf() -- Hi! I'm Jesse, and I'm in year 3.
    print(jesse.private.year) -- nil  [now, this returns 3, not nil]
    print(getmetatable(jesse.private)) -- private
    jesse.private.year = 4 -- error
end)
```

I solve this with this simple if statement, and it works fine:

```
  __index = function(self, index)
      local di = getinfo(2, 'n')
  
      if di.namewhat ~= 'method' and di.namewhat ~= '' then return end
  
      return private[index]
  end,
```