### PR TITLE
feat(interface/alert): custom actions to dialog

### DIFF
--- a/web/src/features/dialog/AlertDialog.tsx
+++ b/web/src/features/dialog/AlertDialog.tsx
@@ -67,19 +67,31 @@ const AlertDialog: React.FC = () => {
             {dialogData.content}
           </ReactMarkdown>
           <Group position="right" spacing={10}>
+            {dialogData.actions?.map(action => (
+                <Button
+                    key={action.id}
+                    mr={3}
+                    variant={action.variant ?? "default"}
+                    onClick={() => closeAlert(action.id)}
+                >
+                    {action.label}
+                </Button>
+            ))}
             {dialogData.cancel && (
               <Button uppercase variant="default" onClick={() => closeAlert('cancel')} mr={3}>
                 {dialogData.labels?.cancel || locale.ui.cancel}
               </Button>
             )}
-            <Button
-              uppercase
-              variant={dialogData.cancel ? 'light' : 'default'}
-              color={dialogData.cancel ? theme.primaryColor : undefined}
-              onClick={() => closeAlert('confirm')}
-            >
-              {dialogData.labels?.confirm || locale.ui.confirm}
-            </Button>
+            {(dialogData.confirm === undefined || dialogData.confirm) && (
+                <Button
+                    uppercase
+                    variant={dialogData.cancel ? 'light' : 'default'}
+                    color={dialogData.cancel ? theme.primaryColor : undefined}
+                    onClick={() => closeAlert('confirm')}
+                >
+                    {dialogData.labels?.confirm || locale.ui.confirm}
+                </Button>
+            )}
           </Group>
         </Stack>
       </Modal>

--- a/web/src/typings/alert.ts
+++ b/web/src/typings/alert.ts
@@ -1,12 +1,20 @@
+import { ButtonVariant } from "@mantine/core";
+
 export interface AlertProps {
   header: string;
   content: string;
   centered?: boolean;
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   overflow?: boolean;
+  confirm?: boolean;
   cancel?: boolean;
   labels?: {
     cancel?: string;
     confirm?: string;
   };
+  actions?: {
+    id: string;
+    label: string;
+    variant?: ButtonVariant;
+  }[];
 }


### PR DESCRIPTION
Hello,

I've introduced custom actions for alert dialogs to enhance flexibility in Alert development. With this enhancement, custom actions can be added, and when clicked, the dialog will return the ID of the action.

Additionally, when implementing fully custom actions, it's now possible to disable the confirm button.

![image](https://github.com/overextended/ox_lib/assets/65678882/2baeb8d4-855f-42bc-806e-0d182a1bc009)
