### PR TITLE
feat(client/dui): implement dui handling

### DIFF
--- a/imports/dui/client.lua
+++ b/imports/dui/client.lua
@@ -23,66 +23,66 @@ local currentId = 0
 
 ---@param data DuiProperties
 function lib.dui:constructor(data)
-	local time = GetGameTimer()
-	local id = ("%s_%s_%s"):format(cache.resource, time, currentId)
-	currentId = currentId + 1
-	local dictName = ('ox_lib_dui_dict_%s'):format(id)
-	local txtName = ('ox_lib_dui_txt_%s'):format(id)
-	local duiObject = CreateDui(data.url, data.width, data.height)
-	local duiHandle = GetDuiHandle(duiObject)
-	local runtimeTxd = CreateRuntimeTxd(dictName)
-	local txdObject = CreateRuntimeTextureFromDuiHandle(runtimeTxd, txtName, duiHandle)
-	self.id = id
-	self.debug = data.debug or false
-	self.url = data.url
-	self.duiObject = duiObject
-	self.duiHandle = duiHandle
-	self.runtimeTxd = runtimeTxd
-	self.txdObject = txdObject
-	self.dictName = dictName
-	self.txtName = txtName
-	duis[id] = self
+    local time = GetGameTimer()
+    local id = ("%s_%s_%s"):format(cache.resource, time, currentId)
+    currentId = currentId + 1
+    local dictName = ('ox_lib_dui_dict_%s'):format(id)
+    local txtName = ('ox_lib_dui_txt_%s'):format(id)
+    local duiObject = CreateDui(data.url, data.width, data.height)
+    local duiHandle = GetDuiHandle(duiObject)
+    local runtimeTxd = CreateRuntimeTxd(dictName)
+    local txdObject = CreateRuntimeTextureFromDuiHandle(runtimeTxd, txtName, duiHandle)
+    self.id = id
+    self.debug = data.debug or false
+    self.url = data.url
+    self.duiObject = duiObject
+    self.duiHandle = duiHandle
+    self.runtimeTxd = runtimeTxd
+    self.txdObject = txdObject
+    self.dictName = dictName
+    self.txtName = txtName
+    duis[id] = self
 
-	if self.debug then
-		print(('Dui %s created'):format(id))
-	end
+    if self.debug then
+        print(('Dui %s created'):format(id))
+    end
 end
 
 function lib.dui:remove()
-	SetDuiUrl(self.duiObject, 'about:blank')
-	DestroyDui(self.duiObject)
-	duis[self.id] = nil
+    SetDuiUrl(self.duiObject, 'about:blank')
+    DestroyDui(self.duiObject)
+    duis[self.id] = nil
 
-	if self.debug then
-		print(('Dui %s removed'):format(self.id))
-	end
+    if self.debug then
+        print(('Dui %s removed'):format(self.id))
+    end
 end
 
 ---@param url string
 function lib.dui:setUrl(url)
-	self.url = url
-	SetDuiUrl(self.duiObject, url)
+    self.url = url
+    SetDuiUrl(self.duiObject, url)
 
-	if self.debug then
-		print(('Dui %s url set to %s'):format(self.id, url))
-	end
+    if self.debug then
+        print(('Dui %s url set to %s'):format(self.id, url))
+    end
 end
 
 ---@param message table
 function lib.dui:sendMessage(message)
-	SendDuiMessage(self.duiObject, json.encode(message))
+    SendDuiMessage(self.duiObject, json.encode(message))
 
-	if self.debug then
-		print(('Dui %s message sent'):format(self.id))
-	end
+    if self.debug then
+        print(('Dui %s message sent with data :'):format(self.id), json.encode(message, { indent = true }))
+    end
 end
 
 AddEventHandler('onResourceStop', function(resourceName)
-	if cache.resource ~= resourceName then return end
+    if cache.resource ~= resourceName then return end
 
-	for _, dui in pairs(duis) do
-		dui:remove()
-	end
+    for _, dui in pairs(duis) do
+        dui:remove()
+    end
 end)
 
 return lib.dui

--- a/imports/dui/client.lua
+++ b/imports/dui/client.lua
@@ -5,8 +5,7 @@
 ---@field debug? boolean
 
 ---@class Dui : OxClass
----@field id string
----@field debug boolean
+---@field private private { id: string, debug: boolean }
 ---@field url string
 ---@field duiObject number
 ---@field duiHandle string
@@ -32,8 +31,8 @@ function lib.dui:constructor(data)
 	local duiHandle = GetDuiHandle(duiObject)
 	local runtimeTxd = CreateRuntimeTxd(dictName)
 	local txdObject = CreateRuntimeTextureFromDuiHandle(runtimeTxd, txtName, duiHandle)
-	self.id = id
-	self.debug = data.debug or false
+	self.private.id = id
+	self.private.debug = data.debug or false
 	self.url = data.url
 	self.duiObject = duiObject
 	self.duiHandle = duiHandle
