### PR TITLE
fix(class): close anonymous-function bypass of private field gate

### DIFF
--- a/imports/class/shared.lua
+++ b/imports/class/shared.lua
@@ -85,20 +85,27 @@ function mixins.new(class, ...)
         private = table.clone(obj.private)
 
         table.wipe(obj.private)
+
+        local function calledFromMethod()
+            local level = 3
+            while true do
+                local di = getinfo(level, 'n')
+                if not di then return false end
+                if di.namewhat == 'method' then return true end
+                level += 1
+            end
+        end
+
         setmetatable(obj.private, {
             __metatable = 'private',
             __tostring = void,
             __index = function(self, index)
-                local di = getinfo(2, 'n')
-
-                if di.namewhat ~= 'method' and di.namewhat ~= '' then return end
+                if not calledFromMethod() then return end
 
                 return private[index]
             end,
             __newindex = function(self, index, value)
-                local di = getinfo(2, 'n')
-
-                if di.namewhat ~= 'method' and di.namewhat ~= '' then
+                if not calledFromMethod() then
                     error(("cannot set value of private field '%s'"):format(index), 2)
                 end
 


### PR DESCRIPTION
### Description

`OxClass` instances expose a `private` table whose metatable is supposed to allow reads and writes only from the class's own methods. The implementation gates access by checking `debug.getinfo(2, 'n').namewhat` of the immediate caller:

```lua
__index = function(self, index)
    local di = getinfo(2, 'n')
    if di.namewhat ~= 'method' and di.namewhat ~= '' then return end
    return private[index]
end,
__newindex = function(self, index, value)
    local di = getinfo(2, 'n')
    if di.namewhat ~= 'method' and di.namewhat ~= '' then
        error(("cannot set value of private field '%s'"):format(index), 2)
    end
    private[index] = value
end
```

The intended allowance was `'method'`. The `''` clause was added to handle internal cases where the caller's namewhat is empty, but it has the side effect of also allowing every anonymous function, every function called via `pcall`, every C-function intermediary, and the main chunk. Three keystrokes wrap any access in an anonymous function and bypass the gate entirely.

### Reproduction

```lua
local Test = lib.class('Test')

function Test:constructor()
    self.private.secret = 42
end

function Test:getSecret()
    return self.private.secret
end

local obj = Test:new()

-- Method access (intended): allowed
print(obj:getSecret())                                              -- 42

-- Global function: namewhat='global', denied
function steal()
    return obj.private.secret
end
print(steal())                                                      -- nil

-- Anonymous IIFE: namewhat='', allowed (bypass)
print((function() return obj.private.secret end)())                 -- 42

-- pcall: same path, allowed (bypass)
print((select(2, pcall(function() return obj.private.secret end)))) -- 42

-- Anonymous write also bypasses
;(function() obj.private.secret = 'pwned' end)()
print(obj:getSecret())                                              -- pwned
```

Any code that puts invariant-bearing state in `self.private` is wrong about its access control. The anonymous-function pattern is trivially constructable, and `pcall`-wrapping covers the slightly less ergonomic case where someone wants to silence errors from the access.

### Fix

Replace the immediate-caller `namewhat` check with a stack walk that allows access if any frame in the call chain is a method. This blocks the external bypasses (anonymous IIFE, pcall, global/local/upvalue access) while keeping legitimate intra-method patterns working. Most importantly `pcall(function() self.private.x = ... end)` inside a method body, which is a normal way to wrap setup code.

```lua
local function calledFromMethod()
    local level = 3
    while true do
        local di = getinfo(level, 'n')
        if not di then return false end
        if di.namewhat == 'method' then return true end
        level += 1
    end
end

setmetatable(obj.private, {
    __metatable = 'private',
    __tostring = void,
    __index = function(self, index)
        if not calledFromMethod() then return end
        return private[index]
    end,
    __newindex = function(self, index, value)
        if not calledFromMethod() then
            error(("cannot set value of private field '%s'"):format(index), 2)
        end
        private[index] = value
    end
})
```

The walk starts at level 3 (caller of `__index`/`__newindex`'s caller, since the helper adds one frame). Each iteration:

- Returns `true` if the current frame is a method.
- Returns `false` if there's no frame at this level (stack ran out without finding a method).
- Continues walking otherwise.

### Behavior matrix

| caller pattern                                                | pre-fix       | post-fix     |
| ------------------------------------------------------------- | ------------- | ------------ |
| `obj:method()` reading `self.private.x`                        | allowed       | allowed      |
| Method calling `pcall(function() self.private.x = 1 end)`      | allowed       | allowed      |
| Method calling an anonymous local helper that touches private  | allowed       | allowed      |
| Global function `function steal() return obj.private.x end`    | denied        | denied       |
| Local function `local function steal() ... end`                | denied        | denied       |
| `(function() return obj.private.x end)()` from outside         | **allowed**   | denied       |
| `pcall(function() return obj.private.x end)` from outside      | **allowed**   | denied       |

The two rows that change are the ones the bypass relied on. Every other call pattern is unaffected.

### Caveat on threat model

This still doesn't make `private` cryptographically private. A determined consumer can attach a function as a method on any class to gain `namewhat='method'` and access anything they want. The privacy mechanism is a best-effort accidental-access barrier, not a sandbox. The fix just raises the bar from "trivially three keystrokes" to "you have to define a real method first," which is enough to catch ordinary mistakes and casual external probing.

### Internal compatibility

Every `self.private` access in ox_lib's own classes (`timer`, `dui`, `scaleform`, `selector`, plus consumers of `lib.class`) is a direct read or write inside a named method body. None go through anonymous helpers that would have relied on the `namewhat == ''` allowance. So tightening doesn't break ox_lib internals.
