### PR TITLE
feat(print): add convar change listener

### DIFF
--- a/imports/print/shared.lua
+++ b/imports/print/shared.lua
@@ -14,12 +14,10 @@ local levelPrefixes = {
     '^4[VERBOSE]',
     '^6[DEBUG]',
 }
-local convarNames = {
-    resource = 'ox:printlevel:' .. cache.resource,
-    global = 'ox:printlevel',
-}
+local convarGlobal = 'ox:printlevel'
+local convarResource = 'ox:printlevel:' .. cache.resource
 local function getPrintLevelFromConvar()
-    return printLevel[GetConvar(convarNames.resource, GetConvar(convarNames.global, 'info'))]
+    return printLevel[GetConvar(convarResource, GetConvar(convarResource, 'info'))]
 end
 local resourcePrintLevel = getPrintLevelFromConvar()
 local template = ('^5[%s] %%s %%s^7'):format(cache.resource)
@@ -31,7 +29,7 @@ local jsonOptions = { sort_keys = true, indent = true, exception = handleExcepti
 
 -- Update the print level when the convar changes
 AddConvarChangeListener('ox:printlevel*', function(convarName, reserved)
-    if (convarName ~= convarNames.resource and convarName ~= convarNames.global) then return end
+    if (convarName ~= convarResource and convarName ~= convarResource) then return end
     resourcePrintLevel = getPrintLevelFromConvar()
 end)
 

--- a/imports/print/shared.lua
+++ b/imports/print/shared.lua
@@ -59,7 +59,7 @@ if (AddConvarChangeListener) then
         resourcePrintLevel = getPrintLevelFromConvar()
     end)
 else
-    lib.print.info('Convar change listener not available, print level will not update dynamically.')
+    libPrint(printLevel.verbose, 'Convar change listener not available, print level will not update dynamically.')
 end
 
 return lib.print

--- a/imports/print/shared.lua
+++ b/imports/print/shared.lua
@@ -17,7 +17,7 @@ local levelPrefixes = {
 local convarGlobal = 'ox:printlevel'
 local convarResource = 'ox:printlevel:' .. cache.resource
 local function getPrintLevelFromConvar()
-    return printLevel[GetConvar(convarResource, GetConvar(convarResource, 'info'))]
+    return printLevel[GetConvar(convarResource, GetConvar(convarGlobal, 'info'))]
 end
 local resourcePrintLevel = getPrintLevelFromConvar()
 local template = ('^5[%s] %%s %%s^7'):format(cache.resource)
@@ -29,7 +29,7 @@ local jsonOptions = { sort_keys = true, indent = true, exception = handleExcepti
 
 -- Update the print level when the convar changes
 AddConvarChangeListener('ox:printlevel*', function(convarName, reserved)
-    if (convarName ~= convarResource and convarName ~= convarResource) then return end
+    if (convarName ~= convarResource and convarName ~= convarGlobal) then return end
     resourcePrintLevel = getPrintLevelFromConvar()
 end)
 

--- a/imports/print/shared.lua
+++ b/imports/print/shared.lua
@@ -27,12 +27,6 @@ local function handleException(reason, value)
 end
 local jsonOptions = { sort_keys = true, indent = true, exception = handleException }
 
--- Update the print level when the convar changes
-AddConvarChangeListener('ox:printlevel*', function(convarName, reserved)
-    if (convarName ~= convarResource and convarName ~= convarGlobal) then return end
-    resourcePrintLevel = getPrintLevelFromConvar()
-end)
-
 ---Prints to console conditionally based on what ox:printlevel is.
 ---Any print with a level more severe will also print. If ox:printlevel is info, then warn and error prints will appear as well, but debug prints will not.
 ---@param level PrintLevel
@@ -57,5 +51,15 @@ lib.print = {
     verbose = function(...) libPrint(printLevel.verbose, ...) end,
     debug = function(...) libPrint(printLevel.debug, ...) end,
 }
+
+-- Update the print level when the convar changes
+if (AddConvarChangeListener) then
+    AddConvarChangeListener('ox:printlevel*', function(convarName, reserved)
+        if (convarName ~= convarResource and convarName ~= convarGlobal) then return end
+        resourcePrintLevel = getPrintLevelFromConvar()
+    end)
+else
+    lib.print.info('Convar change listener not available, print level will not update dynamically.')
+end
 
 return lib.print

--- a/imports/print/shared.lua
+++ b/imports/print/shared.lua
@@ -14,14 +14,26 @@ local levelPrefixes = {
     '^4[VERBOSE]',
     '^6[DEBUG]',
 }
-
-local resourcePrintLevel = printLevel[GetConvar('ox:printlevel:' .. cache.resource, GetConvar('ox:printlevel', 'info'))]
+local convarNames = {
+    resource = 'ox:printlevel:' .. cache.resource,
+    global = 'ox:printlevel',
+}
+local function getPrintLevelFromConvar()
+    return printLevel[GetConvar(convarNames.resource, GetConvar(convarNames.global, 'info'))]
+end
+local resourcePrintLevel = getPrintLevelFromConvar()
 local template = ('^5[%s] %%s %%s^7'):format(cache.resource)
 local function handleException(reason, value)
     if type(value) == 'function' then return tostring(value) end
     return reason
 end
 local jsonOptions = { sort_keys = true, indent = true, exception = handleException }
+
+-- Update the print level when the convar changes
+AddConvarChangeListener('ox:printlevel*', function(convarName, reserved)
+    if (convarName ~= convarNames.resource and convarName ~= convarNames.global) then return end
+    resourcePrintLevel = getPrintLevelFromConvar()
+end)
 
 ---Prints to console conditionally based on what ox:printlevel is.
 ---Any print with a level more severe will also print. If ox:printlevel is info, then warn and error prints will appear as well, but debug prints will not.


### PR DESCRIPTION
add convar change listener to print module, This would allow to set their convar at their runtime and see information without restarting resource.