@@ -43,7 +42,7 @@ function lib.dui:constructor(data)
 	self.txtName = txtName
 	duis[id] = self
 
-	if self.debug then
+	if self.private.debug then
 		print(('Dui %s created'):format(id))
 	end
 end
@@ -51,10 +50,10 @@ end
 function lib.dui:remove()
 	SetDuiUrl(self.duiObject, 'about:blank')
 	DestroyDui(self.duiObject)
-	duis[self.id] = nil
+	duis[self.private.id] = nil
 
-	if self.debug then
-		print(('Dui %s removed'):format(self.id))
+	if self.private.debug then
+		print(('Dui %s removed'):format(self.private.id))
 	end
 end
 
@@ -63,8 +62,8 @@ function lib.dui:setUrl(url)
 	self.url = url
 	SetDuiUrl(self.duiObject, url)
 
-	if self.debug then
-		print(('Dui %s url set to %s'):format(self.id, url))
+	if self.private.debug then
+		print(('Dui %s url set to %s'):format(self.private.id, url))
 	end
 end
 
@@ -72,8 +71,8 @@ end
 function lib.dui:sendMessage(message)
 	SendDuiMessage(self.duiObject, json.encode(message))
 
-	if self.debug then
-		print(('Dui %s message sent with data :'):format(self.id), json.encode(message, { indent = true }))
+	if self.private.debug then
+		print(('Dui %s message sent with data :'):format(self.private.id), json.encode(message, { indent = true }))
 	end
 end
 

--- a/imports/dui/client.lua
+++ b/imports/dui/client.lua
@@ -18,7 +18,7 @@
 ---@field setUrl fun(CDui, string)
 ---@field sendMessage fun(CDui, table)
 
----@type table<number, CDui>
+---@type table<string, CDui>
 local duis = {}
 local resourceName = GetCurrentResourceName()
 

--- a/imports/dui/client.lua
+++ b/imports/dui/client.lua
@@ -1,0 +1,105 @@
+---@class DuiProperties
+---@field url string
+---@field width number
+---@field height number
+---@field debug? boolean
+
+---@class CDui : DuiProperties
+---@field id string
+---@field debug boolean
+---@field url string
+---@field duiObject number
+---@field duiHandle string
+---@field runtimeTxd number
+---@field txdObject number
+---@field dictName string
+---@field txtName string
+---@field remove fun(CDui)
+---@field setUrl fun(CDui, string)
+---@field sendMessage fun(CDui, table)
+
+---@type table<number, CDui>
+local duis = {}
+local resourceName = GetCurrentResourceName()
+
+---@param self CDui
+local function removeDui(self)
+    SetDuiUrl(self.duiObject, 'about:blank')
+    DestroyDui(self.duiObject)
+    duis[self.id] = nil
+
+    if self.debug then
+        print(('Dui %s removed'):format(self.id))
+    end
+end
+
+---@param self CDui
+---@param url string
+local function setDuiUrl(self, url)
+    self.url = url
+    SetDuiUrl(self.duiObject, url)
+
+    if self.debug then
+        print(('Dui %s url set to %s'):format(self.id, url))
+    end
+end
+
+---@param self CDui
+---@param message table
+local function sendMessage(self, message)
+    SendDuiMessage(self.duiObject, json.encode(message))
+
+    if self.debug then
+        print(('Dui %s message sent'):format(self.id))
+    end
+end
+
+lib.dui = {
+    ---@return CDui
+    ---@overload fun(data: DuiProperties): CDui
+    new = function(data)
+        local self
+        local time = GetGameTimer()
+        local id = ("%s_%s_%s"):format(resourceName, time, math.random(1, 1000))
+        while duis[id] do
+            id = ("%s_%s_%s"):format(resourceName, time, math.random(1, 1000))
+            Wait(0)
+        end
+        local dictName = ('ox_lib_dui_dict_%s'):format(id)
+        local txtName = ('ox_lib_dui_txt_%s'):format(id)
+        local duiObject = CreateDui(data.url, data.width, data.height)
+        local duiHandle = GetDuiHandle(duiObject)
+        local runtimeTxd = CreateRuntimeTxd(dictName)
+        local txdObject = CreateRuntimeTextureFromDuiHandle(runtimeTxd, txtName, duiHandle)
+        self = {
+            id = id,
+            debug = data.debug or false,
+            url = data.url,
+            duiObject = duiObject,
+            duiHandle = duiHandle,
+            runtimeTxd = runtimeTxd,
+            txdObject = txdObject,
+            dictName = dictName,
+            txtName = txtName,
+            setUrl = setDuiUrl,
+            sendMessage = sendMessage,
+            remove = removeDui
+        }
+
+        if self.debug then
+            print(('Dui %s created'):format(id))
+        end
+
+        duis[id] = self
+        return self
+    end,
+}
+
+AddEventHandler('onResourceStop', function(stoppedResourceName)
+    if stoppedResourceName ~= resourceName then return end
+    for _, dui in pairs(duis) do
+        dui:remove()
+    end
+end)
+
+return lib.dui

