### PR TITLE
feat(menu): Add isVisible field to the option table.

### DIFF
--- a/resource/interface/client/menu.lua
+++ b/resource/interface/client/menu.lua
@@ -18,6 +18,7 @@ local openMenu
 ---@field defaultIndex? number
 ---@field args? {[any]: any}
 ---@field close? boolean
+---@field isVisible? fun(): boolean
 
 ---@class MenuProps
 ---@field id string
@@ -48,6 +49,12 @@ function lib.showMenu(id, startIndex)
     local menu = registeredMenus[id]
     if not menu then
         error(('No menu with id %s was found'):format(id))
+    end
+
+    for i = #menu.options, 1, -1 do
+        if menu.options[i].isVisible and not menu.options[i].isVisible() then
+            table.remove(menu.options, i)
+        end
     end
 
     if table.type(menu.options) == 'empty' then

--- a/resource/interface/client/menu.lua
+++ b/resource/interface/client/menu.lua
@@ -19,6 +19,7 @@ local openMenu
 ---@field args? {[any]: any}
 ---@field close? boolean
 ---@field isVisible? fun(): boolean
+---@field hidden? boolean
 
 ---@class MenuProps
 ---@field id string
@@ -52,8 +53,8 @@ function lib.showMenu(id, startIndex)
     end
 
     for i = #menu.options, 1, -1 do
-        if menu.options[i].isVisible and not menu.options[i].isVisible() then
-            table.remove(menu.options, i)
+        if menu.options[i].isVisible then
+            menu.options[i].hidden = not menu.options[i].isVisible()
         end
     end
 

--- a/web/src/features/menu/list/index.tsx
+++ b/web/src/features/menu/list/index.tsx
@@ -220,7 +220,9 @@ const ListMenu: React.FC = () => {
             <Box className={classes.buttonsWrapper} onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => moveMenu(e)}>
               <FocusTrap active={visible}>
                 <Stack spacing={8} p={8} sx={{ overflowY: 'scroll' }}>
-                  {menu.items.map((item, index) => (
+                {menu.items
+                  .filter(item => !item.hidden)
+                  .map((item, index) => (
                     <React.Fragment key={`menu-item-${index}`}>
                       {item.label && (
                         <ListItem

--- a/web/src/typings/menu.ts
+++ b/web/src/typings/menu.ts
@@ -16,6 +16,7 @@ export interface MenuItem {
   iconAnimation?: IconAnimation;
   defaultIndex?: number;
   close?: boolean;
+  hidden?: boolean;
 }
 
 export interface MenuSettings {


### PR DESCRIPTION
Works similarly to ox_target's canInteract function, running isVisible function for each menu option (if defined) and determining its visibility based on its boolean return value.