### PR TITLE
feat(locale): support nested key references in phrase interpolation

### DIFF
--- a/imports/locale/shared.lua
+++ b/imports/locale/shared.lua
@@ -71,10 +71,12 @@ function lib.locale(key)
 
     table.wipe(dict)
 
-    for k, v in pairs(flattenDict(locales, {})) do
+    local flat = flattenDict(locales, {})
+
+    for k, v in pairs(flat) do
         if type(v) == 'string' then
             for var in v:gmatch('${[%w%s%p]-}') do
-                local locale = locales[var:sub(3, -2)]
+                local locale = flat[var:sub(3, -2)]
 
                 if locale then
                     locale = locale:gsub('%%', '%%%%')


### PR DESCRIPTION
### Description

Locale files can already contain nested objects, and `locale('parent.child')` resolves them correctly because `flattenDict` runs at load time. Phrase interpolation with `${...}` is the only place this breaks down: the resolver looks names up in the un-flattened nested table, so `${parent.child}` silently fails to substitute even though the same key is reachable via a direct `locale()` call.

```lua
for k, v in pairs(flattenDict(locales, {})) do        -- iterates flat keys
    if type(v) == 'string' then
        for var in v:gmatch('${[%w%s%p]-}') do
            local locale = locales[var:sub(3, -2)]    -- looks up un-flattened tree
```

This patch threads the already-flattened dict through the resolver so both lookup paths behave the same. Top-level references keep working; nested references start working as a side effect.

### Example

`locales/en.json`:
```json
{
  "greeting": "Hello",
  "user": { "name": "Kenshin13" },
  "msg": "${greeting}, ${user.name}!"
}
```

```lua
print(locale('msg'))
-- before: Hello, ${user.name}!
-- after:  Hello, Kenshin13!
```