### PR TITLE
fix for timer start method accessing private variable out of scope

### DIFF
--- a/imports/timer/shared.lua
+++ b/imports/timer/shared.lua
@@ -41,28 +41,22 @@ function timer:start(async)
 
     self.private.startTime = GetGameTimer()
 
-    local function tick(instance)
-        while true do
-            while instance.private.paused do
+    local function tick()
+        while self:getTimeLeft('ms') > 0 do
+            while self:isPaused() do
                 Wait(0)
             end
-
-            if instance:getTimeLeft('ms') <= 0 then
-                break
-            end
-
             Wait(0)
         end
+        self:onEnd()
     end
 
     if async then
         Citizen.CreateThreadNow(function()
-            tick(self)
-            self:onEnd()
+            tick()
         end)
     else
-        tick(self)
-        self:onEnd()
+        tick()
     end
 end
 


### PR DESCRIPTION
this fixes an issue that caused timers to not be able to be paused properly.

also cleans up the start method a bit

[discord support thread](https://discord.com/channels/813030955598086174/1245968051971559466)