### PR TITLE
feat: Add four collection types: lib.set, lib.ringbuffer, lib.lru, lib.heap

### DIFF
--- a/imports/heap/shared.lua
+++ b/imports/heap/shared.lua
@@ -8,7 +8,7 @@
 
 ---@class Heap : OxClass
 ---@field private new HeapConstructor
-local Heap = lib.class('Heap')
+lib.heap = lib.class('Heap')
 
 local function defaultLess(a, b) return a < b end
 
@@ -43,7 +43,7 @@ end
 ---@overload fun(self: Heap, comparator?: fun(a: any, b: any): boolean): Heap
 ---@private
 ---@param comparator? fun(a: any, b: any): boolean Returns true when `a` should come before `b`. Defaults to `a < b` (min-heap).
-function Heap:constructor(comparator)
+function lib.heap:constructor(comparator)
     if comparator ~= nil and type(comparator) ~= 'function' then
         error("comparator must be a function or nil", 2)
     end
@@ -54,7 +54,7 @@ end
 
 ---@param ... any
 ---@return Heap self
-function Heap:push(...)
+function lib.heap:push(...)
     local items = self.private.items
     local lt = self.private.lt
     local n = select('#', ...)
@@ -68,7 +68,7 @@ function Heap:push(...)
 end
 
 ---@return any?
-function Heap:pop()
+function lib.heap:pop()
     local items = self.private.items
     local n = #items
     if n == 0 then return nil end
@@ -87,28 +87,28 @@ function Heap:pop()
 end
 
 ---@return any?
-function Heap:peek()
+function lib.heap:peek()
     return self.private.items[1]
 end
 
 ---@return integer
-function Heap:size()
+function lib.heap:size()
     return #self.private.items
 end
 
 ---@return boolean
-function Heap:isEmpty()
+function lib.heap:isEmpty()
     return #self.private.items == 0
 end
 
 ---@return Heap self
-function Heap:clear()
+function lib.heap:clear()
     self.private.items = {}
     return self
 end
 
 ---@return Array sorted Newly-allocated array drained in pop order.
-function Heap:drain()
+function lib.heap:drain()
     local out = lib.array:new()
     local n = 0
     while #self.private.items > 0 do
@@ -118,7 +118,6 @@ function Heap:drain()
     return out
 end
 
-Heap.__len = Heap.size
+lib.heap.__len = lib.heap.size
 
-lib.heap = Heap
 return lib.heap

--- a/imports/heap/shared.lua
+++ b/imports/heap/shared.lua
@@ -52,12 +52,18 @@ function Heap:constructor(comparator)
     self.private.lt = comparator or defaultLess
 end
 
----@param value any
+---@param ... any
 ---@return Heap self
-function Heap:push(value)
+function Heap:push(...)
     local items = self.private.items
