### PR TITLE
fix(cron): propagate minute/hour rollover past explicit upper units

### DIFF
--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -270,17 +270,31 @@ function OxTask:getNextTime()
     if not hour then return end
 
     if minute >= maxUnits.min then
-        if not self.hour then
-            hour += math.floor(minute / maxUnits.min)
-        end
+        local carry = math.floor(minute / maxUnits.min)
         minute = minute % maxUnits.min
+
+        if not self.hour then
+            hour += carry
+        elseif not self.day then
+            day += carry
+        elseif not self.month then
+            month += carry
+        else
+            month += 12 * carry
+        end
     end
 
     if hour >= maxUnits.hour and day then
-        if not self.day then
-            day += math.floor(hour / maxUnits.hour)
-        end
+        local carry = math.floor(hour / maxUnits.hour)
         hour = hour % maxUnits.hour
+
+        if not self.day then
+            day += carry
+        elseif not self.month then
+            month += carry
+        else
+            month += 12 * carry
+        end
     end
 
     local nextTime = os.time({


### PR DESCRIPTION
### Description

`OxTask:getNextTime` advances the scheduled time field by field. When the minute spec rolls over (e.g. `*/15` past minute 45 returns 60), the rollover code is supposed to bump the hour:

```lua
if minute >= maxUnits.min then
    if not self.hour then
        hour += math.floor(minute / maxUnits.min)
    end
    minute = minute % maxUnits.min
end
```

The `if not self.hour` guard is there so we don't clobber a user-pinned hour, but it has no else branch. If the user pinned an hour, the carry just disappears, and `minute = minute % 60` puts the time at today's already-past fire window. `scheduleTask` sees a negative sleep and calls `self:stop`. The task is dead until the resource restarts. Same shape on the hour-rollover block below.

### Practical effect

Any cron with a fixed hour fires at most once per resource start, then dies:

* `0 0 * * *` (daily midnight cleanup): fires today at midnight, dies, never fires again.
* `30 9 * * *` (daily 9:30 report): same.
* `*/15 5 * * *` (every 15 min during 5am hour): runs through the window once on registration day, dies at 5:45.
* `* 5 * * *` (every minute during hour 5): fires 60 times today, dies at 5:59.

This is masked on most servers because they restart at least daily, so the cron fires once per restart and people assume it's working. Servers that run uninterrupted lose every scheduled task after the first day.

### Reproduction

Pure-logic harness mirroring `getTimeUnit` and the rollover from `getNextTime`.

```lua
local maxUnits = { min = 60, hour = 24, day = 31, month = 12, wday = 7 }

local function getTimeUnit(value, unit, currentTime)
    if not value then return unit == 'min' and currentTime + 1 or currentTime end
    local unitMax = maxUnits[unit]
    if type(value) == 'number' then
        if unit == 'min' then return value <= currentTime and value + unitMax or value end
        return value < currentTime and value + unitMax or value
    end
    local step = value:match('^%*/(%d+)$')
    if step then
        local s = tonumber(step)
        for i = currentTime + 1, unitMax do if i % s == 0 then return i end end
        return s + unitMax
    end
    local lo, hi = value:match('^(%d+)-(%d+)$')
    if lo then
        local mn, mx = tonumber(lo), tonumber(hi)
        if unit == 'min' then if currentTime >= mx then return mn + unitMax end
        else if currentTime > mx then return mn + unitMax end end
        return currentTime < mn and mn or currentTime
    end
    if value:match('%d+,%d+') then
        local vals = {}
        for v in value:gmatch('%d+') do vals[#vals + 1] = tonumber(v) end
        table.sort(vals)
        for _, v in ipairs(vals) do
            if unit == 'min' then if currentTime < v then return v end
            else if currentTime <= v then return v end end
        end
        return vals[1] + unitMax
    end
end

local function rollover(self, minute, hour, day)
    if minute >= maxUnits.min then
        if not self.hour then hour = hour + math.floor(minute / maxUnits.min) end
        minute = minute % maxUnits.min
    end
    if hour >= maxUnits.hour and day then
        if not self.day then day = day + math.floor(hour / maxUnits.hour) end
        hour = hour % maxUnits.hour
    end
    return minute, hour, day
end

local cases = {
    { expr = '0 0 * * *',     self = { minute = 0,       hour = 0  }, fakeMin = 30 },
    { expr = '30-40 5 * * *', self = { minute = '30-40', hour = 5  }, fakeMin = 42 },
    { expr = '*/15 5 * * *',  self = { minute = '*/15',  hour = 5  }, fakeMin = 46 },
    { expr = '0,30 12 * * *', self = { minute = '0,30',  hour = 12 }, fakeMin = 35 },
    { expr = '* 5 * * *',     self = { minute = nil,     hour = 5  }, fakeMin = 59 },
}

local d = os.date('*t')
for _, c in ipairs(cases) do
    local fakeNow = os.time({ year = d.year, month = d.month, day = d.day, hour = c.self.hour, min = c.fakeMin })
    local minute  = getTimeUnit(c.self.minute, 'min', c.fakeMin)
    local hour    = getTimeUnit(c.self.hour, 'hour', c.self.hour)
    local day     = d.day
    minute, hour, day = rollover(c.self, minute, hour, day)
    local nextTime = os.time({ min = minute, hour = hour, day = day, month = d.month, year = d.year })
    local sleep = nextTime - fakeNow
    print(('cron `%s`: now=%s next=%s sleep=%ds'):format(c.expr, os.date('%H:%M', fakeNow), os.date('%c', nextTime), sleep))
end
```

Pre-fix output, every row has negative sleep so `scheduleTask` stops the task:

```
cron `0 0 * * *`:     now=00:30 next=Sun May  3 00:00:00 2026 sleep=-1800s
cron `30-40 5 * * *`: now=05:42 next=Sun May  3 05:30:00 2026 sleep=-720s
cron `*/15 5 * * *`:  now=05:46 next=Sun May  3 05:00:00 2026 sleep=-2760s
cron `0,30 12 * * *`: now=12:35 next=Sun May  3 12:00:00 2026 sleep=-2100s
cron `* 5 * * *`:     now=05:59 next=Sun May  3 05:00:00 2026 sleep=-3540s
```

Swap `rollover` for the post-fix version (below), re-run, every sleep flips positive and lands on the correct next-day fire time.

### Fix

Propagate the carry up through any chain of explicit units instead of dropping it. If the user pinned hour, push into day. If day is also pinned, push into month. If month is also pinned, push `12 * carry` into month and let `os.time` normalize that into the next year.

```lua
if minute >= maxUnits.min then
    local carry = math.floor(minute / maxUnits.min)
    minute = minute % maxUnits.min

    if not self.hour then
        hour += carry
    elseif not self.day then
        day += carry
    elseif not self.month then
        month += carry
    else
        month += 12 * carry
    end
end

if hour >= maxUnits.hour and day then
    local carry = math.floor(hour / maxUnits.hour)
    hour = hour % maxUnits.hour

    if not self.day then
        day += carry
    elseif not self.month then
        month += carry
    else
        month += 12 * carry
    end
end
```

`os.time` already normalizes out-of-range `day` and `month` (`day = 32` becomes the first of next month, `month = 18` becomes June of next year), so each branch only needs to bump the next non-pinned unit; the existing `os.time` call at the end of `getNextTime` does the rest.

Existing behavior, where `not self.hour` or `not self.day` was already true, takes the same first branches as before. The new branches only run when the carry would have been silently dropped, which is the case the function previously gave up on.

### Edge cases checked

| expression          | simulated now    | pre-fix | post-fix             |
| ------------------- | ---------------- | ------- | -------------------- |
| `0 0 * * *`         | 0:30             | dies    | tomorrow 00:00       |
| `30-40 5 * * *`     | 5:42             | dies    | tomorrow 05:30       |
| `*/15 5 * * *`      | 5:46             | dies    | tomorrow 05:00       |
| `0,30 12 * * *`     | 12:35            | dies    | tomorrow 12:00       |
| `* 5 * * *`         | 5:59             | dies    | tomorrow 05:00       |
| `* 8,16 * * *`      | 17:00            | works   | unchanged            |
| `0 0 15 * *`        | 0:30 on 15th     | dies    | next month 15, 00:00 |
| `0 0 15 6 *`        | 0:30 on June 15  | dies    | next year June 15    |
