### PR TITLE
fix(web): Remove unused fonts and switch to Inter. Fixes #721.

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,10 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@200;400;500;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Fira+Mono&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@300;400;500;600;700&display=swap');
-@import url("https://use.typekit.net/wxh5ury.css");
-@import url("https://use.typekit.net/qgr5ebd.css");
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
 
 html {
   color-scheme: normal !important;

--- a/web/src/theme/index.ts
+++ b/web/src/theme/index.ts
@@ -2,7 +2,7 @@ import { MantineThemeOverride } from '@mantine/core';
 
 export const theme: MantineThemeOverride = {
   colorScheme: 'dark',
-  fontFamily: 'Roboto',
+  fontFamily: 'Inter',
   shadows: { sm: '1px 1px 3px rgba(0, 0, 0, 0.5)' },
   components: {
     Button: {


### PR DESCRIPTION
Removes unused font imports and switches the theme font from Roboto to Inter.

![image](https://github.com/user-attachments/assets/e01e3226-c7d2-4c0b-86d2-a8df64d32b3e)
![image](https://github.com/user-attachments/assets/e0f8aa6f-e959-417d-aa5f-1fc8ac9546a6)