--- a/imports/dui/client.lua
+++ b/imports/dui/client.lua
@@ -19,70 +19,70 @@ lib.dui = lib.class('Dui')
 ---@type table<string, Dui>
 local duis = {}
 
+local currentId = 0
+
 ---@param data DuiProperties
 function lib.dui:constructor(data)
-    local time = GetGameTimer()
-    local id = ("%s_%s_%s"):format(cache.resource, time, math.random(1, 1000))
-    while duis[id] do
-        id = ("%s_%s_%s"):format(cache.resource, time, math.random(1, 1000))
-        Wait(0)
-    end
-    local dictName = ('ox_lib_dui_dict_%s'):format(id)
-    local txtName = ('ox_lib_dui_txt_%s'):format(id)
-    local duiObject = CreateDui(data.url, data.width, data.height)
-    local duiHandle = GetDuiHandle(duiObject)
-    local runtimeTxd = CreateRuntimeTxd(dictName)
-    local txdObject = CreateRuntimeTextureFromDuiHandle(runtimeTxd, txtName, duiHandle)
-    self.id = id
-    self.debug = data.debug or false
-    self.url = data.url
-    self.duiObject = duiObject
-    self.duiHandle = duiHandle
-    self.runtimeTxd = runtimeTxd
-    self.txdObject = txdObject
-    self.dictName = dictName
-    self.txtName = txtName
-    if self.debug then
-        print(('Dui %s created'):format(id))
-    end
+	local time = GetGameTimer()
+	local id = ("%s_%s_%s"):format(cache.resource, time, currentId)
+	currentId = currentId + 1
+	local dictName = ('ox_lib_dui_dict_%s'):format(id)
+	local txtName = ('ox_lib_dui_txt_%s'):format(id)
+	local duiObject = CreateDui(data.url, data.width, data.height)
+	local duiHandle = GetDuiHandle(duiObject)
+	local runtimeTxd = CreateRuntimeTxd(dictName)
+	local txdObject = CreateRuntimeTextureFromDuiHandle(runtimeTxd, txtName, duiHandle)
+	self.id = id
+	self.debug = data.debug or false
+	self.url = data.url
+	self.duiObject = duiObject
+	self.duiHandle = duiHandle
+	self.runtimeTxd = runtimeTxd
+	self.txdObject = txdObject
+	self.dictName = dictName
+	self.txtName = txtName
+	duis[id] = self
 
-    duis[id] = self
+	if self.debug then
+		print(('Dui %s created'):format(id))
+	end
 end
 
 function lib.dui:remove()
-    SetDuiUrl(self.duiObject, 'about:blank')
-    DestroyDui(self.duiObject)
-    duis[self.id] = nil
+	SetDuiUrl(self.duiObject, 'about:blank')
+	DestroyDui(self.duiObject)
+	duis[self.id] = nil
 
-    if self.debug then
-        print(('Dui %s removed'):format(self.id))
-    end
+	if self.debug then
+		print(('Dui %s removed'):format(self.id))
+	end
 end
 
 ---@param url string
 function lib.dui:setUrl(url)
-    self.url = url
-    SetDuiUrl(self.duiObject, url)
+	self.url = url
+	SetDuiUrl(self.duiObject, url)
 
-    if self.debug then
-        print(('Dui %s url set to %s'):format(self.id, url))
-    end
+	if self.debug then
+		print(('Dui %s url set to %s'):format(self.id, url))
+	end
 end
 
 ---@param message table
 function lib.dui:sendMessage(message)
-    SendDuiMessage(self.duiObject, json.encode(message))
+	SendDuiMessage(self.duiObject, json.encode(message))
 
-    if self.debug then
-        print(('Dui %s message sent'):format(self.id))
-    end
+	if self.debug then
+		print(('Dui %s message sent'):format(self.id))
+	end
 end
 
 AddEventHandler('onResourceStop', function(resourceName)
-    if cache.resource ~= resourceName then return end
-    for _, dui in pairs(duis) do
-        dui:remove()
-    end
+	if cache.resource ~= resourceName then return end
+
+	for _, dui in pairs(duis) do
+		dui:remove()
+	end
 end)
 
 return lib.dui

--- a/imports/dui/client.lua
+++ b/imports/dui/client.lua
@@ -23,66 +23,66 @@ local currentId = 0
 
 ---@param data DuiProperties
 function lib.dui:constructor(data)
