### PR TITLE
fix: check interval before calling a cb

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -139,8 +139,10 @@ function SetInterval(callback, interval, ...)
         repeat
             interval = intervals[id]
             Wait(interval)
+
+            if interval < 0 then break end
             callback(table.unpack(args))
-        until interval < 0
+        until false
         intervals[id] = nil
     end)
 


### PR DESCRIPTION
This PR fixes an issue where once a Interval is cleared the CB is called twice.

Repro:
![image](https://github.com/user-attachments/assets/5517f29a-8936-40a2-9ecc-2ccba3dc7a4a)
![image](https://github.com/user-attachments/assets/af1bd120-b0f6-427f-8f4b-6f39e04a7c7d)

