### PR TITLE
tweak(resource/cache): update seat cache on vehicle change

### DIFF
--- a/resource/cache/client.lua
+++ b/resource/cache/client.lua
@@ -26,6 +26,10 @@ CreateThread(function()
 		local vehicle = GetVehiclePedIsIn(ped, false)
 
 		if vehicle > 0 then
+			if vehicle ~= cache.vehicle then
+				cache:set('seat', false)
+			end
+
 			cache:set('vehicle', vehicle)
 
 			if not cache.seat or GetPedInVehicleSeat(vehicle, cache.seat) ~= ped then


### PR DESCRIPTION
With this change, seat cache event listeners will be triggered all the time when the player's vehicle changes. This is useful in scenarios where the player doesn't exit the vehicle, but we switch their vehicle and warp them into the same seat index, and we want to listen to the seat event to perform specific actions. Previously, seat listeners were not being triggered because the cached seat value stayed the same.