### PR TITLE
fix(progress): playEnter arg for scenarios in progress bar

### DIFF
--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -74,7 +74,7 @@ local function startProgress(data)
             TaskPlayAnim(cache.ped, anim.dict, anim.clip, anim.blendIn or 3.0, anim.blendOut or 1.0, anim.duration or -1, anim.flag or 49, anim.playbackRate or 0, anim.lockX, anim.lockY, anim.lockZ)
             RemoveAnimDict(anim.dict)
         elseif anim.scenario then
-            TaskStartScenarioInPlace(cache.ped, anim.scenario, 0, anim.playEnter == nil and true or anim.playEnter)
+            TaskStartScenarioInPlace(cache.ped, anim.scenario, 0, anim.playEnter == nil or anim.playEnter)
         end
     end
 

--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -74,7 +74,7 @@ local function startProgress(data)
             TaskPlayAnim(cache.ped, anim.dict, anim.clip, anim.blendIn or 3.0, anim.blendOut or 1.0, anim.duration or -1, anim.flag or 49, anim.playbackRate or 0, anim.lockX, anim.lockY, anim.lockZ)
             RemoveAnimDict(anim.dict)
         elseif anim.scenario then
-            TaskStartScenarioInPlace(cache.ped, anim.scenario, 0, anim.playEnter ~= nil and anim.playEnter or true)
+            TaskStartScenarioInPlace(cache.ped, anim.scenario, 0, anim.playEnter == nil and true or anim.playEnter)
         end
     end
 


### PR DESCRIPTION
- Fixes the "playEnter" arg for TaskStartScenarioInPlace animations in progress bar 

Previously, anim.playEnter would be forced to true even if the value being passed in was set to false. Now, playEnter will default to true if no value is given, otherwise it will be set to the correct boolean value.