### PR TITLE
fix(cron): matching weekdayMap values with os.date wday values

### DIFF
--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -51,13 +51,13 @@ local maxUnits = {
 }
 
 local weekdayMap = {
-    sun = 0,
-    mon = 1,
-    tue = 2,
-    wed = 3,
-    thu = 4,
-    fri = 5,
-    sat = 6,
+    sun = 1,
+    mon = 2,
+    tue = 3,
+    wed = 4,
+    thu = 5,
+    fri = 6,
+    sat = 7,
 }
 
 local monthMap = {


### PR DESCRIPTION
weekdayMap is written according to cron standards, getTimeUnit(self.weekday, 'wday') from the expression “‘0 12 * * * mon’” returns 8 and the cronjob was not running.