### PR TITLE
fix(getNearbyPlayers): More reliable coord getter for players in vehicle

### DIFF
--- a/imports/getClosestPlayer/client.lua
+++ b/imports/getClosestPlayer/client.lua
@@ -25,6 +25,10 @@ function lib.getClosestPlayer(coords, maxDistance, includePlayer)
 			local playerCoords = GetEntityCoords(playerPed)
 			local distance = #(coords - playerCoords)
 
+            if(GetVehiclePedIsIn(playerPed,false) ~= 0 ) then
+				playerCoords=GetWorldPositionOfEntityBone(playerPed,0);
+			end 
+
 			if distance < maxDistance then
 				maxDistance = distance
 				closestId = playerId

--- a/imports/getClosestPlayer/client.lua
+++ b/imports/getClosestPlayer/client.lua
@@ -14,7 +14,7 @@
 ---@return vector3? playerCoords
 function lib.getClosestPlayer(coords, maxDistance, includePlayer)
 	local players = GetActivePlayers()
-	local closestId, closestPed, closestCoords
+	local closestId, closestPed, closestCoords, closestVehicle
 	maxDistance = maxDistance or 2.0
 
 	for i = 1, #players do
@@ -24,9 +24,8 @@ function lib.getClosestPlayer(coords, maxDistance, includePlayer)
 			local playerPed = GetPlayerPed(playerId)
 			local playerCoords = GetEntityCoords(playerPed)
 
-            if GetVehiclePedIsIn(playerPed, false) ~= 0 then
-				playerCoords=GetWorldPositionOfEntityBone(playerPed, 0)
-			end 
+            local vehicle = GetVehiclePedIsIn(playerPed, false)
+            local playerCoords = vehicle == 0 and GetEntityCoords(playerPed) or GetWorldPositionOfEntityBone(playerPed, 0)
             
 			local distance = #(coords - playerCoords)
 
@@ -35,11 +34,12 @@ function lib.getClosestPlayer(coords, maxDistance, includePlayer)
 				closestId = playerId
 				closestPed = playerPed
 				closestCoords = playerCoords
+                closestVehicle = vehicle
 			end
 		end
 	end
 
-	return closestId, closestPed, closestCoords
+	return closestId, closestPed, closestCoords, closestVehicle
 end
 
 return lib.getClosestPlayer

--- a/imports/getClosestPlayer/client.lua
+++ b/imports/getClosestPlayer/client.lua
@@ -25,8 +25,8 @@ function lib.getClosestPlayer(coords, maxDistance, includePlayer)
 			local playerCoords = GetEntityCoords(playerPed)
 			local distance = #(coords - playerCoords)
 
-            if GetVehiclePedIsIn(playerPed,false) ~= 0 then
-				playerCoords=GetWorldPositionOfEntityBone(playerPed,0)
+            if GetVehiclePedIsIn(playerPed, false) ~= 0 then
+				playerCoords=GetWorldPositionOfEntityBone(playerPed, 0)
 			end 
 
 			if distance < maxDistance then

--- a/imports/getClosestPlayer/client.lua
+++ b/imports/getClosestPlayer/client.lua
@@ -25,8 +25,8 @@ function lib.getClosestPlayer(coords, maxDistance, includePlayer)
 			local playerCoords = GetEntityCoords(playerPed)
 			local distance = #(coords - playerCoords)
 
-            if(GetVehiclePedIsIn(playerPed,false) ~= 0 ) then
-				playerCoords=GetWorldPositionOfEntityBone(playerPed,0);
+            if GetVehiclePedIsIn(playerPed,false) ~= 0 then
+				playerCoords=GetWorldPositionOfEntityBone(playerPed,0)
 			end 
 
 			if distance < maxDistance then

--- a/imports/getClosestPlayer/client.lua
+++ b/imports/getClosestPlayer/client.lua
@@ -23,11 +23,12 @@ function lib.getClosestPlayer(coords, maxDistance, includePlayer)
 		if playerId ~= cache.playerId or includePlayer then
 			local playerPed = GetPlayerPed(playerId)
 			local playerCoords = GetEntityCoords(playerPed)
-			local distance = #(coords - playerCoords)
 
             if GetVehiclePedIsIn(playerPed, false) ~= 0 then
 				playerCoords=GetWorldPositionOfEntityBone(playerPed, 0)
 			end 
+            
+			local distance = #(coords - playerCoords)
 
 			if distance < maxDistance then
 				maxDistance = distance

--- a/imports/getNearbyPlayers/client.lua
+++ b/imports/getNearbyPlayers/client.lua
@@ -21,7 +21,10 @@ function lib.getNearbyPlayers(coords, maxDistance, includePlayer)
 
         if playerId ~= cache.playerId or includePlayer then
             local playerPed = GetPlayerPed(playerId)
-            local playerCoords = GetEntityCoords(playerPed)
+            
+            local vehicle = GetVehiclePedIsIn(playerPed, false)
+            local playerCoords = vehicle == 0 and GetEntityCoords(playerPed) or GetWorldPositionOfEntityBone(playerPed, 0)
+            
             local distance = #(coords - playerCoords)
 
             if distance < maxDistance then
@@ -30,6 +33,7 @@ function lib.getNearbyPlayers(coords, maxDistance, includePlayer)
                     id = playerId,
                     ped = playerPed,
                     coords = playerCoords,
+                    vehicle = vehicle
                 }
             end
         end


### PR DESCRIPTION
When a player is inside a vehicle GetEntityCoords returns the center of the vehicle, which is not necessarily the players coords in the world.

This PR improves the reliability of getNearbyPlayers by using the actual position of the player in the world.