### PR TITLE
feat(resource/vehicleProperties/client.lua): Ensures vehicle property is set properly

### DIFF
--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -655,18 +655,10 @@ function lib.setVehicleProperties(vehicle, props, fixVehicle)
     if gameBuild >= 2372 and props.driftTyres then
         SetDriftTyresEnabled(vehicle, true)
     end
-
-    if props.driftKit then
-        TriggerServerEvent('rp_driftkit:server:registerVehicle', VehToNet(vehicle))
-    end
-
+    
     if fixVehicle then
         SetVehicleFixed(vehicle)
     end
-
-    TriggerServerEvent('ox_fuel:createStatebag', VehToNet(vehicle),
-        GetVehicleFuelLevel(vehicle))
-    TriggerServerEvent('jim-mechanic:server:loadStatus', props, VehToNet(vehicle))
 
     return not NetworkGetEntityIsNetworked(vehicle) or NetworkGetEntityOwner(vehicle) == cache.playerId
 end


### PR DESCRIPTION
I know that applying properties to server side vehicles can be buggy. It seems that with the latest version of this script, sometimes when changing buckets with more than 100 players, or spawning the vehicle with a person inside, it gets messy and there is a chance that the vehicle properties aren`t applied. This ensures that the correct properties are set. Tried in a server with 200 online.

Probably doesn`t fix when the vehicle is spawned with a player driving it. On my server it still needed a client to be event sent to the player to ensure all mods are applied correct.