### PR TITLE
Add locale docs, config and Georgian locale

### DIFF
--- a/LOCALES.md
+++ b/LOCALES.md
@@ -1,0 +1,110 @@
+# Locales
+
+ox_lib ships with JSON locale files in the `locales/` directory. English (`en.json`) is always loaded as the base locale; the active locale is merged on top so missing keys fall back to English automatically.
+
+## Setting the language
+
+### Recommended: `config.lua`
+
+Edit `config.lua` in the ox_lib resource root:
+
+```lua
+Config.Locale = 'ka'
+```
+
+Supported values are the locale file names without the `.json` extension, for example:
+
+- `en` — English
+- `ka` — Georgian (ქართული)
+- `tr` — Turkish (Türkçe)
+- `ru` — Russian (Русский)
+
+Restart the resource or server after changing this value.
+
+### Alternative: server convar
+
+You can also set the locale from `server.cfg`:
+
+```cfg
+setr ox:locale ka
+```
+
+When both are configured, the `ox:locale` convar takes precedence. This preserves existing server setups that already use the convar.
+
+### Per-player override (client)
+
+When `ox:userLocales` is enabled (default), players can change their language from the `/ox_lib` settings menu. That choice is stored locally and overrides the server default for that player only.
+
+## Fallback behavior
+
+ox_lib resolves locale strings in this order:
+
+1. Load `locales/en.json` as the base table.
+2. Merge the active locale file on top (for example `locales/ka.json`).
+3. If the active locale file does not exist, log a warning and use English only.
+4. If a translation key is missing in the active locale, the English value is kept.
+5. If a key does not exist in any locale, the key name is returned unchanged.
+
+This applies to both Lua (`locale('key')`) and the NUI interface.
+
+## Adding a new locale
+
+1. Copy `locales/en.json` to `locales/<code>.json` (for example `locales/ka.json`).
+2. Translate the string values. Keep the JSON keys identical to `en.json`.
+3. Set the top-level `"language"` field to the display name shown in the settings menu.
+4. Save the file as **UTF-8** (without BOM).
+
+Example structure:
+
+```json
+{
+  "language": "ქართული",
+  "settings": "პარამეტრები",
+  "ui": {
+    "cancel": "გაუქმება"
+  }
+}
+```
+
+5. Set `Config.Locale = '<code>'` or `setr ox:locale <code>`.
+
+Nested keys are flattened internally (`ui.cancel` → `"ui.cancel"`), so keep the same nesting as `en.json`.
+
+## UTF-8 requirements
+
+All locale files must be saved as UTF-8. This is required for languages that use multibyte characters, including:
+
+- Georgian — `ქართული`, `გაუქმება`, `დადასტურება`
+- Turkish — `Türkçe`, `İptal`, `Ş`, `ğ`, `ü`, `ö`, `ç`
+- Russian — `Русский`, `Отменить`
+
+Do not re-encode locale files as ANSI or Latin-1. ox_lib uses Lua 5.4 and `json.decode`, which handle UTF-8 strings correctly. Avoid manual byte-level string slicing on translated text.
+
+## Using locales in other resources
+
+Import the locale module from your resource `fxmanifest.lua`:
+
+```lua
+ox_lib 'locale'
+```
+
+Then call:
+
+```lua
+locale('your_key')
+```
+
+For resource-specific strings, add your own `locales/<code>.json` files and call `lib.locale()` during startup.
+
+## API reference
+
+| Function | Description |
+| --- | --- |
+| `Config.Locale` | Default locale code from `config.lua` |
+| `lib.getLocaleKey()` | Returns the active locale code |
+| `lib.setLocale(key)` | Client-only. Changes locale at runtime and updates NUI |
+| `lib.loadLocaleData(key)` | Returns merged locale table (`en` + requested locale) |
+| `lib.locale(key?)` | Loads and caches locale strings for Lua |
+| `locale(key, ...)` | Returns a translated string, with optional `string.format` args |
+
+Exports and callbacks are unchanged from previous ox_lib versions.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ For additional legal notices, refer to [NOTICE.md](./NOTICE.md).
 
 https://overextended.dev/ox_lib
 
+See [LOCALES.md](./LOCALES.md) for configuring the active language, adding translations, and UTF-8 locale file requirements.
+
 ## 💾 Download
 
 https://github.com/overextended/ox_lib/releases/latest/download/ox_lib.zip

