### PR TITLE
refactor(logger): split providers into separate files behind a shared dispatcher

### DIFF
--- a/imports/logger/providers/datadog.lua
+++ b/imports/logger/providers/datadog.lua
@@ -1,0 +1,44 @@
+--[[
+    https://github.com/overextended/ox_lib
+
+    This file is licensed under LGPL-3.0 or higher <https://www.gnu.org/licenses/lgpl-3.0.en.html>
+
+    Copyright © 2025 Linden <https://github.com/thelindat>
+]]
+
+---@param ctx LogContext
+---@return LogProvider?
+return function(ctx)
+    local key = GetConvar('datadog:key', ''):gsub("[\'\"]", '')
+    if key == '' then return end
+
+    local hostname = ctx.hostname
+    local formatTags = ctx.formatTags
+
+    return {
+        endpoint = ('https://http-intake.logs.%s/api/v2/logs'):format(GetConvar('datadog:site', 'datadoghq.com')),
+        headers = {
+            ['Content-Type'] = 'application/json',
+            ['DD-API-KEY'] = key,
+        },
+        okStatus = 202,
+        encode = json.encode,
+
+        append = function(buffer, source, event, message, ...)
+            buffer[#buffer + 1] = {
+                hostname = hostname,
+                service = event,
+                message = message,
+                resource = cache.resource,
+                ddsource = tostring(source),
+                ddtags = formatTags(source, ... and string.strjoin(',', string.tostringall(...)) or nil),
+            }
+        end,
+
+        parseError = function(_, response)
+            if type(response) ~= 'string' then return nil end
+            response = json.decode(response:sub(10)) or response
+            return type(response) == 'table' and response.errors[1] or response
+        end,
+    }
+end

--- a/imports/logger/providers/fivemanage.lua
+++ b/imports/logger/providers/fivemanage.lua
@@ -1,0 +1,80 @@
+--[[
+    https://github.com/overextended/ox_lib
+
+    This file is licensed under LGPL-3.0 or higher <https://www.gnu.org/licenses/lgpl-3.0.en.html>
+
+    Copyright © 2025 Linden <https://github.com/thelindat>
+]]
+
+---@param ctx LogContext
+---@return LogProvider?
+return function(ctx)
+    local key = GetConvar('fivemanage:key', '')
+    if key == '' then return end
+
+    local hostname = ctx.hostname
+    local formatTags = ctx.formatTags
+
+    local headers = {
+        ['Content-Type'] = 'application/json',
+        ['Authorization'] = key,
+        ['User-Agent'] = 'ox_lib',
+    }
+
+    local dataset = GetConvar('fivemanage:dataset', '')
+    if dataset ~= '' then
+        headers['X-Fivemanage-Dataset'] = dataset
+    end
+
+    return {
+        endpoint = 'https://api.fivemanage.com/api/logs/batch',
+        headers = headers,
+        okStatus = 200,
+        encode = json.encode,
+
+        append = function(buffer, source, event, message, ...)
+            local metadata = {
+                hostname = hostname,
+                service = event,
+                source = source,
+            }
+
+            local playerTags = formatTags(source, nil)
+            if playerTags and type(playerTags) == 'string' then
+                local tempTable = { string.strsplit(',', playerTags) }
+                for _, v in pairs(tempTable) do
+                    local k, vv = string.strsplit(':', v)
+                    if k and vv then
+                        metadata[k] = vv
+                    end
+                end
+            end
+
+            local args = { ... }
+            for _, arg in pairs(args) do
+                if type(arg) == 'table' then
+                    for k, v in pairs(arg) do
+                        metadata[k] = v
+                    end
+                elseif type(arg) == 'string' then
+                    local k, v = string.strsplit(':', arg)
+                    if k and v then
+                        metadata[k] = v
+                    end
+                end
+            end
+
+            buffer[#buffer + 1] = {
+                level = 'info',
+                message = message,
+                resource = cache.resource,
+                metadata = metadata,
+            }
+        end,
+
+        parseError = function(_, response)
+            if type(response) ~= 'string' then return nil end
+            return json.decode(response) or response
+        end,
+    }
+end

