### PR TITLE
allow keybinds while pause menu is active

### DIFF
--- a/imports/addKeybind/client.lua
+++ b/imports/addKeybind/client.lua
@@ -63,13 +63,13 @@ function lib.addKeybind(data)
     keybinds[data.name] = setmetatable(data, keybind_mt)
 
     RegisterCommand('+' .. data.name, function()
-        if data.disabled or IsPauseMenuActive() then return end
+        if data.disabled or (IsPauseMenuActive() and not data.allowInPauseMenu) then return end
         data.isPressed = true
         if data.onPressed then data:onPressed() end
     end)
 
     RegisterCommand('-' .. data.name, function()
-        if data.disabled or IsPauseMenuActive() then return end
+        if data.disabled or (IsPauseMenuActive() and not data.allowInPauseMenu) then return end
         data.isPressed = false
         if data.onReleased then data:onReleased() end
     end)


### PR DESCRIPTION
Adds an optional `allowInPauseMenu` flag to `lib.addKeybind`.

By default, keybinds keep the existing behavior and are ignored while `IsPauseMenuActive()` is true. When `allowInPauseMenu` is set to true, the keybind can still trigger while the pause menu/frontend is active.

This is useful for resources that use frontend pause menu rendering, such as ped previews, while still needing their mapped keybinds to work.