### PR TITLE
fix(marker): logical error when setting faceCamera

### DIFF
--- a/imports/marker/client.lua
+++ b/imports/marker/client.lua
@@ -5,9 +5,6 @@ local defaultRotation = vector3(0, 0, 0)
 local defaultDirection = vector3(0, 0, 0)
 local defaultColor = { r = 255, g = 255, b = 255, a = 100 }
 local defaultSize = { width = 2, height = 1 }
-local defaultBobUpAndDown = false
-local defaultFaceCamera = true
-local defaultRotate = false
 local defaultTextureDict = nil
 local defaultTextureName = nil
 
@@ -152,9 +149,9 @@ function lib.marker.new(options)
   self.height = options.height or defaultSize.height
   self.rotation = options.rotation or defaultRotation
   self.direction = options.direction or defaultDirection
-  self.bobUpAndDown = options.bobUpAndDown or defaultBobUpAndDown
-  self.faceCamera = options.faceCamera or defaultFaceCamera
-  self.rotate = options.rotate or defaultRotate
+  self.bobUpAndDown = type(options.bobUpAndDown) == 'boolean' and options.bobUpAndDown
+  self.faceCamera = type(options.faceCamera) ~= 'boolean' or options.faceCamera
+  self.rotate = type(options.rotate) == 'boolean' and options.rotate
   self.textureDict = options.textureDict or defaultTextureDict
   self.textureName = options.textureName or defaultTextureName
   self.draw = drawMarker


### PR DESCRIPTION
Due to the way boolean values were being assigned, faceCamera would always evaluate to true because of its default value. This change fixes the logical error and ensures boolean properties are properly set.