--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,10 @@
+---@class OxLibConfig
+Config = {}
+
+---The default locale used by ox_lib.
+---Must match a JSON file in the `locales/` directory (without the `.json` extension).
+---Examples: 'en', 'ka', 'tr', 'ru'
+---
+---This value is used when `ox:locale` is not set in server.cfg.
+---Players can still override the locale in-game when `ox:userLocales` is enabled.
+Config.Locale = 'en'

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -20,6 +20,7 @@ ui_page 'web/build/index.html'
 
 files {
     'init.lua',
+    'config.lua',
     'resource/settings.lua',
     'imports/**/client.lua',
     'imports/**/shared.lua',
@@ -28,6 +29,7 @@ files {
     'locales/*.json',
 }
 
+shared_script 'config.lua'
 shared_script 'resource/init.lua'
 
 shared_scripts {

--- a/imports/locale/shared.lua
+++ b/imports/locale/shared.lua
@@ -47,6 +47,10 @@ function lib.getLocales()
     return dict
 end
 
+local function localeFileExists(key)
+    return LoadResourceFile(cache.resource, ('locales/%s.json'):format(key)) ~= nil
+end
+
 local function loadLocale(key)
     local data = LoadResourceFile(cache.resource, ('locales/%s.json'):format(key))
 
@@ -57,17 +61,33 @@ local function loadLocale(key)
     return json.decode(data) or {}
 end
 
-local table = lib.table
+---Returns merged locale data with English as the base and the requested locale applied on top.
+---Falls back to English when the requested locale file does not exist.
+---@param key string
+---@return table
+function lib.loadLocaleData(key)
+    local lang = key
 
----Loads the ox_lib locale module. Prefer using fxmanifest instead (see [docs](https://overextended.dev/ox_lib#usage)).
----@param key? string
-function lib.locale(key)
-    local lang = key or lib.getLocaleKey()
+    if lang ~= 'en' and not localeFileExists(lang) then
+        warn(("locale '%s' not found, falling back to 'en'"):format(lang))
+        lang = 'en'
+    end
+
     local locales = loadLocale('en')
 
     if lang ~= 'en' then
         table.merge(locales, loadLocale(lang))
     end
+
+    return locales
+end
+
+local table = lib.table
+
+---Loads the ox_lib locale module. Prefer using fxmanifest instead (see [docs](https://overextended.dev/ox_lib#usage)).
+---@param key? string
+function lib.locale(key)
+    local locales = lib.loadLocaleData(key or lib.getLocaleKey())
 
     table.wipe(dict)
 

--- a/locales/ka.json
+++ b/locales/ka.json
@@ -1,0 +1,33 @@
+{
+  "language": "ქართული",
+  "settings": "პარამეტრები",
+  "ui": {
+    "cancel": "გაუქმება",
+    "close": "დახურვა",
+    "confirm": "დადასტურება",
+    "more": "მეტი...",
+    "settings": {
+      "locale": "ენის შეცვლა",
+      "locale_description": "მიმდინარე ენა: ${language} (%s)",
+      "notification_audio": "შეტყობინების ხმა",
+      "notification_position": "შეტყობინების პოზიცია"
+    },
+    "position": {
+      "bottom": "ქვედა",
+      "bottom-left": "ქვედა-მარცხენა",
+      "bottom-right": "ქვედა-მარჯვენა",
+      "center-left": "ცენტრი-მარცხენა",
+      "center-right": "ცენტრი-მარჯვენა",
+      "top": "ზედა",
+      "top-left": "ზედა-მარცხენა",
+      "top-right": "ზედა-მარჯვენა"
+    }
+  },
+  "open_radial_menu": "რადიალური მენიუს გახსნა",
+  "cancel_progress": "მიმდინარე პროგრესის გაუქმება",
+  "txadmin_announcement": "სერვერის განცხადება %s-ისგან",
+  "txadmin_dm": "პირდაპირი შეტყობინება %s-ისგან",
+  "txadmin_warn": "გაფრთხილება %s-ისგან მიიღეთ",
+  "txadmin_warn_content": "%s  \nმოქმედების ID: %s",
+  "txadmin_scheduledrestart": "დაგეგმილი გადატვირთვა"
+}

--- a/resource/locale/client.lua
+++ b/resource/locale/client.lua
@@ -8,12 +8,7 @@
 
 local settings = require 'resource.settings'
 
-local function loadLocaleFile(key)
-    local file = LoadResourceFile(cache.resource, ('locales/%s.json'):format(key))
-        or LoadResourceFile(cache.resource, 'locales/en.json')
-
-    return file and json.decode(file) or {}
-end
+lib.locale(settings.locale)
 
 function lib.getLocaleKey() return settings.locale end
 
@@ -22,7 +17,7 @@ function lib.setLocale(key)
     TriggerEvent('ox_lib:setLocale', key)
     SendNUIMessage({
         action = 'setLocale',
-        data = loadLocaleFile(key)
+        data = lib.loadLocaleData(key)
     })
 end
 
@@ -31,8 +26,6 @@ RegisterNUICallback('init', function(_, cb)
 
     SendNUIMessage({
         action = 'setLocale',
-        data = loadLocaleFile(settings.locale)
+        data = lib.loadLocaleData(settings.locale)
     })
 end)
-
-lib.locale(settings.locale)

--- a/resource/locale/server.lua
+++ b/resource/locale/server.lua
@@ -6,4 +6,8 @@
     Copyright © 2025 Linden <https://github.com/thelindat>
 ]]
 
-function lib.getLocaleKey() return GetConvar('ox:locale', 'en') end
+function lib.getLocaleKey()
+    return GetConvar('ox:locale', Config.Locale or 'en')
+end
+
+lib.locale(lib.getLocaleKey())

--- a/resource/settings.lua
+++ b/resource/settings.lua
@@ -21,7 +21,7 @@ local function safeGetKvp(fn, key, default)
 end
 
 local settings = {
-    default_locale = GetConvar('ox:locale', 'en'),
+    default_locale = GetConvar('ox:locale', Config.Locale or 'en'),
     notification_position = safeGetKvp(GetResourceKvpString, 'notification_position', 'top-right'),
     notification_audio = safeGetKvp(GetResourceKvpInt, 'notification_audio') == 1
 }


### PR DESCRIPTION
Add full localization support: introduce LOCALES.md with usage and UTF-8 requirements, add config.lua for Config.Locale, and include a Georgian translations file (locales/ka.json). Update fxmanifest to ship and load config.lua. Refactor imports/locale/shared.lua to add localeFileExists and lib.loadLocaleData which merges English as the base and falls back to 'en' with a warning if a locale file is missing; lib.locale now uses that loader. Update resource/locale client and server to use lib.loadLocaleData and to prefer the ox:locale convar while defaulting to Config.Locale. Update resource/settings to use Config.Locale as the default convar fallback. Also add a README link to LOCALES.md.