-    local time = GetGameTimer()
-    local id = ("%s_%s_%s"):format(cache.resource, time, currentId)
-    currentId = currentId + 1
-    local dictName = ('ox_lib_dui_dict_%s'):format(id)
-    local txtName = ('ox_lib_dui_txt_%s'):format(id)
-    local duiObject = CreateDui(data.url, data.width, data.height)
-    local duiHandle = GetDuiHandle(duiObject)
-    local runtimeTxd = CreateRuntimeTxd(dictName)
-    local txdObject = CreateRuntimeTextureFromDuiHandle(runtimeTxd, txtName, duiHandle)
-    self.id = id
-    self.debug = data.debug or false
-    self.url = data.url
-    self.duiObject = duiObject
-    self.duiHandle = duiHandle
-    self.runtimeTxd = runtimeTxd
-    self.txdObject = txdObject
-    self.dictName = dictName
-    self.txtName = txtName
-    duis[id] = self
+	local time = GetGameTimer()
+	local id = ("%s_%s_%s"):format(cache.resource, time, currentId)
+	currentId = currentId + 1
+	local dictName = ('ox_lib_dui_dict_%s'):format(id)
+	local txtName = ('ox_lib_dui_txt_%s'):format(id)
+	local duiObject = CreateDui(data.url, data.width, data.height)
+	local duiHandle = GetDuiHandle(duiObject)
+	local runtimeTxd = CreateRuntimeTxd(dictName)
+	local txdObject = CreateRuntimeTextureFromDuiHandle(runtimeTxd, txtName, duiHandle)
+	self.id = id
+	self.debug = data.debug or false
+	self.url = data.url
+	self.duiObject = duiObject
+	self.duiHandle = duiHandle
+	self.runtimeTxd = runtimeTxd
+	self.txdObject = txdObject
+	self.dictName = dictName
+	self.txtName = txtName
+	duis[id] = self
 
-    if self.debug then
-        print(('Dui %s created'):format(id))
-    end
+	if self.debug then
+		print(('Dui %s created'):format(id))
+	end
 end
 
 function lib.dui:remove()
-    SetDuiUrl(self.duiObject, 'about:blank')
-    DestroyDui(self.duiObject)
-    duis[self.id] = nil
+	SetDuiUrl(self.duiObject, 'about:blank')
+	DestroyDui(self.duiObject)
+	duis[self.id] = nil
 
-    if self.debug then
-        print(('Dui %s removed'):format(self.id))
-    end
+	if self.debug then
+		print(('Dui %s removed'):format(self.id))
+	end
 end
 
 ---@param url string
 function lib.dui:setUrl(url)
-    self.url = url
-    SetDuiUrl(self.duiObject, url)
+	self.url = url
+	SetDuiUrl(self.duiObject, url)
 
-    if self.debug then
-        print(('Dui %s url set to %s'):format(self.id, url))
-    end
+	if self.debug then
+		print(('Dui %s url set to %s'):format(self.id, url))
+	end
 end
 
 ---@param message table
 function lib.dui:sendMessage(message)
-    SendDuiMessage(self.duiObject, json.encode(message))
+	SendDuiMessage(self.duiObject, json.encode(message))
 
-    if self.debug then
-        print(('Dui %s message sent with data :'):format(self.id), json.encode(message, { indent = true }))
-    end
+	if self.debug then
+		print(('Dui %s message sent with data :'):format(self.id), json.encode(message, { indent = true }))
+	end
 end
 
 AddEventHandler('onResourceStop', function(resourceName)
-    if cache.resource ~= resourceName then return end
+	if cache.resource ~= resourceName then return end
 
-    for _, dui in pairs(duis) do
-        dui:remove()
-    end
+	for _, dui in pairs(duis) do
+		dui:remove()
+	end
 end)
 
 return lib.dui

--- a/package/client/resource/dui/index.ts
+++ b/package/client/resource/dui/index.ts
@@ -1,12 +1,12 @@
 import {
-	GetGameTimer,
-	CreateDui,
-	GetDuiHandle,
-	CreateRuntimeTxd,
-	CreateRuntimeTextureFromDuiHandle,
-	SetDuiUrl,
-	DestroyDui,
-	SendDuiMessage,
+  GetGameTimer,
+  CreateDui,
+  GetDuiHandle,
+  CreateRuntimeTxd,
+  CreateRuntimeTextureFromDuiHandle,
+  SetDuiUrl,
+  DestroyDui,
+  SendDuiMessage,
 } from '@nativewrappers/client';
 import { cache } from '../cache';
 
