### PR TITLE
refactor(relativeCoords): allow passing full rotation

### DIFF
--- a/imports/getRelativeCoords/shared.lua
+++ b/imports/getRelativeCoords/shared.lua
@@ -5,7 +5,7 @@ local glm_rad = require 'glm'.rad --[[@as fun(n: number): number]]
 ---@param coords vector3 The base coordinates
 ---@param rotation number | vector3 Either a heading (number) or full rotation (vector3)
 ---@param offset vector3 The offset to apply
----@return vector3 | vector4
+---@return vector3
 function lib.getRelativeCoords(coords, rotation, offset)
     if type(rotation) == 'number' then
         local sin, cos = glm_sincos(glm_rad(rotation))

--- a/imports/getRelativeCoords/shared.lua
+++ b/imports/getRelativeCoords/shared.lua
@@ -1,40 +1,47 @@
 local glm_sincos = require 'glm'.sincos --[[@as fun(n: number): number, number]]
 local glm_rad = require 'glm'.rad --[[@as fun(n: number): number]]
 
----Get the relative coordinates of a vector3 based on rotation and offset
----@param coords vector3 The base coordinates
----@param rotation number | vector3 Either a heading (number) or full rotation (vector3)
----@param offset vector3 The offset to apply
----@return vector3
+---Get the relative coordinates based on heading/rotation and offset
+---@overload fun(coords: vector3, heading: number, offset: vector3): vector3
+---@overload fun(coords: vector4, offset: vector3): vector4
+---@overload fun(coords: vector3, rotation: vector3, offset: vector3): vector3
 function lib.getRelativeCoords(coords, rotation, offset)
-    if type(rotation) == 'number' then
-        local sin, cos = glm_sincos(glm_rad(rotation))
-        local relativeX = offset.x * cos - offset.y * sin
-        local relativeY = offset.x * sin + offset.y * cos
+    if type(rotation) == 'vector3' and offset then
+        local pitch = glm_rad(rotation.x)
+        local roll = glm_rad(rotation.y)
+        local yaw = glm_rad(rotation.z)
+
+        local sp, cp = glm_sincos(pitch)
+        local sr, cr = glm_sincos(roll)
+        local sy, cy = glm_sincos(yaw)
+
+        local rotatedX = offset.x * (cy * cr) + offset.y * (cy * sr * sp - sy * cp) + offset.z * (cy * sr * cp + sy * sp)
+        local rotatedY = offset.x * (sy * cr) + offset.y * (sy * sr * sp + cy * cp) + offset.z * (sy * sr * cp - cy * sp)
+        local rotatedZ = offset.x * (-sr) + offset.y * (cr * sp) + offset.z * (cr * cp)
 
         return vec3(
-            coords.x + relativeX,
-            coords.y + relativeY,
-            coords.z + offset.z
+            coords.x + rotatedX,
+            coords.y + rotatedY,
+            coords.z + rotatedZ
         )
     end
 
-    local pitch = glm_rad(rotation.x)
-    local roll = glm_rad(rotation.y)
-    local yaw = glm_rad(rotation.z)
+    offset = offset or rotation
+    local x, y, z, w = coords.x, coords.y, coords.z, type(rotation) == 'number' and rotation or coords.w
 
-    local sp, cp = glm_sincos(pitch)
-    local sr, cr = glm_sincos(roll)
-    local sy, cy = glm_sincos(yaw)
+    local sin, cos = glm_sincos(glm_rad(w))
+    local relativeX = offset.x * cos - offset.y * sin
+    local relativeY = offset.x * sin + offset.y * cos
 
-    local rotatedX = offset.x * (cy * cr) + offset.y * (cy * sr * sp - sy * cp) + offset.z * (cy * sr * cp + sy * sp)
-    local rotatedY = offset.x * (sy * cr) + offset.y * (sy * sr * sp + cy * cp) + offset.z * (sy * sr * cp - cy * sp)
-    local rotatedZ = offset.x * (-sr) + offset.y * (cr * sp) + offset.z * (cr * cp)
-
-    return vec3(
-        coords.x + rotatedX,
-        coords.y + rotatedY,
-        coords.z + rotatedZ
+    return coords.w and vec4(
+        x + relativeX,
+        y + relativeY,
+        z + offset.z,
+        w
+    ) or vec3(
+        x + relativeX,
+        y + relativeY,
+        z + offset.z
     )
 end
 

--- a/imports/getRelativeCoords/shared.lua
+++ b/imports/getRelativeCoords/shared.lua
@@ -1,29 +1,40 @@
-local glm_sincos = require 'glm'.sincos
-local glm_rad = require 'glm'.rad
+local glm_sincos = require 'glm'.sincos --[[@as fun(n: number): number, number]]
+local glm_rad = require 'glm'.rad --[[@as fun(n: number): number]]
 
----Get the relative coordinates of a vector3 based on a heading and offset
----@overload fun(coords: vector3, heading: number, offset: vector3): vector3
----@overload fun(coords: vector4, offset: vector3): vector4
----@param coords vector3 | vector4
----@param heading number
----@param offset vector3
----@return vector3
-function lib.getRelativeCoords(coords, heading, offset)
-    offset = offset or heading
-    local x, y, z, w = coords.x, coords.y, coords.z, type(heading) == 'number' and heading or coords.w
-    local sin, cos = glm_sincos --[[@as fun(n: number): number, number]](glm_rad(w))
-    local relativeX = offset.x * cos - offset.y * sin
-    local relativeY = offset.x * sin + offset.y * cos
+---Get the relative coordinates of a vector3 based on rotation and offset
+---@param coords vector3 The base coordinates
+---@param rotation number | vector3 Either a heading (number) or full rotation (vector3)
+---@param offset vector3 The offset to apply
+---@return vector3 | vector4
+function lib.getRelativeCoords(coords, rotation, offset)
+    if type(rotation) == 'number' then
+        local sin, cos = glm_sincos(glm_rad(rotation))
+        local relativeX = offset.x * cos - offset.y * sin
+        local relativeY = offset.x * sin + offset.y * cos
 
-    return coords.w and vec4(
-        x + relativeX,
-        y + relativeY,
-        z + offset.z,
-        w
-    ) or vec3(
-        x + relativeX,
-        y + relativeY,
-        z + offset.z
+        return vec3(
+            coords.x + relativeX,
+            coords.y + relativeY,
+            coords.z + offset.z
+        )
+    end
+
+    local pitch = glm_rad(rotation.x)
+    local roll = glm_rad(rotation.y)
+    local yaw = glm_rad(rotation.z)
+
+    local sp, cp = glm_sincos(pitch)
+    local sr, cr = glm_sincos(roll)
+    local sy, cy = glm_sincos(yaw)
+
+    local rotatedX = offset.x * (cy * cr) + offset.y * (cy * sr * sp - sy * cp) + offset.z * (cy * sr * cp + sy * sp)
+    local rotatedY = offset.x * (sy * cr) + offset.y * (sy * sr * sp + cy * cp) + offset.z * (sy * sr * cp - cy * sp)
+    local rotatedZ = offset.x * (-sr) + offset.y * (cr * sp) + offset.z * (cr * cp)
+
+    return vec3(
+        coords.x + rotatedX,
+        coords.y + rotatedY,
+        coords.z + rotatedZ
     )
 end
 


### PR DESCRIPTION
Allow passing a full rotation (vector3) to get the relative coords.
Usefull if the entity is rotated on other axis than just vertical.
This prevent to use a vector4 as first arg though.
