### PR TITLE
fix(array): reduce with reverse and no initial value skips index 1

### DIFF
--- a/imports/array/shared.lua
+++ b/imports/array/shared.lua
@@ -257,16 +257,20 @@ end
 ---@return T
 function lib.array:reduce(reducer, initialValue, reverse)
     local length = #self
-    local initialIndex = initialValue and 1 or 2
-    local accumulator = initialValue or self[1]
+    local accumulator, startIdx
 
     if reverse then
-        for i = initialIndex, length do
-            local index = length - i + initialIndex
-            accumulator = reducer(accumulator, self[index], index)
+        accumulator = initialValue or self[length]
+        startIdx = initialValue and length or length - 1
+
+        for i = startIdx, 1, -1 do
+            accumulator = reducer(accumulator, self[i], i)
         end
     else
-        for i = initialIndex, length do
+        accumulator = initialValue or self[1]
+        startIdx = initialValue and 1 or 2
+
+        for i = startIdx, length do
             accumulator = reducer(accumulator, self[i], i)
         end
     end


### PR DESCRIPTION
### Description

`lib.array:reduce` accepts a third `reverse` argument that flips iteration direction (modeled on JavaScript's `Array.prototype.reduceRight`). When `reverse=true` and no `initialValue` is provided, the function seeds the accumulator from `self[1]` and walks indices `length..2`, so index 1 is never visited. Instead, its value gets stuffed into the accumulator slot instead of being folded over.

The reverse case is currently undocumented, but the code path exists, runs, and returns a wrong result on its own terms.

For commutative reducers (sum, product, max) the bug is invisible because order doesn't matter and the missing element still ends up in the accumulator. For non-commutative reducers (subtraction, division, string concat, building tables where later writes win) the result is silently wrong.

### Reproduction

```lua
local arr = lib.array:new(1, 2, 3, 4)

-- forward, no initial: ((1 - 2) - 3) - 4 = -8 (correct)
print(arr:reduce(function(a, x) return a - x end))

-- reverse, no initial: expected ((4 - 3) - 2) - 1 = -2
-- before fix:                   ((1 - 4) - 3) - 2 = -8
-- after fix:                    -2
print(arr:reduce(function(a, x) return a - x end, nil, true))
```

Cross-check against JS:

```js
[1, 2, 3, 4].reduceRight((a, x) => a - x)  // -2
```

### Fix

Branch the accumulator and start index on `reverse` so each direction seeds from the correct end and walks the remaining elements once:

```lua
if reverse then
    accumulator = initialValue or self[length]
    startIdx = initialValue and length or length - 1

    for i = startIdx, 1, -1 do
        accumulator = reducer(accumulator, self[i], i)
    end
else
    accumulator = initialValue or self[1]
    startIdx = initialValue and 1 or 2

    for i = startIdx, length do
        accumulator = reducer(accumulator, self[i], i)
    end
end
```

This also drops the `length - i + initialIndex` index arithmetic in favor of a plain reverse `for` loop.

### Behavior matrix

For `arr = {1, 2, 3, 4}` with subtraction:

| reverse | initialValue | walks | result |
| --- | --- | --- | --- |
| false | none | 2,3,4 | -8 |
| false | 10 | 1,2,3,4 | 0 |
| true | none | 3,2,1 | -2 |
| true | 10 | 4,3,2,1 | 0 |
