### PR TITLE
feat(relativeCoords): add lib.getRelativeCoords function

### DIFF
--- a/imports/getRelativeCoords/shared.lua
+++ b/imports/getRelativeCoords/shared.lua
@@ -1,20 +1,30 @@
---Get the relative coordinates of a vector3 based on a heading and offset
----@param coords vector3
+local glm_sincos = require 'glm'.sincos
+local glm_rad = require 'glm'.rad
+
+---Get the relative coordinates of a vector3 based on a heading and offset
+---@overload fun(coords: vector3, heading: number, offset: vector3): vector3
+---@overload fun(coords: vector4, offset: vector3): vector4
+---@param coords vector3 | vector4
 ---@param heading number
 ---@param offset vector3
----@return vector4 coords
+---@return vector3
 function lib.getRelativeCoords(coords, heading, offset)
-	local headingRad = math.rad(heading)
+    offset = offset or heading
+    local x, y, z, w = coords.x, coords.y, coords.z, type(heading) == 'number' and heading or coords.w
+    local sin, cos = glm_sincos --[[@as fun(n: number): number, number]](glm_rad(w))
+    local relativeX = offset.x * cos - offset.y * sin
+    local relativeY = offset.x * sin + offset.y * cos
 
-    local relativeX = offset.x * math.cos(headingRad) - offset.y * math.sin(headingRad)
-    local relativeY = offset.x * math.sin(headingRad) + offset.y * math.cos(headingRad)
-
-    return vec4(
-		coords.x + relativeX,
-		coords.y + relativeY,
-        coords.z + offset.z,
-        heading
-	)
+    return coords.w and vec4(
+        x + relativeX,
+        y + relativeY,
+        z + offset.z,
+        w
+    ) or vec3(
+        x + relativeX,
+        y + relativeY,
+        z + offset.z
+    )
 end
 
 return lib.getRelativeCoords

--- a/imports/getRelativeCoords/shared.lua
+++ b/imports/getRelativeCoords/shared.lua
@@ -1,0 +1,20 @@
+--Get the relative coordinates of a vector3 based on a heading and offset
+---@param coords vector3
+---@param heading number
+---@param offset vector3
+---@return vector4 coords
+function lib.getRelativeCoords(coords, heading, offset)
+	local headingRad = math.rad(heading)
+
+    local relativeX = offset.x * math.cos(headingRad) - offset.y * math.sin(headingRad)
+    local relativeY = offset.x * math.sin(headingRad) + offset.y * math.cos(headingRad)
+
+    return vec4(
+		coords.x + relativeX,
+		coords.y + relativeY,
+        coords.z + offset.z,
+        heading
+	)
+end
+
+return lib.getRelativeCoords


### PR DESCRIPTION
Added the `lib.getRelativeCoords` function, which is useful for obtaining relative coordinates on the server-side, as [GetOffsetFromCoordAndHeadingInWorldCoords](https://docs.fivem.net/natives/?_0x163E252DE035A133) native is only available on the client-side.