### PR TITLE
fix(timer): restart can prevent executing onEnd function

### DIFF
--- a/imports/timer/shared.lua
+++ b/imports/timer/shared.lua
@@ -92,8 +92,13 @@ function timer:isPaused()
     return self.private.paused
 end
 
-function timer:restart(async, triggerOnEnd)
-    self:forceEnd(triggerOnEnd)
+function timer:restart(async, onEnd)
+    self:forceEnd(not not onEnd)
+
+    if type(onEnd) == 'function' then
+        self.private.onEnd = onEnd
+    end
+
     Wait(0)
     self.private.currentTimeLeft = self.private.initialTime
     self.private.startTime = 0

--- a/imports/timer/shared.lua
+++ b/imports/timer/shared.lua
@@ -93,10 +93,9 @@ function timer:isPaused()
 end
 
 function timer:restart(async)
-    self:forceEnd(false)
+    self:forceEnd(true)
     Wait(0)
     self.private.currentTimeLeft = self.private.initialTime
-    self.private.triggerOnEnd = true
     self.private.startTime = 0
     self:start(async)
 end

--- a/imports/timer/shared.lua
+++ b/imports/timer/shared.lua
@@ -92,8 +92,8 @@ function timer:isPaused()
     return self.private.paused
 end
 
-function timer:restart(async)
-    self:forceEnd(true)
+function timer:restart(async, triggerOnEnd)
+    self:forceEnd(triggerOnEnd)
     Wait(0)
     self.private.currentTimeLeft = self.private.initialTime
     self.private.startTime = 0

--- a/imports/timer/shared.lua
+++ b/imports/timer/shared.lua
@@ -10,6 +10,7 @@
 ---@class OxTimer : OxClass
 ---@field private private TimerPrivateProps
 ---@field start fun(self: self, async?: boolean) starts the timer
+---@field restart fun(self: self, async?: boolean, onEnd?: boolean | function) restart the timer
 ---@field forceEnd fun(self: self, triggerOnEnd: boolean) end timer early and optionally trigger the onEnd function still
 ---@field isPaused fun(self: self): boolean returns wether the timer is paused or not
 ---@field pause fun(self: self) pauses the timer until play method is called

--- a/imports/timer/shared.lua
+++ b/imports/timer/shared.lua
@@ -96,6 +96,7 @@ function timer:restart(async)
     self:forceEnd(false)
     Wait(0)
     self.private.currentTimeLeft = self.private.initialTime
+    self.private.triggerOnEnd = true
     self.private.startTime = 0
     self:start(async)
 end


### PR DESCRIPTION
If we want to restart a timer, previous state would disable the variable that triggers the OnEnd function by default.