### PR TITLE
Add onSelect function for dialog select rows

### DIFF
--- a/resource/interface/client/input.lua
+++ b/resource/interface/client/input.lua
@@ -1,9 +1,11 @@
 local input
+local currentRows
 
 ---@class InputDialogRowProps
 ---@field type 'input' | 'number' | 'checkbox' | 'select' | 'slider' | 'multi-select' | 'date' | 'date-range' | 'time' | 'textarea' | 'color'
 ---@field label string
 ---@field options? { value: string, label: string, default?: string }[]
+---@field onSelect? fun(args: any)
 ---@field password? boolean
 ---@field icon? string | {[1]: IconProp, [2]: string};
 ---@field iconColor? string
@@ -32,6 +34,7 @@ local input
 function lib.inputDialog(heading, rows, options)
     if input then return end
     input = promise.new()
+    currentRows = rows
 
     -- Backwards compat with string tables
     for i = 1, #rows do
@@ -63,6 +66,7 @@ function lib.closeInputDialog()
 
     input:resolve(nil)
     input = nil
+    currentRows = nil
 end
 
 RegisterNUICallback('inputData', function(data, cb)
@@ -71,6 +75,19 @@ RegisterNUICallback('inputData', function(data, cb)
 
     local promise = input
     input = nil
+    currentRows = nil
 
     promise:resolve(data)
+end)
+
+RegisterNUICallback('clickSelect', function(data, cb)
+    cb(1)
+
+    for i = 1, #currentRows do
+        local row = currentRows[i]
+
+        if (type(row) == 'table') and (row.type == 'select') then
+            if row.onSelect then row.onSelect(data.value) end
+        end
+    end
 end)

--- a/web/src/features/dialog/components/fields/select.tsx
+++ b/web/src/features/dialog/components/fields/select.tsx
@@ -2,6 +2,7 @@ import { MultiSelect, Select } from '@mantine/core';
 import { ISelect } from '../../../../typings';
 import { Control, useController } from 'react-hook-form';
 import { FormValues } from '../../InputDialog';
+import { fetchNui } from '../../../../utils/fetchNui';
 import LibIcon from '../../../../components/LibIcon';
 
 interface Props {
@@ -17,6 +18,14 @@ const SelectField: React.FC<Props> = (props) => {
     rules: { required: props.row.required },
   });
 
+  const handleSelectChange = (value: string) => {
+    if (controller.field.onChange) {
+      controller.field.onChange(value);
+    };
+    
+    fetchNui('clickSelect', { index: props.index + 1, value: value });
+  };
+
   return (
     <>
       {props.row.type === 'select' ? (
@@ -26,7 +35,7 @@ const SelectField: React.FC<Props> = (props) => {
           name={controller.field.name}
           ref={controller.field.ref}
           onBlur={controller.field.onBlur}
-          onChange={controller.field.onChange}
+          onChange={handleSelectChange}
           disabled={props.row.disabled}
           label={props.row.label}
           description={props.row.description}


### PR DESCRIPTION
This will allow you to trigger a function when an option is selected, example usage:

```lua
lib.inputDialog('Feature Example', {
    {
        type = 'select',
        required = true,
        icon = 'face-smile',
        label = 'Mood',
        default = 'angry',
        placeholder = 'Select',
        options = {
            { label = 'Angry', value = 'angry' },
            { label = 'Happy', value = 'happy' }
        },
        onSelect = function(value)
            print(('Linden is %s today!'):format(value)) -- Linden is angry | happy today!
        end
    }
})
```