### PR TITLE
fix(zones): Fix error that occurs when there are no duplicate z-coords

### DIFF
--- a/imports/zones/client.lua
+++ b/imports/zones/client.lua
@@ -334,7 +334,7 @@ lib.zones = {
             end)
 
             local zCoord = coordsArray[1].coord
-            local averageTo
+            local averageTo = 1
 
             for i = 1, #coordsArray do
                 if coordsArray[i].count < coordsArray[1].count then


### PR DESCRIPTION
This PR fixes an error that occurs when there are no duplicate z-values during poly zone creation, while keeping the existing implementation.

An alternative solution to #716 