### PR TITLE
fix(callback): scope register's event to local instead of leaking to _G

### DIFF
--- a/imports/callback/client.lua
+++ b/imports/callback/client.lua
@@ -133,7 +133,7 @@ local pcall = pcall
 ---Registers an event handler and callback function to respond to server requests.
 ---@diagnostic disable-next-line: duplicate-set-field
 function lib.callback.register(name, cb)
-    event = cbEvent:format(name)
+    local event = cbEvent:format(name)
 
     lib.setValidCallback(name, true)
 

--- a/imports/callback/server.lua
+++ b/imports/callback/server.lua
@@ -114,7 +114,7 @@ local pcall = pcall
 ---Registers an event handler and callback function to respond to client requests.
 ---@diagnostic disable-next-line: duplicate-set-field
 function lib.callback.register(name, cb)
-    event = cbEvent:format(name)
+    local event = cbEvent:format(name)
 
     lib.setValidCallback(name, true)
 


### PR DESCRIPTION
### Description

`lib.callback.register` builds an event name and stores it in a variable named `event`, but the variable is missing the `local` keyword. In Lua, an assignment without `local` writes to the global namespace, so every call to `lib.callback.register` clobbers `_G.event` in the calling resource:

```lua
function lib.callback.register(name, cb)
    event = cbEvent:format(name)        -- writes to _G.event
    lib.setValidCallback(name, true)
    RegisterNetEvent(event, function(...) ... end)
end
```

Each resource using ox_lib loads its own copy of `imports/callback/*.lua` into its own Lua state (per `resource/init.lua`'s lazy loader), so the leak is into the **calling resource's** globals, not ox_lib's. Any user code that uses `event` as a variable name has it overwritten the moment it calls `lib.callback.register`.

### Reproduction

```lua
-- in any resource using ox_lib
event = 'my-resource-event'
print('before:', event)               -- my-resource-event

lib.callback.register('do_thing', function(source)
    return true
end)

print('after:',  event)               -- __ox_cb_do_thing
```

If the resource later does `TriggerEvent(event)` expecting `'my-resource-event'`, it now fires `'__ox_cb_do_thing'` — a callback channel it didn't intend to invoke. `event` is a fairly common variable name in event-driven code, so the collision isn't theoretical.

### Fix

Add `local` to both register functions:

```diff
 function lib.callback.register(name, cb)
-    event = cbEvent:format(name)
+    local event = cbEvent:format(name)
```

