### PR TITLE
fix(package/callback): fix broken js callbacks

### DIFF
--- a/package/client/resource/callback/index.ts
+++ b/package/client/resource/callback/index.ts
@@ -57,10 +57,9 @@ export function triggerServerCallback<T = unknown>(
 }
 
 export function onServerCallback(eventName: string, cb: (...args: any[]) => any) {
-  eventName = `__ox_cb_${eventName}`
-
   exports.ox_lib.setValidCallback(eventName, true)
-  onNet(eventName, async (resource: string, key: string, ...args: any[]) => {
+
+  onNet(`__ox_cb_${eventName}`, async (resource: string, key: string, ...args: any[]) => {
     let response: any;
 
     try {

--- a/package/server/resource/callback/index.ts
+++ b/package/server/resource/callback/index.ts
@@ -39,10 +39,9 @@ export function triggerClientCallback<T = unknown>(
 }
 
 export function onClientCallback(eventName: string, cb: (playerId: number, ...args: any[]) => any) {
-  eventName = `__ox_cb_${eventName}`;
-  
   exports.ox_lib.setValidCallback(eventName, true)
-  onNet(eventName, async (resource: string, key: string, ...args: any[]) => {
+
+  onNet(`__ox_cb_${eventName}`, async (resource: string, key: string, ...args: any[]) => {
     const src = source;
     let response: any;
 


### PR DESCRIPTION
In the current version, ox_lib's callbacks registered via JS package are broken.

Cause:
The eventName is being mutated before calling exports.ox_lib.setValidCallback(eventName, true) which causes all callback requests to fail.

This pull request resolves #740. 

This commit reverts commit 87818b3710e465f85991fb41a1611304995dd0d3.