### PR TITLE
fix(vehicleProperties): apply driftTyres=false instead of skipping

### DIFF
--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -650,8 +650,8 @@ function lib.setVehicleProperties(vehicle, props, fixVehicle)
         SetVehicleTyresCanBurst(vehicle, props.bulletProofTyres)
     end
 
-    if gameBuild >= 2372 and props.driftTyres then
-        SetDriftTyresEnabled(vehicle, true)
+    if gameBuild >= 2372 and props.driftTyres ~= nil then
+        SetDriftTyresEnabled(vehicle, props.driftTyres)
     end
 
     if fixVehicle then


### PR DESCRIPTION
### Description

`lib.setVehicleProperties` uses the `~= nil` pattern for every other boolean prop in the function so that explicit `false` is honored:

```lua
if props.lockState ~= nil       then SetVehicleDoorsLocked(vehicle, props.lockState)        end
if props.modSmokeEnabled ~= nil then ToggleVehicleMod(vehicle, 20, props.modSmokeEnabled)   end
if props.modTurbo ~= nil        then ToggleVehicleMod(vehicle, 18, props.modTurbo)          end
if props.modSubwoofer ~= nil    then ToggleVehicleMod(vehicle, 19, props.modSubwoofer)      end
if props.modHydraulics ~= nil   then ToggleVehicleMod(vehicle, 21, props.modHydraulics)     end
if props.modXenon ~= nil        then ToggleVehicleMod(vehicle, 22, props.modXenon)          end
if props.bulletProofTyres ~= nil then SetVehicleTyresCanBurst(vehicle, props.bulletProofTyres) end
```

`driftTyres` doesn't follow that pattern, and it also hardcodes the value passed to the native:

```lua
if gameBuild >= 2372 and props.driftTyres then
    SetDriftTyresEnabled(vehicle, true)
end
```

The function can only ever turn drift tyres on; there is no path that turns them off.

`getVehicleProperties` always saves `driftTyres` as a real boolean (line 288: `driftTyres = gameBuild >= 2372 and GetDriftTyresEnabled(vehicle)`), so a vehicle without drift tyres serializes as `driftTyres = false`. Trying to restore that state onto a vehicle that currently has drift tyres enabled is a silent no-op.

### Reproduction

```lua
local target = GetVehiclePedIsIn(PlayerPedId(), false)
SetDriftTyresEnabled(target, true)
print(GetDriftTyresEnabled(target))    -- true

lib.setVehicleProperties(target, { driftTyres = false })

print(GetDriftTyresEnabled(target))
-- before fix: still true
-- after fix:  false
```

### Fix

Mirror the `~= nil` pattern from the other boolean setters and forward the actual value:

```diff
-    if gameBuild >= 2372 and props.driftTyres then
-        SetDriftTyresEnabled(vehicle, true)
+    if gameBuild >= 2372 and props.driftTyres ~= nil then
+        SetDriftTyresEnabled(vehicle, props.driftTyres)
     end
```

After the patch the call passes `props.driftTyres` through untouched, so `false` actually disables and `true` enables. `nil` (caller didn't include the field) still skips entirely, matching the other setters.
