### PR TITLE
chore(package/interface): add label to progressCircle

### DIFF
--- a/package/client/resource/interface/progress.ts
+++ b/package/client/resource/interface/progress.ts
@@ -12,6 +12,7 @@ interface PropProps {
 }
 
 interface ProgressProps {
+  label?: string; 
   duration: number;
   position?: 'middle' | 'bottom';
   useWhileDead?: boolean;


### PR DESCRIPTION
Currently in the package we would get a fat ass red line in vsc whenever we try to use label with progressCircle
![image](https://github.com/user-attachments/assets/ccd2392e-de1c-4eba-a5b6-4999f9897ef5)

So I just added the label to the package g