### PR TITLE
feat(radial) Add new methods to add & remove items from submenus

### DIFF
--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -194,6 +194,64 @@ function lib.removeRadialItem(id)
     refreshRadial(id)
 end
 
+---Registers an item or array of items in a specific radial sub menu.
+---@param string parentMenuId
+---@param items RadialMenuItem | RadialMenuItem[]
+function lib.addRadialSubItem(parentMenuId, items)
+
+    local parentMenu = menus[parentMenuId]
+    if not parentMenu then
+        return error('No radial menu with such id found.')
+    end
+
+    local invokingResource = GetInvokingResource()
+
+    items = table.type(items) == 'array' and items or { items }
+
+    for i = 1, #items do
+        local item = items[i]
+        item.resource = invokingResource
+
+        for j = 1, #parentMenu.items do
+            if parentMenu.items[j].id == item.id then
+                parentMenu.items[j] = item
+            end
+
+            if j == #parentMenu.items then
+                parentMenu.items[#parentMenu.items + 1] = item
+            end
+        end
+        
+    end
+
+    if isOpen then
+        refreshRadial(parentMenuId)
+    end
+end
+
+-- Removes an item from a radial submenu with the given parentMenuId
+---@param parentMenuId string
+---@param id string
+function lib.removeRadialSubItem(parentMenuId, id)
+    local parentMenu = menus[parentMenuId]
+    if not parentMenu then
+        return error('No radial menu with such id found.')
+    end
+
+    for i = 1, #parentMenu.items do
+        local item = parentMenu.items[i]
+
+        if item.id == id then
+            table.remove(parentMenu.items, i)
+            break
+        end
+    end
+
+    if isOpen then
+        refreshRadial(parentMenuId)
+    end
+end
+
 ---Removes all items from the global radial menu.
 function lib.clearRadialItems()
     table.wipe(menuItems)

--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -195,10 +195,9 @@ function lib.removeRadialItem(id)
 end
 
 ---Registers an item or array of items in a specific radial sub menu.
----@param string parentMenuId
+---@param parentMenuId string
 ---@param items RadialMenuItem | RadialMenuItem[]
 function lib.addRadialSubItem(parentMenuId, items)
-
     local parentMenu = menus[parentMenuId]
     if not parentMenu then
         return error('No radial menu with such id found.')
@@ -215,13 +214,13 @@ function lib.addRadialSubItem(parentMenuId, items)
         for j = 1, #parentMenu.items do
             if parentMenu.items[j].id == item.id then
                 parentMenu.items[j] = item
+                break
             end
 
             if j == #parentMenu.items then
                 parentMenu.items[#parentMenu.items + 1] = item
             end
         end
-        
     end
 
     if isOpen then

--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -142,8 +142,20 @@ end
 
 ---Registers an item or array of items in the global radial menu.
 ---@param items RadialMenuItem | RadialMenuItem[]
-function lib.addRadialItem(items)
-    local menuSize = #menuItems
+---@param parentMenuId string? If provided, the item(s) will be added to the specified radial submenu instead of the global menu.
+function lib.addRadialItem(items, parentMenuId)
+    local targetMenu
+    if parentMenuId then
+        if not menus[parentMenuId] then
+            return error('No radial submenu with such parent id found.')
+        end
+
+        targetMenu = menus[parentMenuId].items
+    else
+        targetMenu = menuItems
+    end
+
+    local menuSize = #targetMenu
     local invokingResource = GetInvokingResource()
 
     items = table.type(items) == 'array' and items or { items }
@@ -154,17 +166,17 @@ function lib.addRadialItem(items)
 
         if menuSize == 0 then
             menuSize += 1
-            menuItems[menuSize] = item
+            targetMenu[menuSize] = item
         else
             for j = 1, menuSize do
-                if menuItems[j].id == item.id then
-                    menuItems[j] = item
+                if targetMenu[j].id == item.id then
+                    targetMenu[j] = item
                     break
                 end
 
                 if j == menuSize then
                     menuSize += 1
-                    menuItems[menuSize] = item
+                    targetMenu[menuSize] = item
                 end
             end
         end
@@ -175,80 +187,34 @@ function lib.addRadialItem(items)
     end
 end
 
----Removes an item from the global radial menu with the given id.
+---Removes an item from the global radial menu or a specific radial submenu with the given id.
 ---@param id string
-function lib.removeRadialItem(id)
+---@param parentMenuId string? If provided, the item will be removed from the specified radial submenu instead of the global menu.
+function lib.removeRadialItem(id, parentMenuId)
     local menuItem
+    local targetMenu
+    if parentMenuId then
+        if not menus[parentMenuId] then
+            return error('No radial sub menu with such parent id found.')
+        end
 
-    for i = 1, #menuItems do
-        menuItem = menuItems[i]
+        targetMenu = menus[parentMenuId].items
+    else
+        targetMenu = menuItems
+    end
+
+    for i = 1, #targetMenu do
+        menuItem = targetMenu[i]
 
         if menuItem.id == id then
-            table.remove(menuItems, i)
+            table.remove(targetMenu, i)
             break
         end
     end
 
     if not isOpen then return end
 
-    refreshRadial(id)
-end
-
----Registers an item or array of items in a specific radial sub menu.
----@param parentMenuId string
----@param items RadialMenuItem | RadialMenuItem[]
-function lib.addRadialSubItem(parentMenuId, items)
-    local parentMenu = menus[parentMenuId]
-    if not parentMenu then
-        return error('No radial menu with such id found.')
-    end
-
-    local invokingResource = GetInvokingResource()
-
-    items = table.type(items) == 'array' and items or { items }
-
-    for i = 1, #items do
-        local item = items[i]
-        item.resource = invokingResource
-
-        for j = 1, #parentMenu.items do
-            if parentMenu.items[j].id == item.id then
-                parentMenu.items[j] = item
-                break
-            end
-
-            if j == #parentMenu.items then
-                parentMenu.items[#parentMenu.items + 1] = item
-            end
-        end
-    end
-
-    if isOpen then
-        refreshRadial(parentMenuId)
-    end
-end
-
--- Removes an item from a radial submenu with the given parentMenuId
----@param parentMenuId string
----@param id string
-function lib.removeRadialSubItem(parentMenuId, id)
-    local parentMenu = menus[parentMenuId]
-    if not parentMenu then
-        return error('No radial menu with such id found.')
-    end
-
-    for i = 1, #parentMenu.items do
-        local item = parentMenu.items[i]
-
-        if item.id == id then
-            table.remove(parentMenu.items, i)
-            break
-        end
-    end
-
-    if isOpen then
-        refreshRadial(parentMenuId)
-    end
+    refreshRadial()
 end
 
 ---Removes all items from the global radial menu.


### PR DESCRIPTION
Opened a second PR since i wanted to move this to a new branch as well as had to fix something on it.

This PR adds two new methods for the Radial Menu to allow better/more convenient management of sub menus for common scenarios such as adding & removing options within submenus based on certain conditions (e.g jobs, coords, states etc)

This makes using the radial menu features a lot more convenient and easier when trying to dynamically update what options are available to a player based on the conditions I listed above. 

The current approach is that you have to re-register the whole item/menu each time which is inefficient.

```lua
---Registers an item or array of items in a specific radial sub menu.
---@param parentMenuId string
---@param items RadialMenuItem | RadialMenuItem[]
function lib.addRadialSubItem(parentMenuId, items)
```

```lua
-- Removes an item from a radial submenu with the given parentMenuId
---@param parentMenuId string
---@param id string
function lib.removeRadialSubItem(parentMenuId, id)
```

When i asked around in discord and the docs etc, the current "way to do it" is re-registering the entire submenu e.g if i have an actions menu (globalmenu->actions) i'd have to re-register the entire menu and keep doing so based on conditions.

With these new methods, i can simply use the add and remove functions above to pluck options as needed.

Example usage based on the doc's [example menu](https://overextended.dev/ox_lib/Modules/Interface/Client/radial#usage-example)
```lua
lib.addRadialSubItem('police_menu', {
      {
          id = 'police.one',
          label = 'Hello',
          icon = 'fa-solid fa-car',
          onSelect = function()
              print('Hello')
          end,
      },
      {
          id = 'police.two',
          label = 'World',
          icon = 'fa-solid fa-print',
          onSelect = function()
              print('World')
          end,
      }
  })
```

An additional example would be a generic radial submenu with options e.g for player interactions and then based on either my permissions or a unique condition, I can make more options available or take some away.

And then if i wanted to remove a specific item based on my position, or whatever use case (this is similar to the use case for the docs example garage button being added/removed based on coords)

```lua
lib.removeRadialSubItem('police_menu', 'police.one')
```

Documentation PR was/is: https://github.com/overextended/overextended.github.io/pull/259
