### PR TITLE
Allow explicit rotation order for Progress props

### DIFF
--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -9,6 +9,7 @@ local createdProps = {}
 ---@field bone? number
 ---@field pos vector3
 ---@field rot vector3
+---@field rotOrder? number
 
 ---@class ProgressProps
 ---@field label? string
@@ -29,7 +30,7 @@ local function createProp(ped, prop)
     local coords = GetEntityCoords(ped)
     local object = CreateObject(prop.model, coords.x, coords.y, coords.z, false, false, false)
 
-    AttachEntityToEntity(object, ped, GetPedBoneIndex(ped, prop.bone or 60309), prop.pos.x, prop.pos.y, prop.pos.z, prop.rot.x, prop.rot.y, prop.rot.z, true, true, false, true, 0, true)
+    AttachEntityToEntity(object, ped, GetPedBoneIndex(ped, prop.bone or 60309), prop.pos.x, prop.pos.y, prop.pos.z, prop.rot.x, prop.rot.y, prop.rot.z, true, true, false, true, prop.rotOrder or 0, true)
     SetModelAsNoLongerNeeded(prop.model)
 
     return object


### PR DESCRIPTION
As the rotation order varies wildly across community scripts, and Rockstar usually uses order 2, allowing overrides here is important for compatibility when updating legacy resources.

From a personal perspective, order 0 is kinda just a pain in the ass to use. The X and Z axes have to be manipulated in inverse to each other to produce meaningful rotation. There is also an inversion zone, which causes unexpected shifting at some points of X/Z crossover. Order 1, as well as some others, are much more friendly to work with.