### PR TITLE
fix(notify): reset circle animation on notification re-trigger with id

### DIFF
--- a/web/src/features/notifications/NotificationWrapper.tsx
+++ b/web/src/features/notifications/NotificationWrapper.tsx
@@ -2,7 +2,7 @@ import { useNuiEvent } from '../../hooks/useNuiEvent';
 import { toast, Toaster } from 'react-hot-toast';
 import ReactMarkdown from 'react-markdown';
 import { Box, Center, createStyles, Group, keyframes, RingProgress, Stack, Text, ThemeIcon } from '@mantine/core';
-import React from 'react';
+import React, { useRef } from 'react';
 import tinycolor from 'tinycolor2';
 import type { NotificationProps } from '../../typings';
 import MarkdownComponents from '../../config/MarkdownComponents';
@@ -111,12 +111,12 @@ const durationCircle = keyframes({
 
 const Notifications: React.FC = () => {
   const { classes } = useStyles();
-  const [toastKey, setToastKey] = React.useState(0);
+  const toastKeyRef = useRef(0);
 
   useNuiEvent<NotificationProps>('notify', (data) => {
-    const toastId = data.id?.toString()
+    const toastId = data.id?.toString();
 
-    if (toastId) setToastKey(prevKey => prevKey + 1);
+    if (toastId) toastKeyRef.current++;
 
     if (!data.title && !data.description) return;
 
@@ -195,7 +195,7 @@ const Notifications: React.FC = () => {
               <>
                 {data.showDuration ? (
                   <RingProgress
-                    key={toastKey}
+                    key={toastKeyRef.current}
                     size={38}
                     thickness={2}
                     sections={[{ value: 100, color: iconColor }]}
@@ -207,7 +207,7 @@ const Notifications: React.FC = () => {
                           animationDuration: `${duration}ms`,
                         },
                         margin: -3,
-                      }
+                      },
                     }}
                     label={
                       <Center>
@@ -217,12 +217,7 @@ const Notifications: React.FC = () => {
                           size={32}
                           variant={tinycolor(iconColor).getAlpha() === 0 ? undefined : 'light'}
                         >
-                          <LibIcon
-                            icon={data.icon}
-                            fixedWidth
-                            color={iconColor}
-                            animation={data.iconAnimation}
-                          />
+                          <LibIcon icon={data.icon} fixedWidth color={iconColor} animation={data.iconAnimation} />
                         </ThemeIcon>
                       </Center>
                     }
@@ -235,12 +230,7 @@ const Notifications: React.FC = () => {
                     variant={tinycolor(iconColor).getAlpha() === 0 ? undefined : 'light'}
                     style={{ alignSelf: !data.alignIcon || data.alignIcon === 'center' ? 'center' : 'start' }}
                   >
-                    <LibIcon
-                      icon={data.icon}
-                      fixedWidth
-                      color={iconColor}
-                      animation={data.iconAnimation}
-                    />
+                    <LibIcon icon={data.icon} fixedWidth color={iconColor} animation={data.iconAnimation} />
                   </ThemeIcon>
                 )}
               </>

--- a/web/src/features/notifications/NotificationWrapper.tsx
+++ b/web/src/features/notifications/NotificationWrapper.tsx
@@ -1,5 +1,5 @@
 import { useNuiEvent } from '../../hooks/useNuiEvent';
-import { toast, Toaster, useToasterStore } from 'react-hot-toast';
+import { toast, Toaster } from 'react-hot-toast';
 import ReactMarkdown from 'react-markdown';
 import { Box, Center, createStyles, Group, keyframes, RingProgress, Stack, Text, ThemeIcon } from '@mantine/core';
 import React from 'react';
@@ -111,12 +111,12 @@ const durationCircle = keyframes({
 
 const Notifications: React.FC = () => {
   const { classes } = useStyles();
-  const { toasts } = useToasterStore();
+  const [toastKey, setToastKey] = React.useState(0);
 
   useNuiEvent<NotificationProps>('notify', (data) => {
     const toastId = data.id?.toString()
 
-    if (toastId && toasts.some((toast) => toast.id === toastId)) return;
+    if (toastId) setToastKey(prevKey => prevKey + 1);
 
     if (!data.title && !data.description) return;
 
@@ -195,6 +195,7 @@ const Notifications: React.FC = () => {
               <>
                 {data.showDuration ? (
                   <RingProgress
+                    key={toastKey}
                     size={38}
                     thickness={2}
                     sections={[{ value: 100, color: iconColor }]}

--- a/web/src/features/notifications/NotificationWrapper.tsx
+++ b/web/src/features/notifications/NotificationWrapper.tsx
@@ -1,5 +1,5 @@
 import { useNuiEvent } from '../../hooks/useNuiEvent';
-import { toast, Toaster } from 'react-hot-toast';
+import { toast, Toaster, useToasterStore } from 'react-hot-toast';
 import ReactMarkdown from 'react-markdown';
 import { Box, Center, createStyles, Group, keyframes, RingProgress, Stack, Text, ThemeIcon } from '@mantine/core';
 import React from 'react';
@@ -111,8 +111,13 @@ const durationCircle = keyframes({
 
 const Notifications: React.FC = () => {
   const { classes } = useStyles();
+  const { toasts } = useToasterStore();
 
   useNuiEvent<NotificationProps>('notify', (data) => {
+    const toastId = data.id?.toString()
+
+    if (toastId && toasts.some((toast) => toast.id === toastId)) return;
+
     if (!data.title && !data.description) return;
 
     let iconColor: string;
@@ -254,7 +259,7 @@ const Notifications: React.FC = () => {
         </Box>
       ),
       {
-        id: data.id?.toString(),
+        id: toastId,
         duration: duration,
         position: position || 'top-right',
       }


### PR DESCRIPTION
This pull request is a fix for issue #554 

### **Fixed**
Reset circle animation when re-triggering a notification with `ID`.

### **Solution**
Assigning unique keys to each `RingProgress` instance allows React to properly manage its state and trigger re-renders when necessary.

### **Preview**
![notify](https://github.com/overextended/ox_lib/assets/58100226/318d8c8e-d191-4d09-9054-42acbce2aa54)
