### PR TITLE
fix(settings): apply default when safeGetKvp's pcall fails

### DIFF
--- a/resource/settings.lua
+++ b/resource/settings.lua
@@ -13,7 +13,8 @@ local function safeGetKvp(fn, key, default)
     local ok, result = pcall(fn, key)
 
     if not ok then
-        return DeleteResourceKvp(key)
+        DeleteResourceKvp(key)
+        return default
     end
 
     return result or default


### PR DESCRIPTION
### Description

`safeGetKvp` is used in `resource/settings.lua` to load persisted settings on resource start. When the stored KVP value is the wrong type for the getter (e.g. an `int` getter called against a string-stored key), the native throws, the `pcall` catches it, and the cleanup path runs:

```lua
if not ok then
    return DeleteResourceKvp(key)
end
```

`DeleteResourceKvp` returns nothing, so the function returns `nil` instead of the supplied `default`.
