### PR TITLE
fix(addCommand): print caught tables instead of table references

### DIFF
--- a/imports/addCommand/server.lua
+++ b/imports/addCommand/server.lua
@@ -113,7 +113,7 @@ function lib.addCommand(commandName, properties, cb, ...)
         local success, resp = pcall(cb, source, args, raw)
 
         if not success then
-            Citizen.Trace(("^1command '%s' failed to execute!\n%s"):format(string.strsplit(' ', raw) or raw, resp))
+            Citizen.Trace(("^1command '%s' failed to execute!\n%s"):format(string.strsplit(' ', raw) or raw, json.encode(resp)))
         end
     end
 


### PR DESCRIPTION
When the error thrown by the command handler function is a table, this is printed by reference. This solves the problem json encoding the error body.