### PR TITLE
fix(errorBoundary): stop resetting hasError in componentDidCatch

### DIFF
--- a/web/src/providers/errorBoundary.tsx
+++ b/web/src/providers/errorBoundary.tsx
@@ -12,7 +12,6 @@ class ErrorBoundary extends Component<{ children: ReactNode }, { hasError: boole
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error(error, info)
-    this.setState({ hasError: false });
   }
 
   render() {


### PR DESCRIPTION
### Description

`ErrorBoundary` is supposed to catch a thrown render error, swap the broken subtree for a `null` fallback, and stay there. The current implementation does the swap but then immediately undoes it:

```ts
static getDerivedStateFromError(err: Error) {
    return { hasError: true };
}

componentDidCatch(error: Error, info: ErrorInfo) {
    console.error(error, info)
    this.setState({ hasError: false });   // ← undoes the boundary
}
```

After `getDerivedStateFromError` flips state to `{ hasError: true }` and the broken subtree is replaced with `null`, `componentDidCatch` runs in the commit phase and sets state back to `{ hasError: false }`. React re-renders, mounts `this.props.children` again, the same component throws on its next render, and the cycle repeats. Each iteration takes a single frame; eventually React aborts with [error #185](https://reactjs.org/docs/error-decoder.html?invariant=185) ("Maximum update depth exceeded"), but only after burning a lot of CPU and spamming the console.

### Reproduction

Drop a throwing component anywhere inside the boundary:

```tsx
const Boom: React.FC = () => { throw new Error('boom'); };
// render <Boom /> as a child of the existing <ErrorBoundary> in main.tsx
```

**Before**
```
Error: boom (...js:40)
Error: boom [object Object] (...js:854)
Error: boom (...js:40)
Error: boom [object Object] (...js:854)
... ~50 more pairs across ~80ms ...
Error: Minified React error #185; visit https://reactjs.org/docs/error-decoder.html?invariant=185
```

**After**
```
Error: boom (...js:40)
Error: boom [object Object] (...js:854)
```

Two log lines, fired once. The first comes from React's built-in uncaught-error reporter; the second is `console.error(error, info)` inside `componentDidCatch`. Both fire on the single mount/throw cycle and then the boundary stays in `hasError: true`, rendering `null` for the broken subtree.

### Fix

Remove the `setState` from `componentDidCatch`. The catch handler should only do side-effects (logging, telemetry); the state transition is `getDerivedStateFromError`'s job, and `componentDidCatch` shouldn't reverse it.

```diff
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error(error, info)
-    this.setState({ hasError: false });
   }
```