### PR TITLE
fix(dialog/slider): use nullish coalescing so max=0 mark renders correctly

### DIFF
--- a/web/src/features/dialog/components/fields/slider.tsx
+++ b/web/src/features/dialog/components/fields/slider.tsx
@@ -13,7 +13,7 @@ const SliderField: React.FC<Props> = (props) => {
   const controller = useController({
     name: `test.${props.index}.value`,
     control: props.control,
-    defaultValue: props.row.default || props.row.min || 0,
+    defaultValue: props.row.default ?? props.row.min ?? 0,
   });
 
   return (
@@ -26,14 +26,14 @@ const SliderField: React.FC<Props> = (props) => {
         ref={controller.field.ref}
         onBlur={controller.field.onBlur}
         onChange={controller.field.onChange}
-        defaultValue={props.row.default || props.row.min || 0}
+        defaultValue={props.row.default ?? props.row.min ?? 0}
         min={props.row.min}
         max={props.row.max}
         step={props.row.step}
         disabled={props.row.disabled}
         marks={[
-          { value: props.row.min || 0, label: props.row.min || 0 },
-          { value: props.row.max || 100, label: props.row.max || 100 },
+          { value: props.row.min ?? 0, label: props.row.min ?? 0 },
+          { value: props.row.max ?? 100, label: props.row.max ?? 100 },
         ]}
       />
     </Box>


### PR DESCRIPTION
### Description

`SliderField`'s `marks` array uses `||` to fall back from `min`/`max` to display defaults. Since `0` is falsy in JavaScript, a slider configured with `max = 0` (negative-range slider) renders a right-hand mark labelled `100` instead of `0`.

```ts
marks={[
    { value: props.row.min || 0, label: props.row.min || 0 },
    { value: props.row.max || 100, label: props.row.max || 100 },
]}
```

The same `||` chain appears on the `useController` default value and the `<Slider defaultValue>` prop. Those don't currently produce a user-visible bug because `InputDialog` pre-populates the form with `value: row.default` directly before the field renders, so by the time the Slider draws, `controller.field.value` is already correct and `defaultValue` is shadowed. Switching them to `??` is defense in depth. If the form-init path ever changes, the field would silently fall back to the wrong default.

### Reproduction

```lua
RegisterCommand('testslider', function()
    lib.inputDialog('Slider field test', {
        {
            type = 'slider',
            label = 'default=-5, min=-10, max=0  (before fix: right mark shows "100")',
            default = -5,
            min = -10,
            max = 0,
        },
        {
            type = 'slider',
            label = 'default=5, min=0, max=10  (regression check)',
            default = 5,
            min = 0,
            max = 10,
        },
    })
end, false)
```

Run `/testslider` in-game.

**Before the fix:** the negative-range slider's right mark reads `100`.
**After the fix:** it reads `0`. The regression-check slider is unchanged in both versions.