### PR TITLE
fix input dialog options getting discarded in transit

### DIFF
--- a/package/client/resource/interface/input.ts
+++ b/package/client/resource/interface/input.ts
@@ -158,6 +158,6 @@ type inputDialog = (
     allowCancel?: boolean;
   }
 ) => Promise<Array<string | number | boolean> | undefined>;
-export const inputDialog: inputDialog = async (heading, rows) => await exports.ox_lib.inputDialog(heading, rows);
+export const inputDialog: inputDialog = async (heading, rows, options) => await exports.ox_lib.inputDialog(heading, rows, options);
 
 export const closeInputDialog = () => exports.ox_lib.closeInputDialog();


### PR DESCRIPTION
fix input dialog options getting discarded in transit (this issue only affects the ts/js package for ox_lib)

- also fixes an issue in ox_core, specifically character creation, noticed you could click cancel, and be left sitting floating in the air. (tested)