### PR TITLE
fix(timer): getTimeLeft returns growing negative value while paused

### DIFF
--- a/imports/timer/shared.lua
+++ b/imports/timer/shared.lua
@@ -105,7 +105,9 @@ function timer:restart(async)
 end
 
 function timer:getTimeLeft(format)
-    local ms = self.private.currentTimeLeft - (GetGameTimer() - self.private.startTime)
+    local ms = self.private.paused
+        and self.private.currentTimeLeft
+        or self.private.currentTimeLeft - (GetGameTimer() - self.private.startTime)
 
     local roundedfloat = function(value)
         return tonumber(string.format('%.2f', value))


### PR DESCRIPTION
`timer:getTimeLeft` returns a steadily decreasing value while the timer is paused, eventually going negative, instead of holding at the snapshotted remainder.

`pause()` already stores the remaining time in `self.private.currentTimeLeft` and freezes the clock, but `getTimeLeft` unconditionally subtracts `GetGameTimer() - self.private.startTime` on every call. Since `startTime` is not updated during a pause, the subtracted delta keeps growing and the reported time-left keeps shrinking past zero.

### Reproduction

```lua
CreateThread(function()
    local t = lib.timer(5000, function() end, true)
    t:pause()

    for i = 1, 6 do
        Wait(1000)
        print(('paused for %ds, getTimeLeft = %.2fs'):format(i, t:getTimeLeft('s')))
    end
end)
```

Output before the fix:

```
paused for 1s, getTimeLeft = 4.00
paused for 2s, getTimeLeft = 3.00
paused for 3s, getTimeLeft = 2.00
paused for 4s, getTimeLeft = 1.00
paused for 5s, getTimeLeft = 0.00
paused for 6s, getTimeLeft = -1.00
```

After the fix every iteration prints ~5.00.

### Secondary impact

The negative return also breaks restart-from-paused. `restart()` calls `forceEnd(false)`, whose early return at `getTimeLeft <= 0` falsely fires once the value has crossed zero, so the run loop never releases and the timer stays dead.

```lua
CreateThread(function()
    local t = lib.timer(5000, function() print('fired') end, true)
    Wait(1000)
    t:pause()
    Wait(5000)   -- long enough that getTimeLeft has gone negative
    t:restart()
    Wait(6000)
    -- before fix: 'fired' never prints
    -- after fix:  prints once
end)
```