### PR TITLE
feat(interface/textarea): min / max length for textarea

### DIFF
--- a/web/src/features/dialog/components/fields/textarea.tsx
+++ b/web/src/features/dialog/components/fields/textarea.tsx
@@ -22,6 +22,8 @@ const TextareaField: React.FC<Props> = (props) => {
       disabled={props.row.disabled}
       withAsterisk={props.row.required}
       autosize={props.row.autosize}
+      minLength={props.row.minLength}
+      maxLength={props.row.maxLength}
       minRows={props.row.min}
       maxRows={props.row.max}
     />

--- a/web/src/typings/dialog.ts
+++ b/web/src/typings/dialog.ts
@@ -74,6 +74,8 @@ export interface ITimeInput extends Omit<BaseField<'time', string>, 'placeholder
 
 export interface ITextarea extends BaseField<'textarea', string> {
   autosize?: boolean;
+  minLength?: number;
+  maxLength?: number;
   min?: number;
   max?: number;
 }


### PR DESCRIPTION
Hello,

I've implemented a minimum or maximum length for the textarea to enhance the security of our data persistence.

![image](https://github.com/overextended/ox_lib/assets/65678882/10304b52-18f6-4f7f-a14e-c774bfbcd0d1)
