### PR TITLE
prevent errors in the json encode process

### DIFF
--- a/imports/print/shared.lua
+++ b/imports/print/shared.lua
@@ -17,7 +17,11 @@ local levelPrefixes = {
 
 local resourcePrintLevel = printLevel[GetConvar('ox:printlevel:' .. cache.resource, GetConvar('ox:printlevel', 'info'))]
 local template = ('^5[%s] %%s %%s^7'):format(cache.resource)
-local jsonOptions = { sort_keys = true, indent = true }
+local function handleException(reason, value)
+    if type(value) == 'function' then return tostring(value) end
+    return reason
+end
+local jsonOptions = { sort_keys = true, indent = true, exception = handleException }
 
 ---Prints to console conditionally based on what ox:printlevel is.
 ---Any print with a level more severe will also print. If ox:printlevel is info, then warn and error prints will appear as well, but debug prints will not.


### PR DESCRIPTION
adds an exception handler to the json.encode options so that the parser prints the name of the function or the reason it couldn't parse a key instead of crashing out.

Example before:
```
SCRIPT ERROR: type 'function' is not supported by JSON
[       script:test] 
[       script:test] > libPrint (@ox_lib/imports/print/server.lua:33)
[       script:test] > info (@ox_lib/imports/print/server.lua:42)
[       script:test] > ref (@test/server/test.lua:27)
```
After:
```
script:test] [test] [INFO] {
[       script:test]     "number": 30,
[       script:test]     "string": "Los Angeles",
[       script:test]     "fthis": "function: 0000020E8ABDD3F0"
[       script:test] }
```

Optionally returning `nil` instead of `reason` would still throw an error, while allowing objects with functions on them to be dumped in without needing to remove them first.