### PR TITLE
fix(table): Respect falsy value for addDuplicateNumbers

### DIFF
--- a/imports/table/shared.lua
+++ b/imports/table/shared.lua
@@ -85,7 +85,7 @@ end
 ---@return table
 ---Merges two tables together. Defaults to adding duplicate keys together if they are numbers, otherwise they are overriden.
 local function table_merge(t1, t2, addDuplicateNumbers)
-    addDuplicateNumbers = addDuplicateNumbers ~= nil and addDuplicateNumbers or true
+    addDuplicateNumbers = addDuplicateNumbers == nil and true or addDuplicateNumbers
     for k, v2 in pairs(t2) do
         local v1 = t1[k]
         local type1 = type(v1)


### PR DESCRIPTION
The logic for the third parameter (`addDuplicateNumbers`) does not respect a falsy value.

```lua
addDuplicateNumbers = addDuplicateNumbers ~= nil and addDuplicateNumbers or true
```
When a value of `false` is passed the logic is resolved as follows:
1. `addDuplicateNumbers ~= nil` resolves to `true`
2. `addDuplicateNumbers ~= nil and addDuplicateNumbers` is therefore the same as `true and false` which resolves to `false`
3. `addDuplicateNumbers ~= nil and addDuplicateNumbers or true` is therefore the same a `false or true`, which resolves to `true`

So a falsy value always coerces to `true`.

Simple test script:
```lua
local t1 = { 1 }
local t2 = { 1 }

local tmerged = lib.table.merge(t1, t2, false)
print("Merged", json.encode(tmerged))
--------
-- Output:
-- Merged   [2]
```

Proposed solution is to reverse the logic somewhat so it sets the value to `true` only when `nil`.
```lua
addDuplicateNumbers = addDuplicateNumbers == nil and true or addDuplicateNumbers
```

Running the same test script:
```lua
-- Output:
-- Merged   [1]
```