### PR TITLE
allow keybinds while pause menu is active

### DIFF
--- a/imports/addKeybind/client.lua
+++ b/imports/addKeybind/client.lua
@@ -63,13 +63,13 @@ function lib.addKeybind(data)
     keybinds[data.name] = setmetatable(data, keybind_mt)
 
     RegisterCommand('+' .. data.name, function()
-        if data.disabled or IsPauseMenuActive() then return end
+        if data.disabled or (IsPauseMenuActive() and not data.allowInPauseMenu) then return end
         data.isPressed = true
         if data.onPressed then data:onPressed() end
     end)
 
     RegisterCommand('-' .. data.name, function()
-        if data.disabled or IsPauseMenuActive() then return end
+        if data.disabled or (IsPauseMenuActive() and not data.allowInPauseMenu) then return end
         data.isPressed = false
         if data.onReleased then data:onReleased() end
     end)

--- a/package/client/addKeybind/index.ts
+++ b/package/client/addKeybind/index.ts
@@ -12,6 +12,7 @@ interface KeybindProps {
   description: string;
   defaultMapper?: string;
   defaultKey?: string;
+  allowInPauseMenu?: boolean;
   disabled?: boolean;
   disable?(this: CKeybind, toggle: boolean): void;
   onPressed?(this: CKeybind): void;
@@ -30,6 +31,7 @@ class Keybind implements CKeybind {
   onReleased?: (this: CKeybind) => void;
   secondaryKey?: string;
   secondaryMapper?: string;
+  allowInPauseMenu?: boolean;
   [key: string]: any;
 
   disabled: boolean = false;
@@ -43,6 +45,7 @@ class Keybind implements CKeybind {
     this.defaultKey = data.defaultKey ?? '';
     this.secondaryKey = data.secondaryKey;
     this.secondaryMapper = data.secondaryMapper;
+    this.allowInPauseMenu = data.allowInPauseMenu;
 
     if (typeof data.disabled === 'boolean') this.disabled = data.disabled;
     this.onPressed = data.onPressed;
@@ -77,7 +80,7 @@ export function addKeybind(data: KeybindProps): CKeybind {
   RegisterCommand(
     '+' + kb.name,
     () => {
-      if (kb.disabled || IsPauseMenuActive()) return;
+      if (kb.disabled || (!kb.allowInPauseMenu && IsPauseMenuActive())) return;
       kb.isPressed = true;
       kb.onPressed?.call(kb);
     },
@@ -87,7 +90,7 @@ export function addKeybind(data: KeybindProps): CKeybind {
   RegisterCommand(
     '-' + kb.name,
     () => {
-      if (kb.disabled || IsPauseMenuActive()) return;
+      if (kb.disabled || (!kb.allowInPauseMenu && IsPauseMenuActive())) return;
       kb.isPressed = false;
       kb.onReleased?.call(kb);
     },


### PR DESCRIPTION
Adds an optional `allowInPauseMenu` flag to `lib.addKeybind`.

By default, keybinds keep the existing behavior and are ignored while `IsPauseMenuActive()` is true. When `allowInPauseMenu` is set to true, the keybind can still trigger while the pause menu/frontend is active.

This is useful for resources that use frontend pause menu rendering, such as ped previews, while still needing their mapped keybinds to work.