### PR TITLE
fix(types): add TextAreaProps to RowInput

### DIFF
--- a/package/client/resource/interface/input.ts
+++ b/package/client/resource/interface/input.ts
@@ -149,7 +149,8 @@ type RowInput =
   | ColorProps
   | DateProps
   | DateRangeProps
-  | TimeProps;
+  | TimeProps
+  | TextAreaProps;
 
 type inputDialog = (
   heading: string,


### PR DESCRIPTION
`TextAreaProps` was not referenced by `RowInput`. When using type `textarea` on `inputDialog()`, it would return the following error
`Type '"textarea"' is not assignable to type '"number" | "input" | "checkbox" | "select" | "multi-select" | "slider" | "color" | "date" | "date-range" | "time"'` 