### PR TITLE
fix(callbacks): isCallbackValid returns boolean, not the fallback resource

### DIFF
--- a/resource/callbacks/shared.lua
+++ b/resource/callbacks/shared.lua
@@ -47,7 +47,7 @@ function lib.setValidCallback(callbackName, isValid)
 end
 
 function lib.isCallbackValid(callbackName)
-    return (registeredCallbacks[callbackName] or cache.resource) == GetInvokingResource()
+    return registeredCallbacks[callbackName] == (GetInvokingResource() or cache.resource)
 end
 
 local cbEvent = '__ox_cb_%s'

--- a/resource/callbacks/shared.lua
+++ b/resource/callbacks/shared.lua
@@ -47,7 +47,7 @@ function lib.setValidCallback(callbackName, isValid)
 end
 
 function lib.isCallbackValid(callbackName)
-    return registeredCallbacks[callbackName] == GetInvokingResource() or cache.resource
+    return (registeredCallbacks[callbackName] or cache.resource) == GetInvokingResource()
 end
 
 local cbEvent = '__ox_cb_%s'


### PR DESCRIPTION
### Description

`lib.isCallbackValid` is named to return a boolean. Operator precedence parses the return expression as `(eq) or cache.resource`:

```lua
function lib.isCallbackValid(callbackName)
    return registeredCallbacks[callbackName] == GetInvokingResource() or cache.resource
end
```

When the equality is true, returns `true`. When false, falls through to `or cache.resource`, returning the resource name as a string. Both branches are truthy, so the function never returns a falsy value despite its name. Any caller using it in a boolean position sees "valid" for every callback regardless of whether the calling resource actually owns it.


### Fix

Parenthesize so the `or` resolves the lookup before the equality check:

```diff
 function lib.isCallbackValid(callbackName)
-    return registeredCallbacks[callbackName] == GetInvokingResource() or cache.resource
+    return (registeredCallbacks[callbackName] or cache.resource) == GetInvokingResource()
 end
```

