### PR TITLE
fix(imports/logger): Loki encode does not work as expected

### DIFF
--- a/imports/logger/server.lua
+++ b/imports/logger/server.lua
@@ -246,8 +246,13 @@ if service == 'loki' then
         local values = {}
 
         -- Format the args into strings
-        local tags = formatTags(source, ... and string.strjoin(',', string.tostringall(...)) or nil)
-        local tagsTable = convertDDTagsToKVP(tags)
+        local tagsTable
+        if type(...) == 'string' then
+            local tags = formatTags(source, ... and string.strjoin(',', string.tostringall(...)) or nil)
+            tagsTable = convertDDTagsToKVP(tags)
+        else
+            tagsTable = ...
+        end
 
         -- Concatenates tags kvp table to the values table
         for k,v in pairs(tagsTable) do


### PR DESCRIPTION
Solve the problem that tags are converted to “table:xxx” by string.tostringall and therefore can't be encoded to json by encode.
test code
```lua
lib.logger(-1, 'LogTest', 'Test String', 'test123:test123', 'rpname:Lena Meier', 'job:police')
lib.logger(-1, 'LogTest', 'Test Table', { rpname = "Lena Meier", job = "police" })
``` 
result
![图片](https://github.com/overextended/ox_lib/assets/108532800/2571cd93-b5ce-437b-96a0-f678c8db23c1)
