### PR TITLE
feat(array): support negative indices in :fill to match :at and :slice

### DIFF
--- a/imports/array/shared.lua
+++ b/imports/array/shared.lua
@@ -113,6 +113,8 @@ function lib.array:fill(value, start, endIndex)
     start = start or 1
     endIndex = endIndex or length
 
+    if start < 0 then start = length + start + 1 end
+    if endIndex < 0 then endIndex = length + endIndex + 1 end
     if start < 1 then start = 1 end
     if endIndex > length then endIndex = length end
 


### PR DESCRIPTION
### Description

`lib.array:at` and `lib.array:slice` already accept negative indices as length-relative offsets:

```lua
lib.array:new(1,2,3,4,5):at(-1)              -- 5
lib.array:new(1,2,3,4,5):slice(-2):pop()     -- 5
```

`lib.array:fill` is the only method on the same class that doesn't. Negative `start` is silently rewritten to `1`:

```lua
function lib.array:fill(value, start, endIndex)
    local length = #self
    start = start or 1
    endIndex = endIndex or length

    if start < 1 then start = 1 end
    if endIndex > length then endIndex = length end
    ...
```

Effect: there's no way to express "fill from N before the end" without computing the offset by hand. `arr:fill(0, -2)` doesn't fill the last two elements, it overwrites the entire array because `-2 < 1` triggers the clamp.

### Reproduction

```lua
local arr = lib.array:new(1, 2, 3, 4, 5)

-- expected: only the last two elements zeroed (matches arr:slice(-2)'s range)
arr:fill(0, -2)

print(table.concat(arr, ','))
-- before fix: 0,0,0,0,0   (negative clamped to 1, entire array overwritten)
-- after fix:  1,2,3,0,0   (last two elements, same range :slice would touch)
```

### Fix

Mirror the negative-index handling from `lib.array:slice`:

```diff
 function lib.array:fill(value, start, endIndex)
     local length = #self
     start = start or 1
     endIndex = endIndex or length

+    if start < 0 then start = length + start + 1 end
+    if endIndex < 0 then endIndex = length + endIndex + 1 end
     if start < 1 then start = 1 end
     if endIndex > length then endIndex = length end

     for i = start, endIndex do
         self[i] = value
     end

     return self
end
```

Two added lines. They run before the existing `< 1` clamp, so any input that maps below `1` (e.g. `-100` on a 5-element array) still clamps to `1`. Positive inputs and `nil` are unaffected.

### Internal consistency

After the patch, `:fill` and `:slice` operate on the same range when given the same `(start, endIndex)` arguments:

```lua
arr = lib.array:new(1, 2, 3, 4, 5)
print(table.concat(arr:slice(-3, -2), ','))   -- "3,4"  (positions 3..4 inclusive)

arr = lib.array:new(1, 2, 3, 4, 5)
arr:fill(0, -3, -2)
print(table.concat(arr, ','))                 -- "1,2,0,0,5"  (positions 3..4 zeroed)
```

The class uses Lua-style inclusive end ranges, so the resulting positions match `:slice`'s output. `:fill` was the only sibling that didn't follow that convention for negative inputs.

### Behavior matrix

For `arr = lib.array:new(1, 2, 3, 4, 5)`:

| call                  | pre-fix         | post-fix        |
| --------------------- | --------------- | --------------- |
| `arr:fill(0)`         | `{0,0,0,0,0}`   | `{0,0,0,0,0}`   |
| `arr:fill(0, 2)`      | `{1,0,0,0,0}`   | `{1,0,0,0,0}`   |
| `arr:fill(0, 1, 3)`   | `{0,0,0,4,5}`   | `{0,0,0,4,5}`   |
| `arr:fill(0, -2)`     | `{0,0,0,0,0}`   | `{1,2,3,0,0}`   |
| `arr:fill(0, -10)`    | `{0,0,0,0,0}`   | `{0,0,0,0,0}`   |
| `arr:fill(0, 1, -2)`  | `{0,0,0,0,5}`   | `{0,0,0,0,5}`   |
| `arr:fill(0, 10)`     | `{1,2,3,4,5}`   | `{1,2,3,4,5}`   |

Only inputs with negative `start` or `endIndex` produce different output. Every call that previously worked produces the same result.

### Note on JS equivalence

The lib's `Array` class is JS-named but uses Lua-inclusive range semantics for `:slice` and `:fill`, so it's not a drop-in for JS `Array.prototype` for negative-end ranges. That's a pre-existing convention of the class, not introduced or changed by this patch. Anyone who needs strict JS semantics would need to translate `endIndex` themselves (or `:slice` would need to change too, which is a separate, larger discussion).
