### PR TITLE
fix(addCommand): send chat suggestions to correct source

### DIFF
--- a/imports/__addCommand/server.lua
+++ b/imports/__addCommand/server.lua
@@ -7,7 +7,7 @@ SetTimeout(1000, function()
     TriggerClientEvent('chat:addSuggestions', -1, commands)
 end)
 
-AddEventHandler('playerJoining', function(source)
+AddEventHandler('playerJoining', function()
     TriggerClientEvent('chat:addSuggestions', source, commands)
 end)
 

--- a/imports/addCommand/server.lua
+++ b/imports/addCommand/server.lua
@@ -18,7 +18,7 @@ SetTimeout(1000, function()
     TriggerClientEvent('chat:addSuggestions', -1, registeredCommands)
 end)
 
-AddEventHandler('playerJoining', function(source)
+AddEventHandler('playerJoining', function()
     TriggerClientEvent('chat:addSuggestions', source, registeredCommands)
 end)
 


### PR DESCRIPTION
Removed the `source` as the first parameter, as the actual `source` value is set globally by fivem on event trigger.
Somehow this worked till one of the recent server builds, as the first parameter should have been the `oldID` (which is given to the user temporarily while connecting to a server and downloading the resources).

Without this change the suggestions aren't correctly send to the client and would not show up anymore.

_Tested on server build 8552, with and without the chat as a system-resource._