### PR TITLE
fix(callback/js): prevent args from being wrapped in an array when resolving the promise

### DIFF
--- a/package/client/resource/callback/index.ts
+++ b/package/client/resource/callback/index.ts
@@ -12,7 +12,7 @@ onNet(`__ox_cb_${cache.resource}`, (key: string, ...args: any) => {
 
   delete pendingCallbacks[key];
 
-  resolve(args);
+  resolve(...args);
 });
 
 const eventTimers: Record<string, number> = {};

--- a/package/server/resource/callback/index.ts
+++ b/package/server/resource/callback/index.ts
@@ -10,7 +10,7 @@ onNet(`__ox_cb_${cache.resource}`, (key: string, ...args: any) => {
 
   delete pendingCallbacks[key];
 
-  resolve(args);
+  resolve(...args);
 });
 
 export function triggerClientCallback<T = unknown>(


### PR DESCRIPTION
### Description

This PR fixes a small but important issue where `resolve(args)` was passing the entire `args` array as a single element, resulting in nested arrays.

### Before

```ts
resolve(args); // args = [1, 2] → resolves as [[1, 2]]
```

### After

```ts
resolve(...args); // args = [1, 2] → resolves as 1, 2
```

### Why this matters

- It changes the way how it worked before v3.30.0 and breaks javascript resources that use callbacks