### PR TITLE
fix(addCommand): build a fresh suggestion table instead of mutating properties

### DIFF
--- a/imports/addCommand/server.lua
+++ b/imports/addCommand/server.lua
@@ -77,6 +77,33 @@ local function parseArguments(source, args, raw, params)
     return args
 end
 
+---@param commandName string
+---@param properties OxCommandProperties
+---@return OxCommandProperties
+local function buildSuggestion(commandName, properties)
+    local hints
+
+    if properties.params then
+        hints = {}
+
+        for i = 1, #properties.params do
+            local param = properties.params[i]
+            hints[i] = {
+                name = param.name,
+                help = param.type
+                    and (param.help and ('%s (type: %s)'):format(param.help, param.type) or ('(type: %s)'):format(param.type))
+                    or param.help,
+            }
+        end
+    end
+
+    return {
+        name = ('/%s'):format(commandName),
+        help = properties.help,
+        params = hints,
+    }
+end
+
 ---@param commandName string | string[]
 ---@param properties OxCommandProperties | false
 ---@param cb fun(source: number, args: table, raw: string)
@@ -97,16 +124,6 @@ function lib.addCommand(commandName, properties, cb, ...)
 
         restricted = properties.restricted
         params = properties.params
-    end
-
-    if params then
-        for i = 1, #params do
-            local param = params[i]
-
-            if param.type then
-                param.help = param.help and ('%s (type: %s)'):format(param.help, param.type) or ('(type: %s)'):format(param.type)
-            end
-        end
     end
 
     local commands = type(commandName) ~= 'table' and { commandName } or commandName
@@ -147,16 +164,10 @@ function lib.addCommand(commandName, properties, cb, ...)
         end
 
         if properties then
-            ---@diagnostic disable-next-line: inject-field
-            properties.name = ('/%s'):format(commandName)
-            properties.restricted = nil
-            registeredCommands[totalCommands] = properties
+            local suggestion = buildSuggestion(commandName, properties)
+            registeredCommands[totalCommands] = suggestion
 
-            if i ~= numCommands and numCommands ~= 1 then
-                properties = table.clone(properties)
-            end
-
-            if shouldSendCommands then TriggerClientEvent('chat:addSuggestions', -1, properties) end
+            if shouldSendCommands then TriggerClientEvent('chat:addSuggestions', -1, suggestion) end
         end
     end
 end


### PR DESCRIPTION
### Description

`lib.addCommand` mutates the `properties` table the caller passes in. **This mutation is undocumented**. Neither the function signature, the type annotations, nor any docs page indicates that the input table will be written to. Callers reasonably assume their config object is read-only after the call. **As a result, sharing a single `properties` table across multiple `addCommand` calls  (the natural pattern for "all admin commands use the same ACL gate and arg list") silently leaves every command after the first unrestricted, with no warning.**

The mutations:

```lua
-- appended to each param's help, in place
param.help = param.help and ('%s (type: %s)'):format(param.help, param.type) or ('(type: %s)'):format(param.type)

-- inside the registration loop
properties.name = ('/%s'):format(commandName)
properties.restricted = nil
```

What goes wrong on a shared config:

- The first call extracts `properties.restricted`, registers the ACE, then nils the field on the shared table.
- Every subsequent call reads `properties.restricted` as `nil`, treats the command as unrestricted, and registers it without an ACE gate. **Anyone can invoke it.**
- The `params[i].help` mutation also stacks: each call appends `(type: %s)` to the same shared param's help, so `'Player to act on'` becomes `'Player to act on (type: playerId)'`, then `'... (type: playerId) (type: playerId)'`, etc., visible in chat suggestions.

There's nothing in the type annotations or docs that hints at this. `OxCommandProperties` is annotated as a plain input record. A caller has no way of knowing they need to defensively clone before each call.

### Reproduction

```lua
local adminCmd = {
    restricted = 'group.admin',
    params = {
        { name = 'target', type = 'playerId', help = 'Player to act on' },
    },
}

lib.addCommand('kick', adminCmd, function(source, args)
    DropPlayer(args.target --[[@as string]], 'kicked')
end)

lib.addCommand('ban', adminCmd, function(source, args)
    DropPlayer(args.target --[[@as string]], 'banned')
end)

print('restricted:', adminCmd.restricted)
print('param help:', adminCmd.params[1].help)
```

Before the fix:
```
restricted: nil
param help: Player to act on (type: playerId) (type: playerId)
```

In-game, connecting as a non-admin: `/kick` is correctly denied (the first call's ACE registration ran before the mutation), but `/ban` runs through and drops the targeted player.

After the fix:
```
restricted: group.admin
param help: Player to act on
```

Both `/kick` and `/ban` are gated to `group.admin`. Chat suggestions show the expected single-`(type:)` hint.

### Fix

Stop mutating `properties` at all. The mutations existed because `properties` was being repurposed as the chat-suggestion payload, with each step (append type hints, prepend `/`, strip `restricted`) transforming the input shape into the broadcast shape in place.

This patch separates those roles: `properties` is now read-only from `addCommand`'s perspective; a fresh `suggestion` table is built per command and pushed to the broadcast list.

```lua
local function buildSuggestion(commandName, properties)
    local hints

    if properties.params then
        hints = {}

        for i = 1, #properties.params do
            local param = properties.params[i]
            hints[i] = {
                name = param.name,
                help = param.type
                    and (param.help and ('%s (type: %s)'):format(param.help, param.type) or ('(type: %s)'):format(param.type))
                    or param.help,
            }
        end
    end

    return {
        name = ('/%s'):format(commandName),
        help = properties.help,
        params = hints,
    }
end
```

The registration loop now does:

```lua
if properties then
    local suggestion = buildSuggestion(commandName, properties)
    registeredCommands[totalCommands] = suggestion

    if shouldSendCommands then TriggerClientEvent('chat:addSuggestions', -1, suggestion) end
end
```

The `restricted` field is read once at the top of `addCommand` and never written back; the suggestion table doesn't include it (clients don't need ACL info anyway). The inner `if i ~= numCommands and numCommands ~= 1 then properties = table.clone(properties) end` is gone as it existed only to give each multi-alias suggestion its own copy, which is now naturally the case since each iteration builds its own.
