### PR TITLE
feat(radial) add ability to add & remove items from submenus

### DIFF
--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -194,6 +194,64 @@ function lib.removeRadialItem(id)
     refreshRadial(id)
 end
 
+---Registers an item or array of items in a specific radial sub menu.
+---@param string parentMenuId
+---@param items RadialMenuItem | RadialMenuItem[]
+function lib.addRadialSubItem(parentMenuId, items)
+
+    local parentMenu = menus[parentMenuId]
+    if not parentMenu then
+        return error('No radial menu with such id found.')
+    end
+
+    local invokingResource = GetInvokingResource()
+
+    items = table.type(items) == 'array' and items or { items }
+
+    for i = 1, #items do
+        local item = items[i]
+        item.resource = invokingResource
+
+        for j = 1, #parentMenu.items do
+            if parentMenu.items[j].id == item.id then
+                parentMenu.items[j] = item
+            end
+
+            if j == #parentMenu.items then
+                parentMenu.items[#parentMenu.items + 1] = item
+            end
+        end
+        
+    end
+
+    if isOpen then
+        refreshRadial(parentMenuId)
+    end
+end
+
+-- Removes an item from a radial submenu with the given parentMenuId
+---@param parentMenuId string
+---@param id string
+function lib.removeRadialSubItem(parentMenuId, id)
+    local parentMenu = menus[parentMenuId]
+    if not parentMenu then
+        return error('No radial menu with such id found.')
+    end
+
+    for i = 1, #parentMenu.items do
+        local item = parentMenu.items[i]
+
+        if item.id == id then
+            table.remove(parentMenu.items, i)
+            break
+        end
+    end
+
+    if isOpen then
+        refreshRadial(parentMenuId)
+    end
+end
+
 ---Removes all items from the global radial menu.
 function lib.clearRadialItems()
     table.wipe(menuItems)


### PR DESCRIPTION
This PR adds two new methods for the Radial Menu to allow better/more convenient management of sub menus for common scenarios such as adding & removing options within submenus based on certain conditions (e.g jobs, coords, states etc)

```lua
---Registers an item or array of items in a specific radial sub menu.
---@param string parentMenuId
---@param items RadialMenuItem | RadialMenuItem[]
function lib.addRadialSubItem(parentMenuId, items)
```

```lua
-- Removes an item from a radial submenu with the given parentMenuId
---@param parentMenuId string
---@param id string
function lib.removeRadialSubItem(parentMenuId, id)
```

When i asked around in discord and the docs etc, the current "way to do it" is re-registering the entire submenu e.g if i have an actions menu (globalmenu->actions) i'd have to re-register the entire menu and keep doing so based on conditions.

With these new methods, i can simply use the add and remove functions above to pluck options as needed.

Example usage based on the doc's [example menu](https://overextended.dev/ox_lib/Modules/Interface/Client/radial#usage-example)
```lua
lib.addRadialSubItem('police_menu', {
      {
          id = 'police.one',
          label = 'Hello',
          icon = 'fa-solid fa-car',
          onSelect = function()
              print('Hello')
          end,
      },
      {
          id = 'police.two',
          label = 'World',
          icon = 'fa-solid fa-print',
          onSelect = function()
              print('World')
          end,
      }
  })
```

And then if i wanted to remove a specific item based on my position, or whatever use case (this is similar to the use case for the docs example garage button being added/removed based on coords)

```lua
lib.removeRadialSubItem('police_menu', 'police.one')
```
