### PR TITLE
fix(streaming): use RequestModel and IsModelInCdimage

### DIFF
--- a/imports/requestModel/client.lua
+++ b/imports/requestModel/client.lua
@@ -6,11 +6,11 @@ function lib.requestModel(model, timeout)
     if type(model) ~= 'number' then model = joaat(model) end
     if HasModelLoaded(model) then return model end
 
-    if not IsModelValid(model) then
+    if not IsModelValid(model) and not IsModelInCdimage(model) then
         error(("attempted to load invalid model '%s'"):format(model))
     end
 
-    return lib.streamingRequest(IsModelInCdimage, HasModelLoaded, 'model', model, timeout)
+    return lib.streamingRequest(RequestModel, HasModelLoaded, 'model', model, timeout)
 end
 
 return lib.requestModel


### PR DESCRIPTION
`IsModelInCdimage` doesn't trigger a request to load the model. This moves the check condition to trigger the correct error and restores the `RequestModel` in the streamingRequest.