### PR TITLE
fix(imports/zones): average z coordinate of non planar polys

### DIFF
--- a/imports/zones/client.lua
+++ b/imports/zones/client.lua
@@ -265,6 +265,18 @@ local function convertToVector(coords)
     return coords
 end
 
+local function getAverageZ(vecs)
+    if not vecs or type(vecs) ~= 'table' or #vecs == 0 then return 0 end
+
+    local z = 0
+
+    for i = 1, #vecs do
+        z += vecs[i].z or 0
+    end
+
+    return z / #vecs
+end
+
 local function setDebug(self, bool, colour)
     if not bool and insideZones[self.id] then
         insideZones[self.id] = nil
@@ -308,48 +320,7 @@ lib.zones = {
         data.polygon = glm.polygon.new(points)
 
         if not data.polygon:isPlanar() then
-            local zCoords = {}
-
-            for i = 1, pointN do
-                local zCoord = points[i].z
-
-                if zCoords[zCoord] then
-                    zCoords[zCoord] += 1
-                else
-                    zCoords[zCoord] = 1
-                end
-            end
-
-            local coordsArray = {}
-
-            for coord, count in pairs(zCoords) do
-                coordsArray[#coordsArray + 1] = {
-                    coord = coord,
-                    count = count
-                }
-            end
-
-            table.sort(coordsArray, function(a, b)
-                return a.count > b.count
-            end)
-
-            local zCoord = coordsArray[1].coord
-            local averageTo
-
-            for i = 1, #coordsArray do
-                if coordsArray[i].count < coordsArray[1].count then
-                    averageTo = i - 1
-                    break
-                end
-            end
-
-            if averageTo > 1 then
-                for i = 2, averageTo do
-                    zCoord += coordsArray[i].coord
-                end
-
-                zCoord /= averageTo
-            end
+            local zCoord = getAverageZ(points)
 
             for i = 1, pointN do
                 points[i] = vec3(data.points[i].xy, zCoord)


### PR DESCRIPTION
I noticed that when creating a polyzone with points that have very similar, but not equal, z coordinates (so if they all round to the same number), the previous averaging logic threw an error, it was also overcomplicated.