@@ -14,67 +14,67 @@ let duis: { [key: string]: Dui } = {};
 let currentId = 0;
 
 interface LibDui {
-	url: string;
-	width: number;
-	height: number;
-	debug?: boolean;
+  url: string;
+  width: number;
+  height: number;
+  debug?: boolean;
 }
 
 export class Dui {
-	id: string = "";
-	debug: boolean = false;
-	url: string = "";
-	duiObject: number = 0;
-	duiHandle: string = "";
-	runtimeTxd: number = 0;
-	txdObject: number = 0;
-	dictName: string = "";
-	txtName: string = "";
+  id: string = "";
+  debug: boolean = false;
+  url: string = "";
+  duiObject: number = 0;
+  duiHandle: string = "";
+  runtimeTxd: number = 0;
+  txdObject: number = 0;
+  dictName: string = "";
+  txtName: string = "";
 
-	constructor(data: LibDui) {
-		const time = GetGameTimer();
-		let id = `${cache.resource}_${time}_${currentId}`;
-		currentId++;
-		this.id = id;
-		this.debug = data.debug || false;
-		this.url = data.url;
-		this.dictName = `ox_lib_dui_dict_${id}`;
-		this.txtName = `ox_lib_dui_txt_${id}`;
-		this.duiObject = CreateDui(data.url, data.width, data.height);
-		this.duiHandle = GetDuiHandle(this.duiObject);
-		this.runtimeTxd = CreateRuntimeTxd(this.dictName);
-		this.txdObject = CreateRuntimeTextureFromDuiHandle(this.runtimeTxd, this.txtName, this.duiHandle);
-		duis[id] = this;
+  constructor(data: LibDui) {
+    const time = GetGameTimer();
+    const id = `${cache.resource}_${time}_${currentId}`;
+    currentId++;
+    this.id = id;
+    this.debug = data.debug || false;
+    this.url = data.url;
+    this.dictName = `ox_lib_dui_dict_${id}`;
+    this.txtName = `ox_lib_dui_txt_${id}`;
+    this.duiObject = CreateDui(data.url, data.width, data.height);
+    this.duiHandle = GetDuiHandle(this.duiObject);
+    this.runtimeTxd = CreateRuntimeTxd(this.dictName);
+    this.txdObject = CreateRuntimeTextureFromDuiHandle(this.runtimeTxd, this.txtName, this.duiHandle);
+    duis[id] = this;
 
-		if (this.debug) console.log(`Dui ${this.id} created`);
-	}
+    if (this.debug) console.log(`Dui ${this.id} created`);
+  }
 
-	remove = () => {
-		SetDuiUrl(this.duiObject, 'about:blank');
-		DestroyDui(this.duiObject);
-		delete duis[this.id];
+  remove = () => {
+    SetDuiUrl(this.duiObject, 'about:blank');
+    DestroyDui(this.duiObject);
+    delete duis[this.id];
 
-		if (this.debug) console.log(`Dui ${this.id} removed`);
-	};
+    if (this.debug) console.log(`Dui ${this.id} removed`);
+  };
 
-	setUrl = (url: string) => {
-		this.url = url;
-		SetDuiUrl(this.duiObject, url);
+  setUrl = (url: string) => {
+    this.url = url;
+    SetDuiUrl(this.duiObject, url);
 
-		if (this.debug) console.log(`Dui ${this.id} url set to ${url}`);
-	};
+    if (this.debug) console.log(`Dui ${this.id} url set to ${url}`);
+  };
 
-	sendMessage = (data: object) => {
-		SendDuiMessage(this.duiObject, JSON.stringify(data));
+  sendMessage = (data: object) => {
+    SendDuiMessage(this.duiObject, JSON.stringify(data));
 
-		if (this.debug) console.log(`Dui ${this.id} message sent`);
-	}
+    if (this.debug) console.log(`Dui ${this.id} message sent with data :`, data);
+  }
 }
 
 on('onResourceStop', (resourceName: string) => {
-	if (cache.resource !== resourceName) return;
+  if (cache.resource !== resourceName) return;
 
-	for (const dui in duis) {
-		duis[dui].remove();
-	}
+  for (const dui in duis) {
+    duis[dui].remove();
+  }
 });

