### PR TITLE
feat(callback): disable timeout when callback timeout is 0 or less

### DIFF
--- a/imports/callback/client.lua
+++ b/imports/callback/client.lua
@@ -59,7 +59,9 @@ local function triggerServerCallback(_, event, delay, cb, ...)
     end
 
     if promise then
-        SetTimeout(callbackTimeout, function() promise:reject(("callback event '%s' timed out"):format(key)) end)
+        if callbackTimeout > 0 then
+            SetTimeout(callbackTimeout, function() promise:reject(("callback event '%s' timed out"):format(key)) end)
+        end
 
         return table.unpack(Citizen.Await(promise))
     end

--- a/imports/callback/server.lua
+++ b/imports/callback/server.lua
@@ -40,7 +40,9 @@ local function triggerClientCallback(_, event, playerId, cb, ...)
 	end
 
 	if promise then
-        SetTimeout(callbackTimeout, function() promise:reject(("callback event '%s' timed out"):format(key)) end)
+        if callbackTimeout > 0 then
+            SetTimeout(callbackTimeout, function() promise:reject(("callback event '%s' timed out"):format(key)) end)
+        end
 
 		return table.unpack(Citizen.Await(promise))
 	end

--- a/package/client/resource/callback/index.ts
+++ b/package/client/resource/callback/index.ts
@@ -41,8 +41,9 @@ export function triggerServerCallback<T = unknown>(
 
   return new Promise<T>((resolve, reject) => {
     pendingCallbacks[key] = resolve;
-
-    setTimeout(reject, callbackTimeout, `callback event '${key}' timed out`);
+    if (callbackTimeout > 0) {
+      setTimeout(reject, callbackTimeout, `callback event '${key}' timed out`);
+    }
   });
 }
 

--- a/package/server/resource/callback/index.ts
+++ b/package/server/resource/callback/index.ts
@@ -25,8 +25,9 @@ export function triggerClientCallback<T = unknown>(
 
   return new Promise<T>((resolve, reject) => {
     pendingCallbacks[key] = resolve;
-
-    setTimeout(reject, callbackTimeout, `callback event '${key}' timed out`);
+    if (callbackTimeout > 0) {
+      setTimeout(reject, callbackTimeout, `callback event '${key}' timed out`);
+    }
   });
 }
 


### PR DESCRIPTION
This provides backwards compatibility for resources relying on previous callback behavior which allowed for async callbacks without a callback function. As of https://github.com/overextended/ox_lib/commit/2166b076da31576dc13a5200195b51acb0428dee those resources are now timing out.