### PR TITLE
feat(interface/multi-select): add max prop

### DIFF
--- a/package/client/resource/interface/input.ts
+++ b/package/client/resource/interface/input.ts
@@ -64,6 +64,7 @@ interface SelectProps extends BaseInput {
   default?: string | string[];
   clearable?: boolean;
   searchable?: boolean;
+  max?: number;
 }
 
 interface SliderProps extends BaseInput {

--- a/package/client/resource/interface/input.ts
+++ b/package/client/resource/interface/input.ts
@@ -64,7 +64,7 @@ interface SelectProps extends BaseInput {
   default?: string | string[];
   clearable?: boolean;
   searchable?: boolean;
-  max?: number;
+  maxSelectedValues?: number;
 }
 
 interface SliderProps extends BaseInput {

--- a/resource/interface/client/input.lua
+++ b/resource/interface/client/input.lua
@@ -21,6 +21,7 @@ local input
 ---@field clearable? boolean
 ---@field searchable? boolean
 ---@field description? string
+---@field maxSelectedValues? number
 
 ---@class InputDialogOptionsProps
 ---@field allowCancel? boolean

--- a/web/src/features/dialog/components/fields/select.tsx
+++ b/web/src/features/dialog/components/fields/select.tsx
@@ -51,6 +51,7 @@ const SelectField: React.FC<Props> = (props) => {
               withAsterisk={props.row.required}
               clearable={props.row.clearable}
               searchable={props.row.searchable}
+              maxSelectedValues={props.row.max}
               icon={props.row.icon && <LibIcon icon={props.row.icon} fixedWidth />}
             />
           )}

--- a/web/src/features/dialog/components/fields/select.tsx
+++ b/web/src/features/dialog/components/fields/select.tsx
@@ -51,7 +51,7 @@ const SelectField: React.FC<Props> = (props) => {
               withAsterisk={props.row.required}
               clearable={props.row.clearable}
               searchable={props.row.searchable}
-              maxSelectedValues={props.row.max}
+              maxSelectedValues={props.row.maxSelectedValues}
               icon={props.row.icon && <LibIcon icon={props.row.icon} fixedWidth />}
             />
           )}

--- a/web/src/typings/dialog.ts
+++ b/web/src/typings/dialog.ts
@@ -38,7 +38,7 @@ export interface ISelect extends BaseField<'select' | 'multi-select', string | s
   options: Array<OptionValue>;
   clearable?: boolean;
   searchable?: boolean;
-  max?: number;
+  maxSelectedValues?: number;
 }
 
 export interface INumber extends BaseField<'number', number> {

--- a/web/src/typings/dialog.ts
+++ b/web/src/typings/dialog.ts
@@ -38,6 +38,7 @@ export interface ISelect extends BaseField<'select' | 'multi-select', string | s
   options: Array<OptionValue>;
   clearable?: boolean;
   searchable?: boolean;
+  max?: number;
 }
 
 export interface INumber extends BaseField<'number', number> {


### PR DESCRIPTION
Allows using the max prop to limit how many options can be selected in a multi-select input field. This is an already existing feature in Mantine that I believe could be useful.

A PR has been submitted to update the docs as well in overextended/overextended.github.io#182