--- a/package/client/resource/dui/index.ts
+++ b/package/client/resource/dui/index.ts
@@ -1,0 +1,83 @@
+import {
+  GetGameTimer,
+  GetCurrentResourceName,
+  CreateDui,
+  GetDuiHandle,
+  CreateRuntimeTxd,
+  CreateRuntimeTextureFromDuiHandle,
+  SetDuiUrl,
+  DestroyDui,
+  SendDuiMessage,
+} from '@nativewrappers/client';
+
+let duis: { [key: string]: Dui } = {};
+const resourceName = GetCurrentResourceName();
+
+interface LibDui {
+  url: string;
+  width: number;
+  height: number;
+  debug?: boolean;
+}
+
+export class Dui {
+  id: string = "";
+  debug: boolean = false;
+  url: string = "";
+  duiObject: number = 0;
+  duiHandle: string = "";
+  runtimeTxd: number = 0;
+  txdObject: number = 0;
+  dictName: string = "";
+  txtName: string = "";
+
+  constructor(data: LibDui) {
+    const time = GetGameTimer();
+    let id = `${resourceName}_${time}_${Math.floor(Math.random() * 1000)}`;
+    while (duis[id]) {
+      id = `${resourceName}_${time}_${Math.floor(Math.random() * 1000)}`;
+    }
+    this.id = id;
+    this.debug = data.debug || false;
+    this.url = data.url;
+    this.dictName = `ox_lib_dui_dict_${id}`;
+    this.txtName = `ox_lib_dui_txt_${id}`;
+    this.duiObject = CreateDui(data.url, data.width, data.height);
+    this.duiHandle = GetDuiHandle(this.duiObject);
+    this.runtimeTxd = CreateRuntimeTxd(this.dictName);
+    this.txdObject = CreateRuntimeTextureFromDuiHandle(this.runtimeTxd, this.txtName, this.duiHandle);
+
+    if (this.debug) console.log(`Dui ${this.id} created`);
+
+    duis[id] = this;
+  }
+
+  remove = () => {
+    SetDuiUrl(this.duiObject, 'about:blank');
+    DestroyDui(this.duiObject);
+    delete duis[this.id];
+
+    if (this.debug) console.log(`Dui ${this.id} removed`);
+  };
+
+  setUrl = (url: string) => {
+    this.url = url;
+    SetDuiUrl(this.duiObject, url);
+
+    if (this.debug) console.log(`Dui ${this.id} url set to ${url}`);
+  };
+
+  sendMessage = (data: object) => {
+    SendDuiMessage(this.duiObject, JSON.stringify(data));
+
+    if (this.debug) console.log(`Dui ${this.id} message sent`);
+  }
+}
+
+on('onResourceStop', (stoppedResourceName: string) => {
+  if (stoppedResourceName !== resourceName) return;
+
+  for (const dui in duis) {
+    duis[dui].remove();
+  }
+});

--- a/package/client/resource/dui/index.ts
+++ b/package/client/resource/dui/index.ts
@@ -4,67 +4,67 @@ const duis: Record<string, Dui> = {};
 let currentId = 0;
 
 interface DuiProperties {
-	url: string;
-	width: number;
-	height: number;
-	debug?: boolean;
+  url: string;
+  width: number;
+  height: number;
+  debug?: boolean;
 }
 
 export class Dui {
-	private id: string = "";
-	private debug: boolean = false;
-	url: string = "";
-	duiObject: number = 0;
-	duiHandle: string = "";
-	runtimeTxd: number = 0;
-	txdObject: number = 0;
-	dictName: string = "";
-	txtName: string = "";
+  private id: string = '';
+  private debug: boolean = false;
+  url: string = '';
+  duiObject: number = 0;
+  duiHandle: string = '';
+  runtimeTxd: number = 0;
+  txdObject: number = 0;
+  dictName: string = '';
+  txtName: string = '';
 
-	constructor(data: DuiProperties) {
-		const time = GetGameTimer();
-		const id = `${cache.resource}_${time}_${currentId}`;
-		currentId++;
-		this.id = id;
-		this.debug = data.debug || false;
-		this.url = data.url;
-		this.dictName = `ox_lib_dui_dict_${id}`;
-		this.txtName = `ox_lib_dui_txt_${id}`;
-		this.duiObject = CreateDui(data.url, data.width, data.height);
-		this.duiHandle = GetDuiHandle(this.duiObject);
-		this.runtimeTxd = CreateRuntimeTxd(this.dictName);
-		this.txdObject = CreateRuntimeTextureFromDuiHandle(this.runtimeTxd, this.txtName, this.duiHandle);
-		duis[id] = this;
+  constructor(data: DuiProperties) {
+    const time = GetGameTimer();
+    const id = `${cache.resource}_${time}_${currentId}`;
+    currentId++;
+    this.id = id;
+    this.debug = data.debug || false;
+    this.url = data.url;
+    this.dictName = `ox_lib_dui_dict_${id}`;
+    this.txtName = `ox_lib_dui_txt_${id}`;
+    this.duiObject = CreateDui(data.url, data.width, data.height);
+    this.duiHandle = GetDuiHandle(this.duiObject);
+    this.runtimeTxd = CreateRuntimeTxd(this.dictName);
+    this.txdObject = CreateRuntimeTextureFromDuiHandle(this.runtimeTxd, this.txtName, this.duiHandle);
+    duis[id] = this;
 
-		if (this.debug) console.log(`Dui ${this.id} created`);
-	}
+    if (this.debug) console.log(`Dui ${this.id} created`);
+  }
 
-	remove() {
-		SetDuiUrl(this.duiObject, 'about:blank');
-		DestroyDui(this.duiObject);
-		delete duis[this.id];
+  remove() {
+    SetDuiUrl(this.duiObject, 'about:blank');
+    DestroyDui(this.duiObject);
+    delete duis[this.id];
 
-		if (this.debug) console.log(`Dui ${this.id} removed`);
-	};
+    if (this.debug) console.log(`Dui ${this.id} removed`);
+  }
 
-	setUrl = (url: string) => {
-		this.url = url;
-		SetDuiUrl(this.duiObject, url);
+  setUrl(url: string) {
+    this.url = url;
+    SetDuiUrl(this.duiObject, url);
 
-		if (this.debug) console.log(`Dui ${this.id} url set to ${url}`);
-	};
+    if (this.debug) console.log(`Dui ${this.id} url set to ${url}`);
+  }
 
-	sendMessage = (data: object) => {
-		SendDuiMessage(this.duiObject, JSON.stringify(data));
+  sendMessage(data: object) {
+    SendDuiMessage(this.duiObject, JSON.stringify(data));
 
-		if (this.debug) console.log(`Dui ${this.id} message sent with data :`, data);
-	}
+    if (this.debug) console.log(`Dui ${this.id} message sent with data :`, data);
+  }
 }
 
 on('onResourceStop', (resourceName: string) => {
-	if (cache.resource !== resourceName) return;
+  if (cache.resource !== resourceName) return;
 
-	for (const dui in duis) {
-		duis[dui].remove();
-	}
+  for (const dui in duis) {
+    duis[dui].remove();
+  }
 });

