### PR TITLE
restore onExit feature to distant zones

### DIFF
--- a/imports/zones/shared.lua
+++ b/imports/zones/shared.lua
@@ -137,10 +137,10 @@ CreateThread(function()
                     if not contains then
                         zone.insideZone = false
                         insideZones[zone.id] = nil
-                    end
 
-                    if zone.onExit then
-                        exitingZones:push(zone)
+                        if zone.onExit then
+                            exitingZones:push(zone)
+                        end
                     end
                 end
             end

--- a/imports/zones/shared.lua
+++ b/imports/zones/shared.lua
@@ -138,6 +138,10 @@ CreateThread(function()
                         zone.insideZone = false
                         insideZones[zone.id] = nil
                     end
+
+                    if zone.onExit then
+                        exitingZones:push(zone)
+                    end
                 end
             end
 


### PR DESCRIPTION
Teleporting away from a zone you're currently in no longer triggers the onExit event with the recent grid updates. This restores that functionality.