--- a/imports/logger/providers/loki.lua
+++ b/imports/logger/providers/loki.lua
@@ -1,0 +1,146 @@
+--[[
+    https://github.com/overextended/ox_lib
+
+    This file is licensed under LGPL-3.0 or higher <https://www.gnu.org/licenses/lgpl-3.0.en.html>
+
+    Copyright © 2025 Linden <https://github.com/thelindat>
+]]
+
+local b = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+local function base64encode(data)
+    return ((data:gsub(".", function(x)
+        local r, b = "", x:byte()
+        for i = 8, 1, -1 do
+            r = r .. (b % 2 ^ i - b % 2 ^ (i - 1) > 0 and "1" or "0")
+        end
+        return r;
+    end) .. "0000"):gsub("%d%d%d?%d?%d?%d?", function(x)
+        if (#x < 6) then
+            return ""
+        end
+        local c = 0
+        for i = 1, 6 do
+            c = c + (x:sub(i, i) == "1" and 2 ^ (6 - i) or 0)
+        end
+        return b:sub(c + 1, c + 1)
+    end) .. ({ "", "==", "=" })[#data % 3 + 1])
+end
+
+local function getAuthorizationHeader(user, password)
+    return "Basic " .. base64encode(user .. ":" .. password)
+end
+
+---@param ctx LogContext
+---@return LogProvider?
+return function(ctx)
+    local lokiUser = GetConvar('loki:user', '')
+    local lokiPassword = GetConvar('loki:password', GetConvar('loki:key', ''))
+    local lokiEndpoint = GetConvar('loki:endpoint', '')
+    local lokiTenant = GetConvar('loki:tenant', '')
+    local startingPattern = '^http[s]?://'
+    local headers = {
+        ['Content-Type'] = 'application/json'
+    }
+
+    if lokiUser ~= '' then
+        headers['Authorization'] = getAuthorizationHeader(lokiUser, lokiPassword)
+    end
+
+    if lokiTenant ~= '' then
+        headers['X-Scope-OrgID'] = lokiTenant
+    end
+
+    if not lokiEndpoint:find(startingPattern) then
+        lokiEndpoint = 'https://' .. lokiEndpoint
+    end
+
+    local hostname = ctx.hostname
+    local formatTags = ctx.formatTags
+
+    return {
+        endpoint = ('%s/loki/api/v1/push'):format(lokiEndpoint),
+        headers = headers,
+        okStatus = 204,
+
+        append = function(buffer, source, event, message, ...)
+            ---@diagnostic disable-next-line: param-type-mismatch
+            local timestamp = ('%s000000000'):format(os.time(os.date('*t')))
+
+            local values = { message = message }
+
+            local playerIdentifierTags = formatTags(source, nil)
+            if playerIdentifierTags and type(playerIdentifierTags) == 'string' then
+                local tempTable = { string.strsplit(',', playerIdentifierTags) }
+                for _, v in pairs(tempTable) do
+                    local key, value = string.strsplit(':', v)
+                    values[key] = value
+                end
+            end
+
+            local args = { ... }
+            for _, arg in pairs(args) do
+                if type(arg) == 'table' then
+                    for tagKey, tagValue in pairs(arg) do
+                        values[tagKey] = tagValue
+                    end
+                elseif type(arg) == 'string' then
+                    local tempTable = { string.strsplit(',', arg) }
+
+                    for _, v in pairs(tempTable) do
+                        local tagKey, tagValue = string.strsplit(':', v)
+
+                        if tagKey and tagValue then
+                            values[tagKey] = tagValue
+                        else
+                            lib.print.warn(('Invalid tag format for argument "%s" in event "%s"'):format(v, event))
+                        end
+                    end
+                end
+            end
+
+            local payload = {
+                stream = {
+                    server = hostname,
+                    resource = cache.resource,
+                    event = event
+                },
+                values = {
+                    {
+                        timestamp,
+                        json.encode(values)
+                    }
+                }
+            }
+
+            if not buffer then
+                buffer = {}
+            end
+
+            if not buffer[event] then
+                buffer[event] = payload
+            else
+                local lastIndex = #buffer[event].values
+                lastIndex += 1
+
+                buffer[event].values[lastIndex] = {
+                    timestamp,
+                    json.encode(values)
+                }
+            end
+        end,
+
+        encode = function(buffer)
+            local tempBuffer = {}
+            for _, v in pairs(buffer) do
+                tempBuffer[#tempBuffer + 1] = v
+            end
+
+            return json.encode({ streams = tempBuffer })
+        end,
+
+        parseError = function(status, _, body)
+            return ("%s"):format(status, body)
+        end,
+    }
+end

--- a/imports/logger/server.lua
+++ b/imports/logger/server.lua
@@ -7,8 +7,6 @@
 ]]
 
 local service = GetConvar('ox:logger', 'datadog')
-local buffer
-local bufferSize = 0
 
 local function removeColorCodes(str)
     -- replace ^[0-9] with nothing
@@ -24,32 +22,6 @@ local function removeColorCodes(str)
 end
 
 local hostname = removeColorCodes(GetConvar('ox:logger:hostname', GetConvar('sv_projectName', 'fxserver')))
-
-local b = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-
-local function base64encode(data)
-    return ((data:gsub(".", function(x)
-        local r, b = "", x:byte()
-        for i = 8, 1, -1 do
-            r = r .. (b % 2 ^ i - b % 2 ^ (i - 1) > 0 and "1" or "0")
-        end
-        return r;
-    end) .. "0000"):gsub("%d%d%d?%d?%d?%d?", function(x)
-        if (#x < 6) then
-            return ""
-        end
-        local c = 0
-        for i = 1, 6 do
-            c = c + (x:sub(i, i) == "1" and 2 ^ (6 - i) or 0)
-        end
-        return b:sub(c + 1, c + 1)
-    end) .. ({ "", "==", "=" })[#data % 3 + 1])
-end
-
-local function getAuthorizationHeader(user, password)
-    return "Basic " .. base64encode(user .. ":" .. password)
-end
-
 
 local function badResponse(endpoint, status, response)
     warn(('unable to submit logs to %s (status: %s)\n%s'):format(endpoint, status, json.encode(response, { indent = true })))
@@ -92,246 +64,54 @@ local function formatTags(source, tags)
     return tags
 end
 
-if service == 'fivemanage' then
-    local key = GetConvar('fivemanage:key', '')
-    local dataset = GetConvar('fivemanage:dataset', '')
+---@class LogContext
+---@field hostname string
+---@field formatTags fun(source: any, tags: string?): string?
 
-    if key ~= '' then
-        local endpoint = 'https://api.fivemanage.com/api/logs/batch'
+---@class LogProvider
+---@field endpoint string
+---@field headers table<string, string>
+---@field okStatus number
+---@field append fun(buffer: table, source: any, event: string, message: string, ...): nil
+---@field encode fun(buffer: table): string
+---@field parseError fun(status: number, response: any, body: string): any|nil
 
-        local headers = {
-            ['Content-Type'] = 'application/json',
-            ['Authorization'] = key,
-            ['User-Agent'] = 'ox_lib',
-        }
+local KNOWN = { datadog = true, fivemanage = true, loki = true }
 
-        if dataset ~= "" then
-            headers['X-Fivemanage-Dataset'] = dataset
-        end
+if not KNOWN[service] then return lib.logger end
 
-        function lib.logger(source, event, message, ...)
-            if not buffer then
-                buffer = {}
+---@type fun(ctx: LogContext): LogProvider?
+local providerFactory = lib.require(('imports.logger.providers.%s'):format(service))
+if not providerFactory then return lib.logger end
 
-                SetTimeout(500, function()
-                    PerformHttpRequest(endpoint, function(status, _, _, response)
-                        if status ~= 200 then
-                            if type(response) == 'string' then
-                                response = json.decode(response) or response
-                                badResponse(endpoint, status, response)
-                            end
-                        end
-                    end, 'POST', json.encode(buffer), headers)
+local provider = providerFactory({
+    hostname = hostname,
+    formatTags = formatTags,
+})
+if not provider then return lib.logger end
 
-                    buffer = nil
-                    bufferSize = 0
-                end)
-            end
+local buffer
 
-            local metadata = {
-                hostname = hostname,
-                service = event,
-                source = source,
-            }
+function lib.logger(source, event, message, ...)
+    if not buffer then
+        buffer = {}
 
-            local playerTags = formatTags(source, nil)
-            if playerTags and type(playerTags) == 'string' then
-                local tempTable = { string.strsplit(',', playerTags) }
-                for _, v in pairs(tempTable) do
-                    local key, value = string.strsplit(':', v)
-                    if key and value then
-                        metadata[key] = value
-                    end
-                end
-            end
+        SetTimeout(500, function()
+            local body = provider.encode(buffer)
+            buffer = nil
 
-            local args = { ... }
-            for _, arg in pairs(args) do
-                if type(arg) == 'table' then
-                    for k, v in pairs(arg) do
-                        metadata[k] = v
-                    end
-                elseif type(arg) == 'string' then
-                    local key, value = string.strsplit(':', arg)
-                    if key and value then
-                        metadata[key] = value
-                    end
-                end
-            end
+            PerformHttpRequest(provider.endpoint, function(status, _, _, response)
+                if status == provider.okStatus then return end
 
-            bufferSize += 1
-            buffer[bufferSize] = {
-                level = "info",
-                message = message,
-                resource = cache.resource,
-                metadata = metadata,
-            }
-        end
-    end
-end
+                local err = provider.parseError(status, response, body)
+                if err == nil then return end
 
-if service == 'datadog' then
-    local key = GetConvar('datadog:key', ''):gsub("[\'\"]", '')
-
-    if key ~= '' then
-        local endpoint = ('https://http-intake.logs.%s/api/v2/logs'):format(GetConvar('datadog:site', 'datadoghq.com'))
-
-        local headers = {
-            ['Content-Type'] = 'application/json',
-            ['DD-API-KEY'] = key,
-        }
-
-        function lib.logger(source, event, message, ...)
-            if not buffer then
-                buffer = {}
-
-                SetTimeout(500, function()
-                    PerformHttpRequest(endpoint, function(status, _, _, response)
-                        if status ~= 202 then
-                            if type(response) == 'string' then
-                                response = json.decode(response:sub(10)) or response
-                                badResponse(endpoint, status, type(response) == 'table' and response.errors[1] or response)
-                            end
-                        end
-                    end, 'POST', json.encode(buffer), headers)
-
-                    buffer = nil
-                    bufferSize = 0
-                end)
-            end
-
-            bufferSize += 1
-            buffer[bufferSize] = {
-                hostname = hostname,
-                service = event,
-                message = message,
-                resource = cache.resource,
-                ddsource = tostring(source),
-                ddtags = formatTags(source, ... and string.strjoin(',', string.tostringall(...)) or nil),
-            }
-        end
-    end
-end
-
-if service == 'loki' then
-    local lokiUser = GetConvar('loki:user', '')
-    local lokiPassword = GetConvar('loki:password', GetConvar('loki:key', ''))
-    local lokiEndpoint = GetConvar('loki:endpoint', '')
-    local lokiTenant = GetConvar('loki:tenant', '')
-    local startingPattern = '^http[s]?://'
-    local headers = {
-        ['Content-Type'] = 'application/json'
-    }
-
-    if lokiUser ~= '' then
-        headers['Authorization'] = getAuthorizationHeader(lokiUser, lokiPassword)
+                badResponse(provider.endpoint, status, err)
+            end, 'POST', body, provider.headers)
+        end)
     end
 
-    if lokiTenant ~= '' then
-        headers['X-Scope-OrgID'] = lokiTenant
-    end
-
-    if not lokiEndpoint:find(startingPattern) then
-        lokiEndpoint = 'https://' .. lokiEndpoint
-    end
-
-    local endpoint = ('%s/loki/api/v1/push'):format(lokiEndpoint)
-
-    function lib.logger(source, event, message, ...)
-        if not buffer then
-            buffer = {}
-
-            SetTimeout(500, function()
-                -- Strip string keys from buffer
-                local tempBuffer = {}
-                for _, v in pairs(buffer) do
-                    tempBuffer[#tempBuffer + 1] = v
-                end
-
-                local postBody = json.encode({ streams = tempBuffer })
-                PerformHttpRequest(endpoint, function(status, _, _, _)
-                    if status ~= 204 then
-                        badResponse(endpoint, status, ("%s"):format(status, postBody))
-                    end
-                end, 'POST', postBody, headers)
-
-                buffer = nil
-            end)
-        end
-
-        -- Generates a nanosecond unix timestamp
-        ---@diagnostic disable-next-line: param-type-mismatch
-        local timestamp = ('%s000000000'):format(os.time(os.date('*t')))
-
-        -- Initializes values table with the message
-        local values = { message = message }
-
-        -- Stores the player identifiers to values table
-        local playerIdentifierTags = formatTags(source, nil)
-        if playerIdentifierTags and type(playerIdentifierTags) == 'string' then
-            local tempTable = { string.strsplit(',', playerIdentifierTags) }
-            for _, v in pairs(tempTable) do
-                local key, value = string.strsplit(':', v)
-                values[key] = value
-            end
-        end
-
-        -- Adds custom tags to the values table defined either by k:v string or table
-        local args = { ... }
-        for _, arg in pairs(args) do
-            if type(arg) == 'table' then
-                for tagKey, tagValue in pairs(arg) do
-                    values[tagKey] = tagValue
-                end
-            elseif type(arg) == 'string' then
-                local tempTable = { string.strsplit(',', arg) } -- Support multiple, comma separated k:v pairs in a string argument
-
-                for _, v in pairs(tempTable) do
-                    local tagKey, tagValue = string.strsplit(':', v)
-
-                    if tagKey and tagValue then -- If either is empty then we mitigate errors
-                        values[tagKey] = tagValue
-                    else
-                        lib.print.warn(('Invalid tag format for argument "%s" in event "%s"'):format(v, event))
-                    end
-                end
-            end
-        end
-
-        -- initialise stream payload
-        local payload = {
-            stream = {
-                server = hostname,
-                resource = cache.resource,
-                event = event
-            },
-            values = {
-                {
-                    timestamp,
-                    json.encode(values)
-                }
-            }
-        }
-
-        -- Safety check incase it throws index issue
-        if not buffer then
-            buffer = {}
-        end
-
-        -- Checks if the event exists in the buffer and adds to the values if found
-        -- else initialises the stream
-        if not buffer[event] then
-            buffer[event] = payload
-        else
-            local lastIndex = #buffer[event].values
-            lastIndex += 1
-
-            buffer[event].values[lastIndex] = {
-                timestamp,
-                json.encode(values)
-            }
-        end
-    end
+    provider.append(buffer, source, event, message, ...)
 end
 
 return lib.logger


### PR DESCRIPTION
### Description

`imports/logger/server.lua` was three providers in one file, each redefining `lib.logger` from scratch inside an `if service == 'X' then ... end` block with its own buffering, tag parsing, and HTTP scaffolding. Adding a fourth meant copy-pasting the scaffolding again.

This PR splits the file into a dispatcher plus one file per provider, behind a uniform interface. **Structure-only**: every observable behavior is preserved, including three pre-existing bugs that will land in a followup PR.

### Layout

```
imports/logger/
├── server.lua                  dispatcher + shared helpers
└── providers/
    ├── datadog.lua
    ├── fivemanage.lua
    └── loki.lua
```

### Interface

```lua
---@class LogContext
---@field hostname string
---@field formatTags fun(source: any, tags: string?): string?

---@class LogProvider
---@field endpoint string
---@field headers table<string, string>
---@field okStatus number
---@field append fun(buffer: table, source: any, event: string, message: string, ...): nil
---@field encode fun(buffer: table): string
---@field parseError fun(status: number, response: any, body: string): any|nil
```

Each provider file is `return function(ctx) ... end`. It reads its own convars and returns a `LogProvider`, or `nil` when unconfigured (matching the original's silent fall-through to `noop`). `parseError` returning `nil` tells the dispatcher to skip `badResponse`.

### Adding a new provider

Drop `providers/<name>.lua` exporting a `function(ctx)` factory, add `<name>` to the `KNOWN` whitelist at the top of `server.lua`. The dispatcher, the other providers, and `lib.logger` callers don't change.

### Internal restructuring

- `bufferSize` counter removed in favor of `buffer[#buffer + 1]`. Same assignment indices.
- `base64encode` / `getAuthorizationHeader` moved into `providers/loki.lua` (only caller).
- The flush timer encodes the body before nilling the buffer rather than inline as a `PerformHttpRequest` arg. Same effect.

### Why this is worth doing on its own

Maintenance: a bug in one provider is one focused diff against one file. The three known bugs above each become a small follow-up PR that doesn't touch the others. Issue #776 (Loki labels and structured metadata) becomes a contained change in `providers/loki.lua`.