--- a/package/client/resource/dui/index.ts
+++ b/package/client/resource/dui/index.ts
@@ -1,6 +1,5 @@
 import {
   GetGameTimer,
-  GetCurrentResourceName,
   CreateDui,
   GetDuiHandle,
   CreateRuntimeTxd,
@@ -9,9 +8,9 @@ import {
   DestroyDui,
   SendDuiMessage,
 } from '@nativewrappers/client';
+import { cache } from '../cache';
 
 let duis: { [key: string]: Dui } = {};
-const resourceName = GetCurrentResourceName();
 
 interface LibDui {
   url: string;
@@ -33,9 +32,9 @@ export class Dui {
 
   constructor(data: LibDui) {
     const time = GetGameTimer();
-    let id = `${resourceName}_${time}_${Math.floor(Math.random() * 1000)}`;
+    let id = `${cache.resource}_${time}_${Math.floor(Math.random() * 1000)}`;
     while (duis[id]) {
-      id = `${resourceName}_${time}_${Math.floor(Math.random() * 1000)}`;
+      id = `${cache.resource}_${time}_${Math.floor(Math.random() * 1000)}`;
     }
     this.id = id;
     this.debug = data.debug || false;
@@ -74,8 +73,8 @@ export class Dui {
   }
 }
 
-on('onResourceStop', (stoppedResourceName: string) => {
-  if (stoppedResourceName !== resourceName) return;
+on('onResourceStop', (resourceName: string) => {
+  if (cache.resource !== resourceName) return;
 
   for (const dui in duis) {
     duis[dui].remove();

--- a/package/client/resource/dui/index.ts
+++ b/package/client/resource/dui/index.ts
@@ -1,19 +1,9 @@
-import {
-	GetGameTimer,
-	CreateDui,
-	GetDuiHandle,
-	CreateRuntimeTxd,
-	CreateRuntimeTextureFromDuiHandle,
-	SetDuiUrl,
-	DestroyDui,
-	SendDuiMessage,
-} from '@nativewrappers/client';
 import { cache } from '../cache';
 
-let duis: { [key: string]: Dui } = {};
+const duis: Record<string, Dui> = {};
 let currentId = 0;
 
-interface LibDui {
+interface DuiProperties {
 	url: string;
 	width: number;
 	height: number;
@@ -21,8 +11,8 @@ interface LibDui {
 }
 
 export class Dui {
-	id: string = "";
-	debug: boolean = false;
+	private id: string = "";
+	private debug: boolean = false;
 	url: string = "";
 	duiObject: number = 0;
 	duiHandle: string = "";
@@ -31,7 +21,7 @@ export class Dui {
 	dictName: string = "";
 	txtName: string = "";
 
-	constructor(data: LibDui) {
+	constructor(data: DuiProperties) {
 		const time = GetGameTimer();
 		const id = `${cache.resource}_${time}_${currentId}`;
 		currentId++;
@@ -49,7 +39,7 @@ export class Dui {
 		if (this.debug) console.log(`Dui ${this.id} created`);
 	}
 
-	remove = () => {
+	remove() {
 		SetDuiUrl(this.duiObject, 'about:blank');
 		DestroyDui(this.duiObject);
 		delete duis[this.id];

--- a/package/client/resource/dui/index.ts
+++ b/package/client/resource/dui/index.ts
@@ -1,12 +1,12 @@
 import {
-  GetGameTimer,
-  CreateDui,
-  GetDuiHandle,
-  CreateRuntimeTxd,
-  CreateRuntimeTextureFromDuiHandle,
-  SetDuiUrl,
-  DestroyDui,
-  SendDuiMessage,
+	GetGameTimer,
+	CreateDui,
+	GetDuiHandle,
+	CreateRuntimeTxd,
+	CreateRuntimeTextureFromDuiHandle,
+	SetDuiUrl,
+	DestroyDui,
+	SendDuiMessage,
 } from '@nativewrappers/client';
 import { cache } from '../cache';
 
@@ -14,67 +14,67 @@ let duis: { [key: string]: Dui } = {};
 let currentId = 0;
 
 interface LibDui {
-  url: string;
-  width: number;
-  height: number;
-  debug?: boolean;
+	url: string;
+	width: number;
+	height: number;
+	debug?: boolean;
 }
 
 export class Dui {
-  id: string = "";
-  debug: boolean = false;
-  url: string = "";
-  duiObject: number = 0;
-  duiHandle: string = "";
-  runtimeTxd: number = 0;
-  txdObject: number = 0;
-  dictName: string = "";
-  txtName: string = "";
+	id: string = "";
+	debug: boolean = false;
+	url: string = "";
+	duiObject: number = 0;
+	duiHandle: string = "";
+	runtimeTxd: number = 0;
+	txdObject: number = 0;
+	dictName: string = "";
+	txtName: string = "";
 
-  constructor(data: LibDui) {
-    const time = GetGameTimer();
-    const id = `${cache.resource}_${time}_${currentId}`;
-    currentId++;
-    this.id = id;
-    this.debug = data.debug || false;
-    this.url = data.url;
-    this.dictName = `ox_lib_dui_dict_${id}`;
-    this.txtName = `ox_lib_dui_txt_${id}`;
-    this.duiObject = CreateDui(data.url, data.width, data.height);
-    this.duiHandle = GetDuiHandle(this.duiObject);
-    this.runtimeTxd = CreateRuntimeTxd(this.dictName);
-    this.txdObject = CreateRuntimeTextureFromDuiHandle(this.runtimeTxd, this.txtName, this.duiHandle);
-    duis[id] = this;
+	constructor(data: LibDui) {
+		const time = GetGameTimer();
+		const id = `${cache.resource}_${time}_${currentId}`;
+		currentId++;
+		this.id = id;
+		this.debug = data.debug || false;
+		this.url = data.url;
+		this.dictName = `ox_lib_dui_dict_${id}`;
+		this.txtName = `ox_lib_dui_txt_${id}`;
+		this.duiObject = CreateDui(data.url, data.width, data.height);
+		this.duiHandle = GetDuiHandle(this.duiObject);
+		this.runtimeTxd = CreateRuntimeTxd(this.dictName);
+		this.txdObject = CreateRuntimeTextureFromDuiHandle(this.runtimeTxd, this.txtName, this.duiHandle);
+		duis[id] = this;
 
-    if (this.debug) console.log(`Dui ${this.id} created`);
-  }
+		if (this.debug) console.log(`Dui ${this.id} created`);
+	}
 
-  remove = () => {
-    SetDuiUrl(this.duiObject, 'about:blank');
-    DestroyDui(this.duiObject);
-    delete duis[this.id];
+	remove = () => {
+		SetDuiUrl(this.duiObject, 'about:blank');
+		DestroyDui(this.duiObject);
+		delete duis[this.id];
 
-    if (this.debug) console.log(`Dui ${this.id} removed`);
-  };
+		if (this.debug) console.log(`Dui ${this.id} removed`);
+	};
 
-  setUrl = (url: string) => {
-    this.url = url;
-    SetDuiUrl(this.duiObject, url);
+	setUrl = (url: string) => {
+		this.url = url;
+		SetDuiUrl(this.duiObject, url);
 
-    if (this.debug) console.log(`Dui ${this.id} url set to ${url}`);
-  };
+		if (this.debug) console.log(`Dui ${this.id} url set to ${url}`);
+	};
 
-  sendMessage = (data: object) => {
-    SendDuiMessage(this.duiObject, JSON.stringify(data));
+	sendMessage = (data: object) => {
+		SendDuiMessage(this.duiObject, JSON.stringify(data));
 
-    if (this.debug) console.log(`Dui ${this.id} message sent with data :`, data);
-  }
+		if (this.debug) console.log(`Dui ${this.id} message sent with data :`, data);
+	}
 }
 
 on('onResourceStop', (resourceName: string) => {
-  if (cache.resource !== resourceName) return;
+	if (cache.resource !== resourceName) return;
 
-  for (const dui in duis) {
-    duis[dui].remove();
-  }
+	for (const dui in duis) {
+		duis[dui].remove();
+	}
 });

--- a/package/client/resource/index.ts
+++ b/package/client/resource/index.ts
@@ -13,3 +13,4 @@ export * from './streaming';
 export * from './vehicleProperties';
 export * from './callback';
 export * from './points';
+export * from './dui';


### PR DESCRIPTION
It's really simple to create new dui and don't have to handle for resource stop etc

```lua
local dui = lib.dui:new({
	url = ("nui://%s/web/index.html"):format(cache.resource), 
	width = 1920, 
	height = 1080,
	debug = true
})

-- Change url
dui:setUrl("https://google.com")

-- Send a message
dui:sendMessage({
	action = "play",
	value = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
})

-- Destroy
dui:remove()
```

It's just a utility, all texture replace etc need to be handle by other scripts

### *JS version is not tested*