-    items[#items + 1] = value
-    siftUp(items, #items, self.private.lt)
+    local lt = self.private.lt
+    local n = select('#', ...)
+
+    for i = 1, n do
+        items[#items + 1] = (select(i, ...))
+        siftUp(items, #items, lt)
+    end
+
     return self
 end
 
@@ -101,20 +107,6 @@ function Heap:clear()
     return self
 end
 
----@param values any[]
----@return Heap self
-function Heap:pushAll(values)
-    local items = self.private.items
-    local lt = self.private.lt
-
-    for i = 1, #values do
-        items[#items + 1] = values[i]
-        siftUp(items, #items, lt)
-    end
-
-    return self
-end
-
 ---@return Array sorted Newly-allocated array drained in pop order.
 function Heap:drain()
     local out = lib.array:new()
@@ -125,6 +117,8 @@ function Heap:drain()
     end
     return out
 end
+
+Heap.__len = Heap.size
 
 lib.heap = Heap
 return lib.heap

--- a/imports/heap/shared.lua
+++ b/imports/heap/shared.lua
@@ -111,7 +111,7 @@ function lib.heap:clear()
     return self
 end
 
----@return Array sorted newly-allocated array drained in pop order.
+---@return Array sorted Newly-allocated array drained in pop order.
 function lib.heap:drain()
     local out = lib.array:new()
     local n = 0

--- a/imports/heap/shared.lua
+++ b/imports/heap/shared.lua
@@ -1,0 +1,130 @@
+--[[
+    https://github.com/overextended/ox_lib
+
+    This file is licensed under LGPL-3.0 or higher <https://www.gnu.org/licenses/lgpl-3.0.en.html>
+
+    Copyright © 2025 Linden <https://github.com/thelindat>
+]]
+
+---@class Heap : OxClass
+---@field private new HeapConstructor
+local Heap = lib.class('Heap')
+
+local function defaultLess(a, b) return a < b end
+
+local function siftUp(items, i, lt)
+    while i > 1 do
+        local parent = i >> 1
+        if not lt(items[i], items[parent]) then return end
+        items[i], items[parent] = items[parent], items[i]
+        i = parent
+    end
+end
+
+local function siftDown(items, i, n, lt)
+    while true do
+        local left = i * 2
+        if left > n then return end
+
+        local smallest = i
+        if lt(items[left], items[smallest]) then smallest = left end
+
+        local right = left + 1
+        if right <= n and lt(items[right], items[smallest]) then smallest = right end
+
+        if smallest == i then return end
+
+        items[i], items[smallest] = items[smallest], items[i]
+        i = smallest
+    end
+end
+
+---@class HeapConstructor
+---@overload fun(self: Heap, comparator?: fun(a: any, b: any): boolean): Heap
+---@private
+---@param comparator? fun(a: any, b: any): boolean Returns true when `a` should come before `b`. Defaults to `a < b` (min-heap).
+function Heap:constructor(comparator)
+    if comparator ~= nil and type(comparator) ~= 'function' then
+        error("comparator must be a function or nil", 2)
+    end
+
+    self.private.items = {}
+    self.private.lt = comparator or defaultLess
+end
+
+---@param value any
+---@return Heap self
+function Heap:push(value)
+    local items = self.private.items
+    items[#items + 1] = value
+    siftUp(items, #items, self.private.lt)
+    return self
+end
+
+---@return any?
+function Heap:pop()
+    local items = self.private.items
+    local n = #items
+    if n == 0 then return nil end
+
+    local top = items[1]
+
+    if n == 1 then
+        items[1] = nil
+    else
+        items[1] = items[n]
+        items[n] = nil
+        siftDown(items, 1, n - 1, self.private.lt)
+    end
+
+    return top
+end
+
+---@return any?
+function Heap:peek()
+    return self.private.items[1]
+end
+
+---@return integer
+function Heap:size()
+    return #self.private.items
+end
+
+---@return boolean
+function Heap:isEmpty()
+    return #self.private.items == 0
+end
+
+---@return Heap self
+function Heap:clear()
+    self.private.items = {}
+    return self
+end
+
+---@param values any[]
+---@return Heap self
+function Heap:pushAll(values)
+    local items = self.private.items
+    local lt = self.private.lt
+
+    for i = 1, #values do
+        items[#items + 1] = values[i]
+        siftUp(items, #items, lt)
+    end
+
+    return self
+end
+
+---@return Array sorted Newly-allocated array drained in pop order.
+function Heap:drain()
+    local out = lib.array:new()
+    local n = 0
+    while #self.private.items > 0 do
+        n += 1
+        out[n] = self:pop()
+    end
+    return out
+end
+
+lib.heap = Heap
+return lib.heap

--- a/imports/heap/shared.lua
+++ b/imports/heap/shared.lua
@@ -107,7 +107,7 @@ end
 
 ---@return Heap self
 function lib.heap:clear()
-    self.private.items = {}
+    table.wipe(self.private.items)
     return self
 end
 

--- a/imports/heap/shared.lua
+++ b/imports/heap/shared.lua
@@ -111,7 +111,7 @@ function lib.heap:clear()
     return self
 end
 
----@return Array sorted Newly-allocated array drained in pop order.
+---@return Array sorted newly-allocated array drained in pop order.
 function lib.heap:drain()
     local out = lib.array:new()
     local n = 0

--- a/imports/heap/shared.lua
+++ b/imports/heap/shared.lua
@@ -55,13 +55,17 @@ end
 ---@param ... any
 ---@return Heap self
 function lib.heap:push(...)
+    local n = select('#', ...)
+    if n == 0 then return self end
+
     local items = self.private.items
     local lt = self.private.lt
-    local n = select('#', ...)
+    local startIndex = #items
+
+    table.move({ ... }, 1, n, startIndex + 1, items)
 
     for i = 1, n do
-        items[#items + 1] = (select(i, ...))
-        siftUp(items, #items, lt)
+        siftUp(items, startIndex + i, lt)
     end
 
     return self

--- a/imports/lru/shared.lua
+++ b/imports/lru/shared.lua
@@ -14,7 +14,7 @@
 
 ---@class Lru : OxClass
 ---@field private new LruConstructor
-local Lru = lib.class('Lru')
+lib.lru = lib.class('Lru')
 
 local function detach(self, node)
     local prev, nxt = node.prev, node.next
@@ -36,7 +36,7 @@ end
 ---@overload fun(self: Lru, capacity: integer): Lru
 ---@private
 ---@param capacity integer
-function Lru:constructor(capacity)
+function lib.lru:constructor(capacity)
     if type(capacity) ~= 'number' or capacity < 1 or capacity % 1 ~= 0 then
         error("capacity must be a positive integer", 2)
     end
@@ -50,7 +50,7 @@ end
 
 ---@param key any
 ---@return any?
-function Lru:get(key)
+function lib.lru:get(key)
     local node = self.private.map[key]
     if not node then return nil end
     detach(self, node)
@@ -62,7 +62,7 @@ end
 ---@param value any
 ---@return any? evictedKey
 ---@return any? evictedValue
-function Lru:set(key, value)
+function lib.lru:set(key, value)
     local node = self.private.map[key]
 
     if node then
@@ -88,13 +88,13 @@ end
 
 ---@param key any
 ---@return boolean
-function Lru:has(key)
+function lib.lru:has(key)
     return self.private.map[key] ~= nil
 end
 
 ---@param key any
 ---@return any?
-function Lru:peek(key)
+function lib.lru:peek(key)
     local node = self.private.map[key]
     if not node then return nil end
     return node.value
@@ -102,7 +102,7 @@ end
 
 ---@param key any
 ---@return boolean removed
-function Lru:delete(key)
+function lib.lru:delete(key)
     local node = self.private.map[key]
     if not node then return false end
     detach(self, node)
@@ -112,17 +112,17 @@ function Lru:delete(key)
 end
 
 ---@return integer
-function Lru:size()
+function lib.lru:size()
     return self.private.count
 end
 
 ---@return integer
-function Lru:capacity()
+function lib.lru:capacity()
     return self.private.capacity
 end
 
 ---@return Lru self
-function Lru:clear()
+function lib.lru:clear()
     self.private.map = {}
     self.private.head = nil
     self.private.tail = nil
@@ -131,7 +131,7 @@ function Lru:clear()
 end
 
 ---@return fun(): any?, any?
-function Lru:each()
+function lib.lru:each()
     local node = self.private.head
     return function()
         if not node then return nil end
@@ -141,11 +141,10 @@ function Lru:each()
     end
 end
 
-function Lru:__pairs()
+function lib.lru:__pairs()
     return self:each(), nil, nil
 end
 
-Lru.__len = Lru.size
+lib.lru.__len = lib.lru.size
 
-lib.lru = Lru
 return lib.lru

--- a/imports/lru/shared.lua
+++ b/imports/lru/shared.lua
@@ -141,5 +141,11 @@ function Lru:each()
     end
 end
 
+function Lru:__pairs()
+    return self:each(), nil, nil
+end
+
+Lru.__len = Lru.size
+
 lib.lru = Lru
 return lib.lru

--- a/imports/lru/shared.lua
+++ b/imports/lru/shared.lua
@@ -123,7 +123,7 @@ end
 
 ---@return Lru self
 function lib.lru:clear()
-    self.private.map = {}
+    table.wipe(self.private.map)
     self.private.head = nil
     self.private.tail = nil
     self.private.count = 0

--- a/imports/lru/shared.lua
+++ b/imports/lru/shared.lua
@@ -1,0 +1,145 @@
+--[[
+    https://github.com/overextended/ox_lib
+
+    This file is licensed under LGPL-3.0 or higher <https://www.gnu.org/licenses/lgpl-3.0.en.html>
+
+    Copyright © 2025 Linden <https://github.com/thelindat>
+]]
+
+---@class LruNode
+---@field key any
+---@field value any
+---@field prev? LruNode
+---@field next? LruNode
+
+---@class Lru : OxClass
+---@field private new LruConstructor
+local Lru = lib.class('Lru')
+
+local function detach(self, node)
+    local prev, nxt = node.prev, node.next
+    if prev then prev.next = nxt else self.private.head = nxt end
+    if nxt then nxt.prev = prev else self.private.tail = prev end
+    node.prev = nil
+    node.next = nil
+end
+
+local function attachHead(self, node)
+    node.prev = nil
+    node.next = self.private.head
+    if self.private.head then self.private.head.prev = node end
+    self.private.head = node
+    if not self.private.tail then self.private.tail = node end
+end
+
+---@class LruConstructor
+---@overload fun(self: Lru, capacity: integer): Lru
+---@private
+---@param capacity integer
+function Lru:constructor(capacity)
+    if type(capacity) ~= 'number' or capacity < 1 or capacity % 1 ~= 0 then
+        error("capacity must be a positive integer", 2)
+    end
+
+    self.private.capacity = capacity
+    self.private.map = {}
+    self.private.count = 0
+    self.private.head = nil
+    self.private.tail = nil
+end
+
+---@param key any
+---@return any?
+function Lru:get(key)
+    local node = self.private.map[key]
+    if not node then return nil end
+    detach(self, node)
+    attachHead(self, node)
+    return node.value
+end
+
+---@param key any
+---@param value any
+---@return any? evictedKey
+---@return any? evictedValue
+function Lru:set(key, value)
+    local node = self.private.map[key]
+
+    if node then
+        node.value = value
+        detach(self, node)
+        attachHead(self, node)
+        return nil
+    end
+
+    node = { key = key, value = value }
+    self.private.map[key] = node
+    attachHead(self, node)
+    self.private.count += 1
+
+    if self.private.count > self.private.capacity then
+        local evicted = self.private.tail
+        detach(self, evicted)
+        self.private.map[evicted.key] = nil
+        self.private.count -= 1
+        return evicted.key, evicted.value
+    end
+end
+
+---@param key any
+---@return boolean
+function Lru:has(key)
+    return self.private.map[key] ~= nil
+end
+
+---@param key any
+---@return any?
+function Lru:peek(key)
+    local node = self.private.map[key]
+    if not node then return nil end
+    return node.value
+end
+
+---@param key any
+---@return boolean removed
+function Lru:delete(key)
+    local node = self.private.map[key]
+    if not node then return false end
+    detach(self, node)
+    self.private.map[key] = nil
+    self.private.count -= 1
+    return true
+end
+
+---@return integer
+function Lru:size()
+    return self.private.count
+end
+
+---@return integer
+function Lru:capacity()
+    return self.private.capacity
+end
+
+---@return Lru self
+function Lru:clear()
+    self.private.map = {}
+    self.private.head = nil
+    self.private.tail = nil
+    self.private.count = 0
+    return self
+end
+
+---@return fun(): any?, any?
+function Lru:each()
+    local node = self.private.head
+    return function()
+        if not node then return nil end
+        local k, v = node.key, node.value
+        node = node.next
+        return k, v
+    end
+end
+
+lib.lru = Lru
+return lib.lru

--- a/imports/ringbuffer/shared.lua
+++ b/imports/ringbuffer/shared.lua
@@ -109,6 +109,12 @@ function RingBuffer:each()
     end
 end
 
+function RingBuffer:__pairs()
+    return self:each(), nil, nil
+end
+
+RingBuffer.__len = RingBuffer.size
+
 ---@return Array oldestFirst
 function RingBuffer:toArray()
     return lib.array:from(self:each())

--- a/imports/ringbuffer/shared.lua
+++ b/imports/ringbuffer/shared.lua
@@ -88,7 +88,7 @@ end
 
 ---@return RingBuffer self
 function lib.ringbuffer:clear()
-    self.private.items = table.create(self.private.capacity, 0)
+    table.wipe(self.private.items)
     self.private.count = 0
     self.private.nextIndex = 1
     return self

--- a/imports/ringbuffer/shared.lua
+++ b/imports/ringbuffer/shared.lua
@@ -8,13 +8,13 @@
 
 ---@class RingBuffer : OxClass
 ---@field private new RingBufferConstructor
-local RingBuffer = lib.class('RingBuffer')
+lib.ringbuffer = lib.class('RingBuffer')
 
 ---@class RingBufferConstructor
 ---@overload fun(self: RingBuffer, capacity: integer): RingBuffer
 ---@private
 ---@param capacity integer
-function RingBuffer:constructor(capacity)
+function lib.ringbuffer:constructor(capacity)
     if type(capacity) ~= 'number' or capacity < 1 or capacity % 1 ~= 0 then
         error("capacity must be a positive integer", 2)
     end
@@ -27,7 +27,7 @@ end
 
 ---@param value any
 ---@return any? evicted Value that was overwritten, if the buffer was full.
-function RingBuffer:push(value)
+function lib.ringbuffer:push(value)
     local items = self.private.items
     local capacity = self.private.capacity
     local nextIndex = self.private.nextIndex
@@ -52,7 +52,7 @@ end
 
 ---@param i integer Positive index from the oldest (1 = oldest); negative from the newest (-1 = newest).
 ---@return any?
-function RingBuffer:get(i)
+function lib.ringbuffer:get(i)
     if type(i) ~= 'number' or i % 1 ~= 0 then
         error("index must be an integer", 2)
     end
@@ -67,27 +67,27 @@ function RingBuffer:get(i)
 end
 
 ---@return integer
-function RingBuffer:size()
+function lib.ringbuffer:size()
     return self.private.count
 end
 
 ---@return integer
-function RingBuffer:capacity()
+function lib.ringbuffer:capacity()
     return self.private.capacity
 end
 
 ---@return boolean
-function RingBuffer:isFull()
+function lib.ringbuffer:isFull()
     return self.private.count == self.private.capacity
 end
 
 ---@return boolean
-function RingBuffer:isEmpty()
+function lib.ringbuffer:isEmpty()
     return self.private.count == 0
 end
 
 ---@return RingBuffer self
-function RingBuffer:clear()
+function lib.ringbuffer:clear()
     self.private.items = table.create(self.private.capacity, 0)
     self.private.count = 0
     self.private.nextIndex = 1
@@ -95,7 +95,7 @@ function RingBuffer:clear()
 end
 
 ---@return fun(): any?
-function RingBuffer:each()
+function lib.ringbuffer:each()
     local count = self.private.count
     local capacity = self.private.capacity
     local items = self.private.items
@@ -109,16 +109,15 @@ function RingBuffer:each()
     end
 end
 
-function RingBuffer:__pairs()
+function lib.ringbuffer:__pairs()
     return self:each(), nil, nil
 end
 
-RingBuffer.__len = RingBuffer.size
+lib.ringbuffer.__len = lib.ringbuffer.size
 
 ---@return Array oldestFirst
-function RingBuffer:toArray()
+function lib.ringbuffer:toArray()
     return lib.array:from(self:each())
 end
 
-lib.ringbuffer = RingBuffer
 return lib.ringbuffer

--- a/imports/ringbuffer/shared.lua
+++ b/imports/ringbuffer/shared.lua
@@ -1,0 +1,118 @@
+--[[
+    https://github.com/overextended/ox_lib
+
+    This file is licensed under LGPL-3.0 or higher <https://www.gnu.org/licenses/lgpl-3.0.en.html>
+
+    Copyright © 2025 Linden <https://github.com/thelindat>
+]]
+
+---@class RingBuffer : OxClass
+---@field private new RingBufferConstructor
+local RingBuffer = lib.class('RingBuffer')
+
+---@class RingBufferConstructor
+---@overload fun(self: RingBuffer, capacity: integer): RingBuffer
+---@private
+---@param capacity integer
+function RingBuffer:constructor(capacity)
+    if type(capacity) ~= 'number' or capacity < 1 or capacity % 1 ~= 0 then
+        error("capacity must be a positive integer", 2)
+    end
+
+    self.private.items = table.create(capacity, 0)
+    self.private.capacity = capacity
+    self.private.count = 0
+    self.private.nextIndex = 1
+end
+
+---@param value any
+---@return any? evicted Value that was overwritten, if the buffer was full.
+function RingBuffer:push(value)
+    local items = self.private.items
+    local capacity = self.private.capacity
+    local nextIndex = self.private.nextIndex
+
+    local evicted
+    if self.private.count == capacity then
+        evicted = items[nextIndex]
+    else
+        self.private.count += 1
+    end
+
+    items[nextIndex] = value
+    self.private.nextIndex = nextIndex % capacity + 1
+
+    return evicted
+end
+
+local function oldestIndex(self)
+    if self.private.count < self.private.capacity then return 1 end
+    return self.private.nextIndex
+end
+
+---@param i integer Positive index from the oldest (1 = oldest); negative from the newest (-1 = newest).
+---@return any?
+function RingBuffer:get(i)
+    if type(i) ~= 'number' or i % 1 ~= 0 then
+        error("index must be an integer", 2)
+    end
+
+    local count = self.private.count
+    if i < 0 then i = count + i + 1 end
+    if i < 1 or i > count then return nil end
+
+    local start = oldestIndex(self)
+    local capacity = self.private.capacity
+    return self.private.items[((start - 1 + i - 1) % capacity) + 1]
+end
+
+---@return integer
+function RingBuffer:size()
+    return self.private.count
+end
+
+---@return integer
+function RingBuffer:capacity()
+    return self.private.capacity
+end
+
+---@return boolean
+function RingBuffer:isFull()
+    return self.private.count == self.private.capacity
+end
+
+---@return boolean
+function RingBuffer:isEmpty()
+    return self.private.count == 0
+end
+
+---@return RingBuffer self
+function RingBuffer:clear()
+    self.private.items = table.create(self.private.capacity, 0)
+    self.private.count = 0
+    self.private.nextIndex = 1
+    return self
+end
+
+---@return fun(): any?
+function RingBuffer:each()
+    local count = self.private.count
+    local capacity = self.private.capacity
+    local items = self.private.items
+    local start = oldestIndex(self)
+    local i = 0
+
+    return function()
+        i += 1
+        if i > count then return nil end
+        return items[((start - 1 + i - 1) % capacity) + 1]
+    end
+end
+
+---@return Array oldestFirst
+function RingBuffer:toArray()
+    return lib.array:from(self:each())
+end
+
+lib.ringbuffer = RingBuffer
+return lib.ringbuffer

--- a/imports/set/shared.lua
+++ b/imports/set/shared.lua
@@ -1,0 +1,138 @@
+--[[
+    https://github.com/overextended/ox_lib
+
+    This file is licensed under LGPL-3.0 or higher <https://www.gnu.org/licenses/lgpl-3.0.en.html>
+
+    Copyright © 2025 Linden <https://github.com/thelindat>
+]]
+
+---@class Set : OxClass
+---@field private new SetConstructor
+local Set = lib.class('Set')
+
+---@class SetConstructor
+---@overload fun(self: Set, values?: any[]): Set
+---@private
+---@param values? any[]
+function Set:constructor(values)
+    self.private.items = {}
+    self.private.count = 0
+
+    if values then
+        for i = 1, #values do
+            local v = values[i]
+            if not self.private.items[v] then
+                self.private.items[v] = true
+                self.private.count += 1
+            end
+        end
+    end
+end
+
+---@param value any
+---@return Set self
+function Set:add(value)
+    if not self.private.items[value] then
+        self.private.items[value] = true
+        self.private.count += 1
+    end
+    return self
+end
+
+---@param value any
+---@return boolean removed
+function Set:remove(value)
+    if not self.private.items[value] then return false end
+    self.private.items[value] = nil
+    self.private.count -= 1
+    return true
+end
+
+---@param value any
+---@return boolean
+function Set:has(value)
+    return self.private.items[value] ~= nil
+end
+
+---@return integer
+function Set:size()
+    return self.private.count
+end
+
+---@return boolean
+function Set:isEmpty()
+    return self.private.count == 0
+end
+
+---@return Set self
+function Set:clear()
+    self.private.items = {}
+    self.private.count = 0
+    return self
+end
+
+---@return fun(): any?
+function Set:each()
+    local items = self.private.items
+    local k
+    return function()
+        k = next(items, k)
+        return k
+    end
+end
+
+---@return Array
+function Set:toArray()
+    return lib.array:from(self:each())
+end
+
+---@param other Set
+---@return Set
+function Set:union(other)
+    local result = lib.set(self:toArray())
+    for v in other:each() do result:add(v) end
+    return result
+end
+
+---@param other Set
+---@return Set
+function Set:intersection(other)
+    local result = lib.set()
+    for v in self:each() do
+        if other:has(v) then result:add(v) end
+    end
+    return result
+end
+
+---@param other Set
+---@return Set
+function Set:difference(other)
+    local result = lib.set()
+    for v in self:each() do
+        if not other:has(v) then result:add(v) end
+    end
+    return result
+end
+
+---@param other Set
+---@return boolean
+function Set:equals(other)
+    if self.private.count ~= other:size() then return false end
+    for v in self:each() do
+        if not other:has(v) then return false end
+    end
+    return true
+end
+
+---@param other Set
+---@return boolean
+function Set:isSubsetOf(other)
+    if self.private.count > other:size() then return false end
+    for v in self:each() do
+        if not other:has(v) then return false end
+    end
+    return true
+end
+
+lib.set = Set
+return lib.set

--- a/imports/set/shared.lua
+++ b/imports/set/shared.lua
@@ -72,8 +72,8 @@ end
 
 ---@return Set self
 function lib.set:clear()
-    self.private.items = {}
-    self.private.index = {}
+    table.wipe(self.private.items)
+    table.wipe(self.private.index)
     return self
 end
 

--- a/imports/set/shared.lua
+++ b/imports/set/shared.lua
@@ -44,9 +44,10 @@ function lib.set:remove(value)
     local lastI = #items
 
     if i ~= lastI then
-        local last = items[lastI]
-        items[i] = last
-        self.private.index[last] = i
+        table.move(items, i + 1, lastI, i)
+        for j = i, lastI - 1 do
+            self.private.index[items[j]] = j
+        end
     end
 
     items[lastI] = nil

--- a/imports/set/shared.lua
+++ b/imports/set/shared.lua
@@ -17,9 +17,9 @@ function lib.set:constructor(...)
     self.private.items = {}
     self.private.index = {}
 
-    local n = select('#', ...)
-    for i = 1, n do
-        self:add((select(i, ...)))
+    local args = { ... }
+    for i = 1, select('#', ...) do
+        self:add(args[i])
     end
 end
 

--- a/imports/set/shared.lua
+++ b/imports/set/shared.lua
@@ -11,85 +11,99 @@
 local Set = lib.class('Set')
 
 ---@class SetConstructor
----@overload fun(self: Set, values?: any[]): Set
+---@overload fun(self: Set, ...: any): Set
 ---@private
----@param values? any[]
-function Set:constructor(values)
+function Set:constructor(...)
     self.private.items = {}
-    self.private.count = 0
+    self.private.index = {}
 
-    if values then
-        for i = 1, #values do
-            local v = values[i]
-            if not self.private.items[v] then
-                self.private.items[v] = true
-                self.private.count += 1
-            end
-        end
+    local n = select('#', ...)
+    for i = 1, n do
+        self:add((select(i, ...)))
     end
 end
 
 ---@param value any
 ---@return Set self
 function Set:add(value)
-    if not self.private.items[value] then
-        self.private.items[value] = true
-        self.private.count += 1
-    end
+    if value == nil or self.private.index[value] then return self end
+    local items = self.private.items
+    local i = #items + 1
+    items[i] = value
+    self.private.index[value] = i
     return self
 end
 
 ---@param value any
 ---@return boolean removed
 function Set:remove(value)
-    if not self.private.items[value] then return false end
-    self.private.items[value] = nil
-    self.private.count -= 1
+    local i = self.private.index[value]
+    if not i then return false end
+
+    local items = self.private.items
+    local lastI = #items
+
+    if i ~= lastI then
+        local last = items[lastI]
+        items[i] = last
+        self.private.index[last] = i
+    end
+
+    items[lastI] = nil
+    self.private.index[value] = nil
     return true
 end
 
 ---@param value any
 ---@return boolean
 function Set:has(value)
-    return self.private.items[value] ~= nil
+    return self.private.index[value] ~= nil
 end
 
 ---@return integer
 function Set:size()
-    return self.private.count
+    return #self.private.items
 end
 
 ---@return boolean
 function Set:isEmpty()
-    return self.private.count == 0
+    return #self.private.items == 0
 end
 
 ---@return Set self
 function Set:clear()
     self.private.items = {}
-    self.private.count = 0
+    self.private.index = {}
     return self
 end
 
 ---@return fun(): any?
 function Set:each()
     local items = self.private.items
-    local k
+    local i = 0
     return function()
-        k = next(items, k)
-        return k
+        i += 1
+        return items[i]
     end
 end
 
+function Set:__pairs()
+    return self:each(), nil, nil
+end
+
+Set.__len = Set.size
+
 ---@return Array
 function Set:toArray()
-    return lib.array:from(self:each())
+    return lib.array:from(self.private.items)
 end
 
 ---@param other Set
 ---@return Set
 function Set:union(other)
-    local result = lib.set(self:toArray())
+    local result = Set:new()
+    local items = self.private.items
+    for i = 1, #items do result:add(items[i]) end
     for v in other:each() do result:add(v) end
     return result
 end
@@ -97,9 +111,10 @@ end
 ---@param other Set
 ---@return Set
 function Set:intersection(other)
-    local result = lib.set()
-    for v in self:each() do
-        if other:has(v) then result:add(v) end
+    local result = Set:new()
+    local items = self.private.items
+    for i = 1, #items do
+        if other:has(items[i]) then result:add(items[i]) end
     end
     return result
 end
@@ -107,9 +122,10 @@ end
 ---@param other Set
 ---@return Set
 function Set:difference(other)
-    local result = lib.set()
-    for v in self:each() do
-        if not other:has(v) then result:add(v) end
+    local result = Set:new()
+    local items = self.private.items
+    for i = 1, #items do
+        if not other:has(items[i]) then result:add(items[i]) end
     end
     return result
 end
@@ -117,9 +133,10 @@ end
 ---@param other Set
 ---@return boolean
 function Set:equals(other)
-    if self.private.count ~= other:size() then return false end
-    for v in self:each() do
-        if not other:has(v) then return false end
+    if #self.private.items ~= other:size() then return false end
+    local items = self.private.items
+    for i = 1, #items do
+        if not other:has(items[i]) then return false end
     end
     return true
 end
@@ -127,9 +144,10 @@ end
 ---@param other Set
 ---@return boolean
 function Set:isSubsetOf(other)
-    if self.private.count > other:size() then return false end
-    for v in self:each() do
-        if not other:has(v) then return false end
+    if #self.private.items > other:size() then return false end
+    local items = self.private.items
+    for i = 1, #items do
+        if not other:has(items[i]) then return false end
     end
     return true
 end

--- a/imports/set/shared.lua
+++ b/imports/set/shared.lua
@@ -89,9 +89,10 @@ function lib.set:each()
 end
 
 function lib.set:__pairs()
-    return self:each(), nil, nil
+    return next, self.private.items
 end
 
+lib.set.__ipairs = lib.set.__pairs
 lib.set.__len = lib.set.size
 
 ---@return Array

--- a/imports/set/shared.lua
+++ b/imports/set/shared.lua
@@ -8,12 +8,12 @@
 
 ---@class Set : OxClass
 ---@field private new SetConstructor
-local Set = lib.class('Set')
+lib.set = lib.class('Set')
 
 ---@class SetConstructor
 ---@overload fun(self: Set, ...: any): Set
 ---@private
-function Set:constructor(...)
+function lib.set:constructor(...)
     self.private.items = {}
     self.private.index = {}
 
@@ -25,7 +25,7 @@ end
 
 ---@param value any
 ---@return Set self
-function Set:add(value)
+function lib.set:add(value)
     if value == nil or self.private.index[value] then return self end
     local items = self.private.items
     local i = #items + 1
@@ -36,7 +36,7 @@ end
 
 ---@param value any
 ---@return boolean removed
-function Set:remove(value)
+function lib.set:remove(value)
     local i = self.private.index[value]
     if not i then return false end
 
@@ -56,29 +56,29 @@ end
 
 ---@param value any
 ---@return boolean
-function Set:has(value)
+function lib.set:has(value)
     return self.private.index[value] ~= nil
 end
 
 ---@return integer
-function Set:size()
+function lib.set:size()
     return #self.private.items
 end
 
 ---@return boolean
-function Set:isEmpty()
+function lib.set:isEmpty()
     return #self.private.items == 0
 end
 
 ---@return Set self
-function Set:clear()
+function lib.set:clear()
     self.private.items = {}
     self.private.index = {}
     return self
 end
 
 ---@return fun(): any?
-function Set:each()
+function lib.set:each()
     local items = self.private.items
     local i = 0
     return function()
@@ -87,21 +87,21 @@ function Set:each()
     end
 end
 
-function Set:__pairs()
+function lib.set:__pairs()
     return self:each(), nil, nil
 end
 
-Set.__len = Set.size
+lib.set.__len = lib.set.size
 
 ---@return Array
-function Set:toArray()
+function lib.set:toArray()
     return lib.array:from(self.private.items)
 end
 
 ---@param other Set
 ---@return Set
-function Set:union(other)
-    local result = Set:new()
+function lib.set:union(other)
+    local result = lib.set:new()
     local items = self.private.items
     for i = 1, #items do result:add(items[i]) end
     for v in other:each() do result:add(v) end
@@ -110,8 +110,8 @@ end
 
 ---@param other Set
 ---@return Set
-function Set:intersection(other)
-    local result = Set:new()
+function lib.set:intersection(other)
+    local result = lib.set:new()
     local items = self.private.items
     for i = 1, #items do
         if other:has(items[i]) then result:add(items[i]) end
@@ -121,8 +121,8 @@ end
 
 ---@param other Set
 ---@return Set
-function Set:difference(other)
-    local result = Set:new()
+function lib.set:difference(other)
+    local result = lib.set:new()
     local items = self.private.items
     for i = 1, #items do
         if not other:has(items[i]) then result:add(items[i]) end
@@ -132,7 +132,7 @@ end
 
 ---@param other Set
 ---@return boolean
-function Set:equals(other)
+function lib.set:equals(other)
     if #self.private.items ~= other:size() then return false end
     local items = self.private.items
     for i = 1, #items do
@@ -143,7 +143,7 @@ end
 
 ---@param other Set
 ---@return boolean
-function Set:isSubsetOf(other)
+function lib.set:isSubsetOf(other)
     if #self.private.items > other:size() then return false end
     local items = self.private.items
     for i = 1, #items do
@@ -152,5 +152,4 @@ function Set:isSubsetOf(other)
     return true
 end
 
-lib.set = Set
 return lib.set


### PR DESCRIPTION
## Add four collection types: `lib.set`, `lib.ringbuffer`, `lib.lru`, `lib.heap`

Each is its own `OxClass`, one file per type, no cross-dependencies. The PR is split into four feature commits plus one follow-up commit that applies maintainer feedback (varargs constructors, sparse-set storage for Set, `__pairs`/`__len` metamethods on the iterables).

## `lib.set`: Unique values with set operations

Use when you want membership semantics with real ops (union, intersection, difference, subset). Storage is dense-array + hashmap (sparse-set style), so `add`/`remove`/`has` are O(1) and the underlying array gives clean iteration. Swap-remove on `:remove`. Insertion order is preserved until the first delete.

```lua
local online = lib.set:new(1, 2, 3, 4)
local admins = lib.set:new(2, 5)

online:has(2)              -- true
online:add(6):add(7)       -- chainable
online:remove(1)           -- → true (was present)
online:size()              -- 5
#online                    -- 5  (__len)

-- set algebra
local both       = online:intersection(admins)   -- Set { 2 }
local everybody  = online:union(admins)          -- Set { 2, 3, 4, 5, 6, 7 }
local nonAdmins  = online:difference(admins)     -- Set { 3, 4, 6, 7 }

online:isSubsetOf(everybody)                     -- true
online:equals(lib.set:new(2, 3, 4, 6, 7))        -- true

-- iteration
for playerId in pairs(online) do                 -- __pairs (single-value yield)
    print(playerId)
end

for playerId in online:each() do                 -- or explicit
    print(playerId)
end

online:toArray()                                 -- returns Array, chain :map/:filter/:reduce
```

---

## `lib.ringbuffer`: Fixed-capacity rolling log

Use when you want "the last N of something." Kill feeds, chat backlogs, recent damage events, audit trails, recent errors. `push` returns whatever was evicted, so you can hook a cleanup pass without a separate query.

```lua
local recent = lib.ringbuffer:new(3)

recent:push('a')           -- nil  (room left)
recent:push('b')           -- nil
recent:push('c')           -- nil  (buffer full)
recent:push('d')           -- 'a'  (evicted)

recent:get(1)              -- 'b'  (oldest)
recent:get(-1)             -- 'd'  (newest; negative indexes from end)
recent:size()              -- 3
#recent                    -- 3   (__len)
recent:isFull()            -- true

recent:toArray()           -- Array { 'b', 'c', 'd' }  (oldest first)

for entry in pairs(recent) do     -- __pairs
    print(entry)
end
```

---

## `lib.lru`: Bounded cache with LRU eviction

Use when you want to cache things but bound the size. HTTP response memo, oxmysql query cache, player-metadata lookup, "remember the last N times someone did X." Unbounded tables leak memory in long-running servers; this gives you a hard ceiling and evicts the least-recently-used entry on overflow.

```lua
local cache = lib.lru:new(100)

cache:set('player:42', metadata)
cache:get('player:42')                -- bumps to most-recently-used
cache:has('player:42')                -- true (no bump)
cache:peek('player:42')               -- read without bumping

-- evictions are surfaced
local evictedKey, evictedValue = cache:set('player:101', otherMetadata)
if evictedKey then
    print(('cache evicted %s'):format(evictedKey))
end

cache:delete('player:42')             -- → true
cache:size()                          -- 1
#cache                                -- 1   (__len)
cache:capacity()                      -- 100
cache:clear()

-- iterate MRU → LRU
for k, v in pairs(cache) do           -- __pairs (two-value yield)
    print(k, v)
end
```

---

## `lib.heap`: Binary heap / priority queue

Use when you need the smallest (or comparator-first) item out of a growing set in O(log n). Dispatch by priority, scheduled events.

```lua
-- min-heap (default)
local h = lib.heap:new()
h:push(5):push(1):push(3):push(2)
h:peek()                              -- 1
h:pop()                               -- 1
h:pop()                               -- 2
h:size()                              -- 2
#h                                    -- 2   (__len)

-- varargs push
local h2 = lib.heap:new()
h2:push(5, 1, 3, 2, 8, 4)
h2:drain()                            -- Array { 1, 2, 3, 4, 5, 8 }

-- max-heap via comparator
local maxHeap = lib.heap:new(function(a, b) return a > b end)
maxHeap:push(3, 1, 4, 1, 5, 9)
maxHeap:pop()                         -- 9

-- priority queue of objects
local dispatch = lib.heap:new(function(a, b) return a.priority < b.priority end)
dispatch:push(
    { priority = 5, call = 'noise complaint' },
    { priority = 1, call = 'shots fired' },
    { priority = 3, call = 'traffic stop' }
)

while not dispatch:isEmpty() do
    local job = dispatch:pop()
    print(job.priority, job.call)
end
-- 1  shots fired
-- 3  traffic stop
-- 5  noise complaint
```