### PR TITLE
fix(client/zones): fix nil error when multiple zones are removes at once

### DIFF
--- a/imports/zones/client.lua
+++ b/imports/zones/client.lua
@@ -167,7 +167,7 @@ CreateThread(function()
                 return a.distance > b.distance
             end)
 
-            for i = 1, exitingSize do
+            for i = exitingSize, 1, -1 do
                 exitingZones[i]:onExit()
             end
 


### PR DESCRIPTION
Reverse the order in which we iterate through `exitingZones` to prevent issues with the index shifting.

Fixes #712