### PR TITLE
linear interpolation for vectors.

### DIFF
--- a/imports/math/shared.lua
+++ b/imports/math/shared.lua
@@ -134,4 +134,22 @@ function math.clamp(val, lower, upper) -- credit https://love2d.org/forums/viewt
     return math.max(lower, math.min(upper, val))
 end
 
+---Lerps (linearly interpolates) between two vectors over a specified duration.
+---@param startVector vector -- Starting vector, the interpolation begins here.
+---@param endVector vector   -- Ending vector, the interpolation targets this.
+---@param duration number    -- The total duration of the interpolation in milliseconds.
+---@param cb function        -- Callback function that gets called with the interpolated vector as its argument.
+---@return boolean
+function math.lerpVectors(startVector, endVector, duration, cb)
+	local startTime = GetGameTimer()
+	local t = 0
+	while t < 1 do
+		t = math.min((GetGameTimer() - startTime) / duration, 1)
+		local interpolatedVector = startVector + (endVector - startVector) * t
+		cb(interpolatedVector)
+		Wait(0)
+	end
+	return true
+end
+
 return lib.math


### PR DESCRIPTION
`math.lerpVectors` is a standard linear interpolation between 2 vectors. This will allow developers to smoothy transition between 2 vectors for rotations or coords over a set duration.

this function is currently blocking. optional async is something that we can add if desired.

example: 
```lua
RegisterCommand('testLerp', function(source, args, raw)
	lib.requestModel(`gr_prop_gr_target_04b`)

	local offset = GetOffsetFromEntityInWorldCoords(cache.ped, 0, 3.0, 0)
	local object = CreateObject(`gr_prop_gr_target_04b`, offset.x, offset.y, offset.z, false, false, false)

	PlaceObjectOnGroundProperly_2(object)
	math.lerpVectors(vec3(0, 0, 0), vec3(-90.0, 0, 0), 500, function(interpolated)
		SetEntityRotation(object, interpolated.x, interpolated.y, interpolated.z, 0, false)
	end)
end)
```




https://github.com/overextended/ox_lib/assets/60995067/3d1d06a7-4458-4f35-8519-be37a3a5f6f8

