### PR TITLE
  feat(callback): `ox_lib` callback registers a duplicate event with the same name 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ pnpm-debug.log*
 /package/**/*.js
 /package/**/*.js.map
 /package/**/*.d.ts
+package-lock.json
 
 /web/node_modules
 /web/build

--- a/imports/callback/client.lua
+++ b/imports/callback/client.lua
@@ -2,6 +2,7 @@ local pendingCallbacks = {}
 local timers = {}
 local cbEvent = '__ox_cb_%s'
 local callbackTimeout = GetConvarInt('ox:callbackTimeout', 300000)
+local eventsTree = {}
 
 RegisterNetEvent(cbEvent:format(cache.resource), function(key, ...)
     local cb = pendingCallbacks[key]
@@ -127,7 +128,11 @@ function lib.callback.register(name, cb)
 
     lib.setValidCallback(name, true)
 
-    RegisterNetEvent(event, function(resource, key, ...)
+    if eventsTree[event] then
+        RemoveEventHandler(eventsTree[event])
+    end
+
+    eventsTree[event] = RegisterNetEvent(event, function(resource, key, ...)
         TriggerServerEvent(cbEvent:format(resource), key, callbackResponse(pcall(cb, ...)))
     end)
 end

--- a/imports/callback/server.lua
+++ b/imports/callback/server.lua
@@ -1,6 +1,7 @@
 local pendingCallbacks = {}
 local cbEvent = '__ox_cb_%s'
 local callbackTimeout = GetConvarInt('ox:callbackTimeout', 300000)
+local eventsTree = {}
 
 RegisterNetEvent(cbEvent:format(cache.resource), function(key, ...)
     local cb = pendingCallbacks[key]
@@ -110,7 +111,11 @@ function lib.callback.register(name, cb)
 
     lib.setValidCallback(name, true)
 
-    RegisterNetEvent(event, function(resource, key, ...)
+    if eventsTree[event] then
+        RemoveEventHandler(eventsTree[event])
+    end
+
+    eventsTree[event] = RegisterNetEvent(event, function(resource, key, ...)
         TriggerClientEvent(cbEvent:format(resource), source, key, callbackResponse(pcall(cb, source, ...)))
     end)
 end


### PR DESCRIPTION
This pull request introduces changes to manage event handlers more effectively in the callback system by adding an `eventsTree` structure to both the client and server callback handling code. The key changes include initializing the `eventsTree` and updating the event registration logic to remove existing handlers before adding new ones.

> When a script using an `ox_lib` callback restarts and attempts to register another callback with the same event name, a native error occurs, requiring a script/server restart. To prevent this, the system first checks if the event already exists. If it does, it removes the existing event before re-registering it, ensuring error-free execution.

Key changes:

**Client-side changes:**

* [`imports/callback/client.lua`](diffhunk://#diff-df95117281f72ede3d5231154ea02e38836a2bc3a9837f5f8c8741ab93dc0bc6R5): Added `eventsTree` to manage event handlers and updated the `lib.callback.register` function to remove existing event handlers before registering new ones. [[1]](diffhunk://#diff-df95117281f72ede3d5231154ea02e38836a2bc3a9837f5f8c8741ab93dc0bc6R5) [[2]](diffhunk://#diff-df95117281f72ede3d5231154ea02e38836a2bc3a9837f5f8c8741ab93dc0bc6L130-R135)

**Server-side changes:**

* [`imports/callback/server.lua`](diffhunk://#diff-8216d68de1da173a0d98eba3a05ebcd4e2e283740ad0288e2c74638ef66d8c4aR4): Added `eventsTree` to manage event handlers and updated the `lib.callback.register` function to remove existing event handlers before registering new ones. [[1]](diffhunk://#diff-8216d68de1da173a0d98eba3a05ebcd4e2e283740ad0288e2c74638ef66d8c4aR4) [[2]](diffhunk://#diff-8216d68de1da173a0d98eba3a05ebcd4e2e283740ad0288e2c74638ef66d8c4aL113-R118)