### PR TITLE
feat(addCommand): longString

### DIFF
--- a/imports/addCommand/server.lua
+++ b/imports/addCommand/server.lua
@@ -46,14 +46,12 @@ local function parseArguments(source, args, raw, params)
                 value = false
             end
         elseif param.type == 'longString' and i == paramsNum then
-            value = arg
-
-            local argsNum = #args
-            if paramsNum < argsNum then
-                for a = i + 1, argsNum do
-                    value = value .. ' ' .. args[a]
-                end
+            local words = {}
+            for word in raw:gmatch('%S+') do
+                words[#words + 1] = word
             end
+
+            value = table.type(words) ~= 'empty' and table.concat(words, ' ', i)
         else
             value = arg
         end

--- a/imports/addCommand/server.lua
+++ b/imports/addCommand/server.lua
@@ -1,7 +1,7 @@
 ---@class OxCommandParams
 ---@field name string
 ---@field help? string
----@field type? 'number' | 'playerId' | 'string'
+---@field type? 'number' | 'playerId' | 'string' | 'longString'
 ---@field optional? boolean
 
 ---@class OxCommandProperties
@@ -30,7 +30,8 @@ end)
 local function parseArguments(source, args, raw, params)
     if not params then return args end
 
-    for i = 1, #params do
+    local paramsNum = #params
+    for i = 1, paramsNum do
         local arg, param = args[i], params[i]
         local value
 
@@ -43,6 +44,15 @@ local function parseArguments(source, args, raw, params)
 
             if not value or not DoesPlayerExist(value--[[@as string]]) then
                 value = false
+            end
+        elseif param.type == 'longString' and i == paramsNum then
+            value = arg
+
+            local argsNum = #args
+            if paramsNum < argsNum then
+                for a = i + 1, argsNum do
+                    value = value .. ' ' .. args[a]
+                end
             end
         else
             value = arg
@@ -131,6 +141,7 @@ function lib.addCommand(commandName, properties, cb, ...)
         end
 
         if properties then
+            ---@diagnostic disable-next-line: inject-field
             properties.name = ('/%s'):format(commandName)
             properties.restricted = nil
             registeredCommands[totalCommands] = properties

--- a/imports/addCommand/server.lua
+++ b/imports/addCommand/server.lua
@@ -46,12 +46,8 @@ local function parseArguments(source, args, raw, params)
                 value = false
             end
         elseif param.type == 'longString' and i == paramsNum then
-            local words = {}
-            for word in raw:gmatch('%S+') do
-                words[#words + 1] = word
-            end
-
-            value = table.type(words) ~= 'empty' and table.concat(words, ' ', i)
+            local start = raw:find(arg, 1, true)
+            value = start and raw:sub(start)
         else
             value = arg
         end

--- a/package/server/resource/addCommand/index.ts
+++ b/package/server/resource/addCommand/index.ts
@@ -28,10 +28,6 @@ on('playerJoining', (source: number) => {
   emitNet('chat:addSuggestions', source, registeredCommmands);
 });
 
-function getTextFromRecord (record: Record<string | number, string | number | boolean>, startIndex: number): string {
-  return Object.entries(record).filter(([key, value]) => !Number(key) && Number(key) >= startIndex && typeof value === 'string').map(([, value]) => value).join(' ');
-}
-
 function parseArguments(
   source: number,
   args: OxCommandArguments,
@@ -60,8 +56,9 @@ function parseArguments(
         break;
 
       case 'longString':
-        const extraText = getTextFromRecord(args, index + 1);
-        value = (extraText !== '' && extraText !== ' ') ? `${arg} ${extraText}` : arg;
+        const words = raw.split(' ');
+        const newString = words.slice(index).join(' ');
+        value = newString !== '' ? newString : false;
         break;
 
       default:

--- a/package/server/resource/addCommand/index.ts
+++ b/package/server/resource/addCommand/index.ts
@@ -56,9 +56,7 @@ function parseArguments(
         break;
 
       case 'longString':
-        const words = raw.split(' ');
-        const newString = words.slice(index).join(' ');
-        value = newString !== '' ? newString : false;
+        value = raw.substring(raw.indexOf(arg as string));
         break;
 
       default:

--- a/package/server/resource/addCommand/index.ts
+++ b/package/server/resource/addCommand/index.ts
@@ -5,7 +5,7 @@ type OxCommandArguments = Record<string | number, string | number | boolean>;
 interface OxCommandParams {
   name: string;
   help?: string;
-  paramType?: 'number' | 'playerId' | 'string';
+  paramType?: 'number' | 'playerId' | 'string' | 'longString';
   optional?: boolean;
 }
 
@@ -27,6 +27,10 @@ setTimeout(() => {
 on('playerJoining', (source: number) => {
   emitNet('chat:addSuggestions', source, registeredCommmands);
 });
+
+function getTextFromRecord (record: Record<string | number, string | number | boolean>, startIndex: number): string {
+  return Object.entries(record).filter(([key, value]) => !Number(key) && Number(key) >= startIndex && typeof value === 'string').map(([, value]) => value).join(' ');
+}
 
 function parseArguments(
   source: number,
@@ -53,6 +57,11 @@ function parseArguments(
         value = arg === 'me' ? source : +arg;
         if (!value || !DoesPlayerExist(value.toString())) value = false;
 
+        break;
+
+      case 'longString':
+        const extraText = getTextFromRecord(args, index + 1);
+        value = (extraText !== '' && extraText !== ' ') ? `${arg} ${extraText}` : arg;
         break;
 
       default:


### PR DESCRIPTION
Whenever you have a command that has a text type at the end where you want to catch all text from that argument and on, only the first word will be assigned to that argument and the rest ends up all in an array which makes for a mixed table. With longString it catches those extras if the argument is at the end of the given params.

For example
`/test test1 test2`

Before only `test1` would be shown.
After, all text will be shown.

*I haven't tested this yet but ChatGPT said it will work fine*