### PR TITLE
feat(cron): match days on the wrapped side of weekday ranges

### DIFF
--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -210,6 +210,10 @@ local function getTimeUnit(value, unit)
                 return min + unitMax
             end
 
+            if max > unitMax and currentTime + unitMax <= max then
+                return currentTime
+            end
+
             return currentTime < min and min or currentTime
         end
 


### PR DESCRIPTION
### Description

`parseCron` already handles wrap-around weekday ranges by adding 7 to the end when the parsed `stop` is less than `start`:

```lua
if stop < start then stop = stop + 7 end
return ('%d-%d'):format(start, stop)
```

So `sat-sun` becomes the internal range `"7-8"` (Sun encoded as `1 + 7`), and `fri-mon` becomes `"6-9"`. That branch only exists to deliberately support wrap-around.

`getTimeUnit` then matches the parsed range against `currentDate.wday`, which is always `1..7`. The matcher does literal numeric comparisons and never inflates today's `wday` to check the wrapped equivalent, so any day on the wrapped side never compares equal:

```lua
return currentTime < min and min or currentTime
```

For `"7-8"` on Sunday (`currentTime = 1`):
- `1 > 8` is false, skip the past-the-range branch
- `1 < 7` is true → return `7`

Then `getNextTime` checks `weekday ~= currentDate.wday` (`7 ~= 1`) and silently skips the day. The parser inflates the wrapped end but the matcher never inflates `currentTime`, so the feature the parser was clearly built for never actually fires.

### Net effect

- `sat-sun` fires Saturday only — Sunday is dropped.
- `fri-mon` fires only Fri/Sat — Sun and Mon are dropped.
- `mon-sun` (parser turns into `"2-8"`, intuitively "every day") loses Sunday.
- Any range crossing the Sunday boundary loses every day on the wrapped side.

### Reproduction

```lua
local function rangeMatcher(value, unit, currentTime)
    local min, max = value:match('(%d+)-(%d+)')
    min, max = tonumber(min), tonumber(max)
    local unitMax = (unit == 'wday') and 7 or 60

    if unit == 'min' then
        if currentTime >= max then return min + unitMax end
    elseif currentTime > max then
        return min + unitMax
    end

    return currentTime < min and min or currentTime
end

-- pre-fix:
print(rangeMatcher('7-8', 'wday', 1))  -- 7  (Sun returns Sat → won't match)
-- post-fix should be:
print(1)                                -- 1  (Sun returns itself → matches)
```

### Fix

Add a single branch in `getTimeUnit` that detects the wrap-around case and returns `currentTime` so the downstream equality check succeeds:

```lua
if max > unitMax and currentTime + unitMax <= max then
    return currentTime
end
```

`max > unitMax` is the signal that the parser inflated the end (i.e. wrap-around range). `currentTime + unitMax` is today's wraparound-equivalent value. If it's inside the range, today is a match.

### Why this is additive

Non-wrap ranges have `max <= unitMax` (e.g. `mon-fri` is `"2-6"`, max=6 ≤ 7) and skip the new branch entirely. Every existing case routes through the unchanged fall-through. The patch only changes behavior for ranges where `parseCron` deliberately set `max > unitMax`, i.e. exactly the wrap-around case it was built to support.
