### PR TITLE
fix(imports/logger): Loki not indexing varargs 

### DIFF
--- a/imports/logger/server.lua
+++ b/imports/logger/server.lua
@@ -243,7 +243,7 @@ if service == 'loki' then
         local timestamp = ('%s000000000'):format(os.time(os.date('*t')))
 
         -- Initializes values table with the message
-        local values = {message = message}
+        local values = {}
 
         -- Format the args into strings
         local tags = formatTags(source, ... and string.strjoin(',', string.tostringall(...)) or nil)
@@ -264,7 +264,8 @@ if service == 'loki' then
             values = {
                 {
                     timestamp,
-                    json.encode(values)
+                    message,
+                    values
                 }
             }
         }


### PR DESCRIPTION
Hey!

i dont know if this is expected behaviour and the loki provider probably needs more rework but i played around with it a bit and currently its submitting the data in a wrong format. The code i used to submit logs (test):

```lua
RegisterCommand('t_log', function(source, args, rawCommand)
    lib.logger(-1, 'LogTest', 'Test 123', 'test123:test123', 'rpname:Lena Meier', 'job:police')
end, true)
```
(before)
![image](https://github.com/overextended/ox_lib/assets/6567620/5af78f80-f125-49c8-888e-ee4e6a9d4df9)
(after my changes)
![image](https://github.com/overextended/ox_lib/assets/6567620/52e6b7c4-560b-4274-82a2-9c52314b48ba)


I tried the following:
```lua
RegisterCommand('t_log', function(source, args, rawCommand)
    lib.logger(-1, 'LogTest', 'Test 123', { rpname = "Lena Meier", job = "police" })
end, true)
```

Which ended up in this:
![image](https://github.com/overextended/ox_lib/assets/6567620/1a75feb2-d91d-4c3e-a723-95c050c6df7d)

Probably this need some more rework, i think submitting the meta data in this format `key:value` is inconvenient. But this is out-of-scope for this "fix" 🗡️ 