### PR TITLE
fix(selector): exclude zero-weight items from getRandomWeighted

### DIFF
--- a/imports/selector/shared.lua
+++ b/imports/selector/shared.lua
@@ -72,7 +72,7 @@ function OxSelector:getRandomWeighted(setName)
 
     for i = 1, #set do
         cumulativeWeight = cumulativeWeight + set[i][1]
-        if randomWeight <= cumulativeWeight then
+        if randomWeight < cumulativeWeight then
             local item = set[i][2]
             return type(item) == "table" and deepClone(item) or item
         end


### PR DESCRIPTION
When a set contains an item with weight 0 followed by items with non-zero weight, getRandomWeighted can return the zero-weight item if math.random() returns exactly 0. The function uses randomWeight <= cumulativeWeight, which matches the boundary at 0 and falls into the zero-weight slot.

Changed the comparison to randomWeight < cumulativeWeight so a zero-weight item is never matched by the picker.

This is rare in practice, but unexpected behaviour nonetheless.


```lua
local s = lib.selector:new({ {0, 'never'}, {1, 'always'} })
s:getRandomWeighted()
```