### PR TITLE
feat: add insertion-ordered Map & refactor Set to use it

### DIFF
--- a/imports/heap/shared.lua
+++ b/imports/heap/shared.lua
@@ -6,30 +6,40 @@
     Copyright © 2025 Linden <https://github.com/thelindat>
 ]]
 
+---@alias HeapComparator fun(a: any, b: any): boolean
+
 ---@class Heap : OxClass
 ---@field private new HeapConstructor
 lib.heap = lib.class('Heap')
 
+---@type HeapComparator
 local function defaultLess(a, b) return a < b end
 
+---@param items any[]
+---@param i integer
+---@param lt HeapComparator
 local function siftUp(items, i, lt)
     while i > 1 do
-        local parent = i >> 1
+        local parent = i >> 1 ---@type integer
         if not lt(items[i], items[parent]) then return end
         items[i], items[parent] = items[parent], items[i]
         i = parent
     end
 end
 
+---@param items any[]
+---@param i integer
+---@param n integer
+---@param lt HeapComparator
 local function siftDown(items, i, n, lt)
     while true do
-        local left = i * 2
+        local left = i * 2 ---@type integer
         if left > n then return end
 
-        local smallest = i
+        local smallest = i ---@type integer
         if lt(items[left], items[smallest]) then smallest = left end
 
-        local right = left + 1
+        local right = left + 1 ---@type integer
         if right <= n and lt(items[right], items[smallest]) then smallest = right end
 
         if smallest == i then return end
@@ -40,9 +50,9 @@ local function siftDown(items, i, n, lt)
 end
 
 ---@class HeapConstructor
----@overload fun(self: Heap, comparator?: fun(a: any, b: any): boolean): Heap
+---@overload fun(self: Heap, comparator?: HeapComparator): Heap
 ---@private
----@param comparator? fun(a: any, b: any): boolean Returns true when `a` should come before `b`. Defaults to `a < b` (min-heap).
+---@param comparator? HeapComparator Returns true when `a` should come before `b`. Defaults to `a < b` (min-heap).
 function lib.heap:constructor(comparator)
     if comparator ~= nil and type(comparator) ~= 'function' then
         error("comparator must be a function or nil", 2)
@@ -55,12 +65,12 @@ end
 ---@param ... any
 ---@return Heap self
 function lib.heap:push(...)
-    local n = select('#', ...)
+    local n = select('#', ...) ---@type integer
     if n == 0 then return self end
 
-    local items = self.private.items
-    local lt = self.private.lt
-    local startIndex = #items
+    local items = self.private.items ---@type any[]
+    local lt = self.private.lt ---@type HeapComparator
+    local startIndex = #items ---@type integer
 
     table.move({ ... }, 1, n, startIndex + 1, items)
 
@@ -73,11 +83,11 @@ end
 
 ---@return any?
 function lib.heap:pop()
-    local items = self.private.items
-    local n = #items
+    local items = self.private.items ---@type any[]
+    local n = #items ---@type integer
     if n == 0 then return nil end
 
-    local top = items[1]
+    local top = items[1] ---@type any
 
     if n == 1 then
         items[1] = nil
@@ -111,10 +121,10 @@ function lib.heap:clear()
     return self
 end
 
----@return Array sorted Newly-allocated array drained in pop order.
+---@return Array sorted newly-allocated array drained in pop order.
 function lib.heap:drain()
-    local out = lib.array:new()
-    local n = 0
+    local out = lib.array:new() ---@type Array
+    local n = 0 ---@type integer
     while #self.private.items > 0 do
         n += 1
         out[n] = self:pop()

--- a/imports/heap/shared.lua
+++ b/imports/heap/shared.lua
@@ -8,8 +8,13 @@
 
 ---@alias HeapComparator fun(a: any, b: any): boolean
 
+---@class HeapPrivate
+---@field items any[]
+---@field lt HeapComparator
+
 ---@class Heap : OxClass
 ---@field private new HeapConstructor
+---@field private private HeapPrivate
 lib.heap = lib.class('Heap')
 
 ---@type HeapComparator
@@ -20,7 +25,7 @@ local function defaultLess(a, b) return a < b end
 ---@param lt HeapComparator
 local function siftUp(items, i, lt)
     while i > 1 do
-        local parent = i >> 1 ---@type integer
+        local parent = i >> 1
         if not lt(items[i], items[parent]) then return end
         items[i], items[parent] = items[parent], items[i]
         i = parent
@@ -33,13 +38,13 @@ end
 ---@param lt HeapComparator
 local function siftDown(items, i, n, lt)
     while true do
-        local left = i * 2 ---@type integer
+        local left = i * 2
         if left > n then return end
 
-        local smallest = i ---@type integer
+        local smallest = i
         if lt(items[left], items[smallest]) then smallest = left end
 
-        local right = left + 1 ---@type integer
+        local right = left + 1
         if right <= n and lt(items[right], items[smallest]) then smallest = right end
 
         if smallest == i then return end
@@ -65,12 +70,12 @@ end
 ---@param ... any
 ---@return Heap self
 function lib.heap:push(...)
-    local n = select('#', ...) ---@type integer
+    local n = select('#', ...)
     if n == 0 then return self end
 
-    local items = self.private.items ---@type any[]
-    local lt = self.private.lt ---@type HeapComparator
-    local startIndex = #items ---@type integer
+    local items = self.private.items
+    local lt = self.private.lt
+    local startIndex = #items
 
     table.move({ ... }, 1, n, startIndex + 1, items)
 
@@ -83,11 +88,11 @@ end
 
 ---@return any?
 function lib.heap:pop()
-    local items = self.private.items ---@type any[]
-    local n = #items ---@type integer
+    local items = self.private.items
+    local n = #items
     if n == 0 then return nil end
 
-    local top = items[1] ---@type any
+    local top = items[1]
 
     if n == 1 then
         items[1] = nil
@@ -121,10 +126,10 @@ function lib.heap:clear()
     return self
 end
 
----@return Array sorted newly-allocated array drained in pop order.
+---@return Array sorted Newly-allocated array drained in pop order.
 function lib.heap:drain()
-    local out = lib.array:new() ---@type Array
-    local n = 0 ---@type integer
+    local out = lib.array:new()
+    local n = 0
     while #self.private.items > 0 do
         n += 1
         out[n] = self:pop()

--- a/imports/lru/shared.lua
+++ b/imports/lru/shared.lua
@@ -6,6 +6,8 @@
     Copyright © 2025 Linden <https://github.com/thelindat>
 ]]
 
+---@diagnostic disable: invisible
+
 ---@class LruNode
 ---@field key any
 ---@field value any
@@ -16,14 +18,19 @@
 ---@field private new LruConstructor
 lib.lru = lib.class('Lru')
 
+---@param self Lru
+---@param node LruNode
 local function detach(self, node)
-    local prev, nxt = node.prev, node.next
+    local prev = node.prev ---@type LruNode?
+    local nxt = node.next ---@type LruNode?
     if prev then prev.next = nxt else self.private.head = nxt end
     if nxt then nxt.prev = prev else self.private.tail = prev end
     node.prev = nil
     node.next = nil
 end
 
+---@param self Lru
+---@param node LruNode
 local function attachHead(self, node)
     node.prev = nil
     node.next = self.private.head
@@ -51,7 +58,7 @@ end
 ---@param key any
 ---@return any?
 function lib.lru:get(key)
-    local node = self.private.map[key]
+    local node = self.private.map[key] ---@type LruNode?
     if not node then return nil end
     detach(self, node)
     attachHead(self, node)
@@ -63,7 +70,7 @@ end
 ---@return any? evictedKey
 ---@return any? evictedValue
 function lib.lru:set(key, value)
-    local node = self.private.map[key]
+    local node = self.private.map[key] ---@type LruNode?
 
     if node then
         node.value = value
@@ -78,7 +85,7 @@ function lib.lru:set(key, value)
     self.private.count += 1
 
     if self.private.count > self.private.capacity then
-        local evicted = self.private.tail
+        local evicted = self.private.tail ---@type LruNode
         detach(self, evicted)
         self.private.map[evicted.key] = nil
         self.private.count -= 1
@@ -95,7 +102,7 @@ end
 ---@param key any
 ---@return any?
 function lib.lru:peek(key)
-    local node = self.private.map[key]
+    local node = self.private.map[key] ---@type LruNode?
     if not node then return nil end
     return node.value
 end
@@ -103,7 +110,7 @@ end
 ---@param key any
 ---@return boolean removed
 function lib.lru:delete(key)
-    local node = self.private.map[key]
+    local node = self.private.map[key] ---@type LruNode?
     if not node then return false end
     detach(self, node)
     self.private.map[key] = nil
@@ -132,7 +139,7 @@ end
 
 ---@return fun(): any?, any?
 function lib.lru:each()
-    local node = self.private.head
+    local node = self.private.head ---@type LruNode?
     return function()
         if not node then return nil end
         local k, v = node.key, node.value

--- a/imports/lru/shared.lua
+++ b/imports/lru/shared.lua
@@ -14,15 +14,22 @@
 ---@field prev? LruNode
 ---@field next? LruNode
 
+---@class LruPrivate
+---@field capacity integer
+---@field map table<any, LruNode>
+---@field count integer
+---@field head? LruNode
+---@field tail? LruNode
+
 ---@class Lru : OxClass
 ---@field private new LruConstructor
+---@field private private LruPrivate
 lib.lru = lib.class('Lru')
 
 ---@param self Lru
 ---@param node LruNode
 local function detach(self, node)
-    local prev = node.prev ---@type LruNode?
-    local nxt = node.next ---@type LruNode?
+    local prev, nxt = node.prev, node.next
     if prev then prev.next = nxt else self.private.head = nxt end
     if nxt then nxt.prev = prev else self.private.tail = prev end
     node.prev = nil
@@ -58,7 +65,7 @@ end
 ---@param key any
 ---@return any?
 function lib.lru:get(key)
-    local node = self.private.map[key] ---@type LruNode?
+    local node = self.private.map[key]
     if not node then return nil end
     detach(self, node)
     attachHead(self, node)
@@ -70,7 +77,7 @@ end
 ---@return any? evictedKey
 ---@return any? evictedValue
 function lib.lru:set(key, value)
-    local node = self.private.map[key] ---@type LruNode?
+    local node = self.private.map[key]
 
     if node then
         node.value = value
@@ -85,7 +92,7 @@ function lib.lru:set(key, value)
     self.private.count += 1
 
     if self.private.count > self.private.capacity then
-        local evicted = self.private.tail ---@type LruNode
+        local evicted = self.private.tail --[[@as LruNode]]
         detach(self, evicted)
         self.private.map[evicted.key] = nil
         self.private.count -= 1
@@ -102,7 +109,7 @@ end
 ---@param key any
 ---@return any?
 function lib.lru:peek(key)
-    local node = self.private.map[key] ---@type LruNode?
+    local node = self.private.map[key]
     if not node then return nil end
     return node.value
 end
@@ -110,7 +117,7 @@ end
 ---@param key any
 ---@return boolean removed
 function lib.lru:delete(key)
-    local node = self.private.map[key] ---@type LruNode?
+    local node = self.private.map[key]
     if not node then return false end
     detach(self, node)
     self.private.map[key] = nil
@@ -139,7 +146,7 @@ end
 
 ---@return fun(): any?, any?
 function lib.lru:each()
-    local node = self.private.head ---@type LruNode?
+    local node = self.private.head
     return function()
         if not node then return nil end
         local k, v = node.key, node.value

--- a/imports/map/shared.lua
+++ b/imports/map/shared.lua
@@ -6,20 +6,23 @@
     Copyright © 2025 Linden <https://github.com/thelindat>
 ]]
 
+---@diagnostic disable: invisible
+
 ---@class Map : OxClass
 ---@field private new MapConstructor
 lib.map = lib.class('Map')
 
-local TOMBSTONE = {}
-local MIN_REBUILD = 8
+local TOMBSTONE = {} ---@type table
+local MIN_REBUILD = 8 ---@type integer
 
+---@param self Map
 local function rebuild(self)
-    local newKeys = {}
-    local newValues = {}
-    local newIndex = {}
-    local keys = self.private.keys
-    local values = self.private.values
-    local n = 0
+    local newKeys = {} ---@type any[]
+    local newValues = {} ---@type any[]
+    local newIndex = {} ---@type table<any, integer>
+    local n = 0 ---@type integer
+    local keys = self.private.keys ---@type any[]
+    local values = self.private.values ---@type any[]
 
     for i = 1, #keys do
         local k = keys[i]
@@ -71,13 +74,13 @@ function lib.map:set(key, value)
         return self
     end
 
-    local pos = self.private.index[key]
+    local pos = self.private.index[key] ---@type integer?
 
     if pos then
         self.private.values[pos] = value
     else
-        local keys = self.private.keys
-        local newPos = #keys + 1
+        local keys = self.private.keys ---@type any[]
+        local newPos = #keys + 1 ---@type integer
         keys[newPos] = key
         self.private.values[newPos] = value
         self.private.index[key] = newPos
@@ -90,7 +93,7 @@ end
 ---@param key any
 ---@return any?
 function lib.map:get(key)
-    local pos = self.private.index[key]
+    local pos = self.private.index[key] ---@type integer?
     if not pos then return nil end
     return self.private.values[pos]
 end
@@ -104,7 +107,7 @@ end
 ---@param key any
 ---@return boolean removed
 function lib.map:delete(key)
-    local pos = self.private.index[key]
+    local pos = self.private.index[key] ---@type integer?
     if not pos then return false end
 
     self.private.keys[pos] = TOMBSTONE
@@ -142,10 +145,10 @@ end
 
 ---@return fun(): any?, any?
 function lib.map:entries()
-    local keys = self.private.keys
-    local values = self.private.values
-    local n = #keys
-    local i = 0
+    local keys = self.private.keys ---@type any[]
+    local values = self.private.values ---@type any[]
+    local n = #keys ---@type integer
+    local i = 0 ---@type integer
 
     return function()
         i += 1
@@ -159,9 +162,9 @@ end
 
 ---@return fun(): any?
 function lib.map:keys()
-    local keys = self.private.keys
-    local n = #keys
-    local i = 0
+    local keys = self.private.keys ---@type any[]
+    local n = #keys ---@type integer
+    local i = 0 ---@type integer
 
     return function()
         i += 1
@@ -175,10 +178,10 @@ end
 
 ---@return fun(): any?
 function lib.map:values()
-    local keys = self.private.keys
-    local values = self.private.values
-    local n = #keys
-    local i = 0
+    local keys = self.private.keys ---@type any[]
+    local values = self.private.values ---@type any[]
+    local n = #keys ---@type integer
+    local i = 0 ---@type integer
 
     return function()
         i += 1
@@ -199,9 +202,9 @@ lib.map.__len = lib.map.size
 
 ---@return table
 function lib.map:toTable()
-    local out = {}
-    local keys = self.private.keys
-    local values = self.private.values
+    local out = {} ---@type table
+    local keys = self.private.keys ---@type any[]
+    local values = self.private.values ---@type any[]
     for i = 1, #keys do
         local k = keys[i]
         if k ~= TOMBSTONE then out[k] = values[i] end

--- a/imports/map/shared.lua
+++ b/imports/map/shared.lua
@@ -8,21 +8,29 @@
 
 ---@diagnostic disable: invisible
 
+---@class MapPrivate
+---@field keys any[]
+---@field values any[]
+---@field index table<any, integer>
+---@field count integer
+---@field deleted integer
+
 ---@class Map : OxClass
 ---@field private new MapConstructor
+---@field private private MapPrivate
 lib.map = lib.class('Map')
 
-local TOMBSTONE = {} ---@type table
-local MIN_REBUILD = 8 ---@type integer
+local TOMBSTONE = {}
+local MIN_REBUILD = 8
 
 ---@param self Map
 local function rebuild(self)
-    local newKeys = {} ---@type any[]
-    local newValues = {} ---@type any[]
-    local newIndex = {} ---@type table<any, integer>
-    local n = 0 ---@type integer
-    local keys = self.private.keys ---@type any[]
-    local values = self.private.values ---@type any[]
+    local newKeys = {}
+    local newValues = {}
+    local newIndex = {}
+    local n = 0
+    local keys = self.private.keys
+    local values = self.private.values
 
     for i = 1, #keys do
         local k = keys[i]
@@ -62,7 +70,7 @@ function lib.map:constructor(initial)
 end
 
 ---@param key any
----@param value any Setting a nil value is equivalent to `:delete(key)`.
+---@param value any Must be non-nil. Use `:delete(key)` to remove entries.
 ---@return Map self
 function lib.map:set(key, value)
     if key == nil then
@@ -70,17 +78,16 @@ function lib.map:set(key, value)
     end
 
     if value == nil then
-        self:delete(key)
-        return self
+        error("map value cannot be nil; use :delete(key) to remove entries", 2)
     end
 
-    local pos = self.private.index[key] ---@type integer?
+    local pos = self.private.index[key]
 
     if pos then
         self.private.values[pos] = value
     else
-        local keys = self.private.keys ---@type any[]
-        local newPos = #keys + 1 ---@type integer
+        local keys = self.private.keys
+        local newPos = #keys + 1
         keys[newPos] = key
         self.private.values[newPos] = value
         self.private.index[key] = newPos
@@ -93,7 +100,7 @@ end
 ---@param key any
 ---@return any?
 function lib.map:get(key)
-    local pos = self.private.index[key] ---@type integer?
+    local pos = self.private.index[key]
     if not pos then return nil end
     return self.private.values[pos]
 end
@@ -107,7 +114,7 @@ end
 ---@param key any
 ---@return boolean removed
 function lib.map:delete(key)
-    local pos = self.private.index[key] ---@type integer?
+    local pos = self.private.index[key]
     if not pos then return false end
 
     self.private.keys[pos] = TOMBSTONE
@@ -145,10 +152,10 @@ end
 
 ---@return fun(): any?, any?
 function lib.map:entries()
-    local keys = self.private.keys ---@type any[]
-    local values = self.private.values ---@type any[]
-    local n = #keys ---@type integer
-    local i = 0 ---@type integer
+    local keys = self.private.keys
+    local values = self.private.values
+    local n = #keys
+    local i = 0
 
     return function()
         i += 1
@@ -162,9 +169,9 @@ end
 
 ---@return fun(): any?
 function lib.map:keys()
-    local keys = self.private.keys ---@type any[]
-    local n = #keys ---@type integer
-    local i = 0 ---@type integer
+    local keys = self.private.keys
+    local n = #keys
+    local i = 0
 
     return function()
         i += 1
@@ -178,10 +185,10 @@ end
 
 ---@return fun(): any?
 function lib.map:values()
-    local keys = self.private.keys ---@type any[]
-    local values = self.private.values ---@type any[]
-    local n = #keys ---@type integer
-    local i = 0 ---@type integer
+    local keys = self.private.keys
+    local values = self.private.values
+    local n = #keys
+    local i = 0
 
     return function()
         i += 1
@@ -202,9 +209,9 @@ lib.map.__len = lib.map.size
 
 ---@return table
 function lib.map:toTable()
-    local out = {} ---@type table
-    local keys = self.private.keys ---@type any[]
-    local values = self.private.values ---@type any[]
+    local out = {}
+    local keys = self.private.keys
+    local values = self.private.values
     for i = 1, #keys do
         local k = keys[i]
         if k ~= TOMBSTONE then out[k] = values[i] end
@@ -214,10 +221,10 @@ end
 
 ---@return Array entries Array of `{ key, value }` tables in insertion order.
 function lib.map:toArray()
-    local out = lib.array:new() ---@type Array
-    local keys = self.private.keys ---@type any[]
-    local values = self.private.values ---@type any[]
-    local n = 0 ---@type integer
+    local out = lib.array:new()
+    local keys = self.private.keys
+    local values = self.private.values
+    local n = 0
     for i = 1, #keys do
         local k = keys[i]
         if k ~= TOMBSTONE then

--- a/imports/map/shared.lua
+++ b/imports/map/shared.lua
@@ -1,0 +1,212 @@
+--[[
+    https://github.com/overextended/ox_lib
+
+    This file is licensed under LGPL-3.0 or higher <https://www.gnu.org/licenses/lgpl-3.0.en.html>
+
+    Copyright © 2025 Linden <https://github.com/thelindat>
+]]
+
+---@class Map : OxClass
+---@field private new MapConstructor
+lib.map = lib.class('Map')
+
+local TOMBSTONE = {}
+local MIN_REBUILD = 8
+
+local function rebuild(self)
+    local newKeys = {}
+    local newValues = {}
+    local newIndex = {}
+    local keys = self.private.keys
+    local values = self.private.values
+    local n = 0
+
+    for i = 1, #keys do
+        local k = keys[i]
+        if k ~= TOMBSTONE then
+            n += 1
+            newKeys[n] = k
+            newValues[n] = values[i]
+            newIndex[k] = n
+        end
+    end
+
+    self.private.keys = newKeys
+    self.private.values = newValues
+    self.private.index = newIndex
+    self.private.deleted = 0
+end
+
+---@class MapConstructor
+---@overload fun(self: Map, initial?: table): Map
+---@private
+---@param initial? table Optional table of initial entries. Iteration order from a Lua table literal is not guaranteed.
+function lib.map:constructor(initial)
+    self.private.keys = {}
+    self.private.values = {}
+    self.private.index = {}
+    self.private.count = 0
+    self.private.deleted = 0
+
+    if initial ~= nil then
+        if type(initial) ~= 'table' then
+            error("initial must be a table or nil", 2)
+        end
+        for k, v in pairs(initial) do
+            self:set(k, v)
+        end
+    end
+end
+
+---@param key any
+---@param value any Setting a nil value is equivalent to `:delete(key)`.
+---@return Map self
+function lib.map:set(key, value)
+    if key == nil then
+        error("map key cannot be nil", 2)
+    end
+
+    if value == nil then
+        self:delete(key)
+        return self
+    end
+
+    local pos = self.private.index[key]
+
+    if pos then
+        self.private.values[pos] = value
+    else
+        local keys = self.private.keys
+        local newPos = #keys + 1
+        keys[newPos] = key
+        self.private.values[newPos] = value
+        self.private.index[key] = newPos
+        self.private.count += 1
+    end
+
+    return self
+end
+
+---@param key any
+---@return any?
+function lib.map:get(key)
+    local pos = self.private.index[key]
+    if not pos then return nil end
+    return self.private.values[pos]
+end
+
+---@param key any
+---@return boolean
+function lib.map:has(key)
+    return self.private.index[key] ~= nil
+end
+
+---@param key any
+---@return boolean removed
+function lib.map:delete(key)
+    local pos = self.private.index[key]
+    if not pos then return false end
+
+    self.private.keys[pos] = TOMBSTONE
+    self.private.values[pos] = nil
+    self.private.index[key] = nil
+    self.private.count -= 1
+    self.private.deleted += 1
+
+    if self.private.deleted >= self.private.count and self.private.deleted >= MIN_REBUILD then
+        rebuild(self)
+    end
+
+    return true
+end
+
+---@return integer
+function lib.map:size()
+    return self.private.count
+end
+
+---@return boolean
+function lib.map:isEmpty()
+    return self.private.count == 0
+end
+
+---@return Map self
+function lib.map:clear()
+    table.wipe(self.private.keys)
+    table.wipe(self.private.values)
+    table.wipe(self.private.index)
+    self.private.count = 0
+    self.private.deleted = 0
+    return self
+end
+
+---@return fun(): any?, any?
+function lib.map:entries()
+    local keys = self.private.keys
+    local values = self.private.values
+    local n = #keys
+    local i = 0
+
+    return function()
+        i += 1
+        while i <= n do
+            local k = keys[i]
+            if k ~= TOMBSTONE then return k, values[i] end
+            i += 1
+        end
+    end
+end
+
+---@return fun(): any?
+function lib.map:keys()
+    local keys = self.private.keys
+    local n = #keys
+    local i = 0
+
+    return function()
+        i += 1
+        while i <= n do
+            local k = keys[i]
+            if k ~= TOMBSTONE then return k end
+            i += 1
+        end
+    end
+end
+
+---@return fun(): any?
+function lib.map:values()
+    local keys = self.private.keys
+    local values = self.private.values
+    local n = #keys
+    local i = 0
+
+    return function()
+        i += 1
+        while i <= n do
+            if keys[i] ~= TOMBSTONE then return values[i] end
+            i += 1
+        end
+    end
+end
+
+lib.map.each = lib.map.entries
+
+function lib.map:__pairs()
+    return self:entries()
+end
+
+lib.map.__len = lib.map.size
+
+---@return table
+function lib.map:toTable()
+    local out = {}
+    local keys = self.private.keys
+    local values = self.private.values
+    for i = 1, #keys do
+        local k = keys[i]
+        if k ~= TOMBSTONE then out[k] = values[i] end
+    end
+    return out
+end
+
+return lib.map

--- a/imports/map/shared.lua
+++ b/imports/map/shared.lua
@@ -111,7 +111,7 @@ function lib.map:delete(key)
     if not pos then return false end
 
     self.private.keys[pos] = TOMBSTONE
-    self.private.values[pos] = nil
+    self.private.values[pos] = TOMBSTONE
     self.private.index[key] = nil
     self.private.count -= 1
     self.private.deleted += 1

--- a/imports/map/shared.lua
+++ b/imports/map/shared.lua
@@ -212,4 +212,20 @@ function lib.map:toTable()
     return out
 end
 
+---@return Array entries Array of `{ key, value }` tables in insertion order.
+function lib.map:toArray()
+    local out = lib.array:new() ---@type Array
+    local keys = self.private.keys ---@type any[]
+    local values = self.private.values ---@type any[]
+    local n = 0 ---@type integer
+    for i = 1, #keys do
+        local k = keys[i]
+        if k ~= TOMBSTONE then
+            n += 1
+            out[n] = { key = k, value = values[i] }
+        end
+    end
+    return out
+end
+
 return lib.map

--- a/imports/ringbuffer/shared.lua
+++ b/imports/ringbuffer/shared.lua
@@ -8,8 +8,15 @@
 
 ---@diagnostic disable: invisible
 
+---@class RingBufferPrivate
+---@field items any[]
+---@field capacity integer
+---@field count integer
+---@field nextIndex integer
+
 ---@class RingBuffer : OxClass
 ---@field private new RingBufferConstructor
+---@field private private RingBufferPrivate
 lib.ringbuffer = lib.class('RingBuffer')
 
 ---@class RingBufferConstructor
@@ -30,11 +37,11 @@ end
 ---@param value any
 ---@return any? evicted Value that was overwritten, if the buffer was full.
 function lib.ringbuffer:push(value)
-    local items = self.private.items ---@type any[]
-    local capacity = self.private.capacity ---@type integer
-    local nextIndex = self.private.nextIndex ---@type integer
+    local items = self.private.items
+    local capacity = self.private.capacity
+    local nextIndex = self.private.nextIndex
 
-    local evicted ---@type any?
+    local evicted
     if self.private.count == capacity then
         evicted = items[nextIndex]
     else
@@ -61,12 +68,12 @@ function lib.ringbuffer:get(i)
         error("index must be an integer", 2)
     end
 
-    local count = self.private.count ---@type integer
+    local count = self.private.count
     if i < 0 then i = count + i + 1 end
     if i < 1 or i > count then return nil end
 
-    local start = oldestIndex(self) ---@type integer
-    local capacity = self.private.capacity ---@type integer
+    local start = oldestIndex(self)
+    local capacity = self.private.capacity
     return self.private.items[((start - 1 + i - 1) % capacity) + 1]
 end
 
@@ -100,11 +107,11 @@ end
 
 ---@return fun(): any?
 function lib.ringbuffer:each()
-    local count = self.private.count ---@type integer
-    local capacity = self.private.capacity ---@type integer
-    local items = self.private.items ---@type any[]
-    local start = oldestIndex(self) ---@type integer
-    local i = 0 ---@type integer
+    local count = self.private.count
+    local capacity = self.private.capacity
+    local items = self.private.items
+    local start = oldestIndex(self)
+    local i = 0
 
     return function()
         i += 1

--- a/imports/ringbuffer/shared.lua
+++ b/imports/ringbuffer/shared.lua
@@ -6,6 +6,8 @@
     Copyright © 2025 Linden <https://github.com/thelindat>
 ]]
 
+---@diagnostic disable: invisible
+
 ---@class RingBuffer : OxClass
 ---@field private new RingBufferConstructor
 lib.ringbuffer = lib.class('RingBuffer')
@@ -28,11 +30,11 @@ end
 ---@param value any
 ---@return any? evicted Value that was overwritten, if the buffer was full.
 function lib.ringbuffer:push(value)
-    local items = self.private.items
-    local capacity = self.private.capacity
-    local nextIndex = self.private.nextIndex
+    local items = self.private.items ---@type any[]
+    local capacity = self.private.capacity ---@type integer
+    local nextIndex = self.private.nextIndex ---@type integer
 
-    local evicted
+    local evicted ---@type any?
     if self.private.count == capacity then
         evicted = items[nextIndex]
     else
@@ -45,6 +47,8 @@ function lib.ringbuffer:push(value)
     return evicted
 end
 
+---@param self RingBuffer
+---@return integer
 local function oldestIndex(self)
     if self.private.count < self.private.capacity then return 1 end
     return self.private.nextIndex
@@ -57,12 +61,12 @@ function lib.ringbuffer:get(i)
         error("index must be an integer", 2)
     end
 
-    local count = self.private.count
+    local count = self.private.count ---@type integer
     if i < 0 then i = count + i + 1 end
     if i < 1 or i > count then return nil end
 
-    local start = oldestIndex(self)
-    local capacity = self.private.capacity
+    local start = oldestIndex(self) ---@type integer
+    local capacity = self.private.capacity ---@type integer
     return self.private.items[((start - 1 + i - 1) % capacity) + 1]
 end
 
@@ -96,11 +100,11 @@ end
 
 ---@return fun(): any?
 function lib.ringbuffer:each()
-    local count = self.private.count
-    local capacity = self.private.capacity
-    local items = self.private.items
-    local start = oldestIndex(self)
-    local i = 0
+    local count = self.private.count ---@type integer
+    local capacity = self.private.capacity ---@type integer
+    local items = self.private.items ---@type any[]
+    local start = oldestIndex(self) ---@type integer
+    local i = 0 ---@type integer
 
     return function()
         i += 1

--- a/imports/set/shared.lua
+++ b/imports/set/shared.lua
@@ -14,8 +14,7 @@ lib.set = lib.class('Set')
 ---@overload fun(self: Set, ...: any): Set
 ---@private
 function lib.set:constructor(...)
-    self.private.items = {}
-    self.private.index = {}
+    self.private.map = lib.map:new()
 
     local args = { ... }
     for i = 1, select('#', ...) do
@@ -26,70 +25,54 @@ end
 ---@param value any
 ---@return Set self
 function lib.set:add(value)
-    if value == nil or self.private.index[value] then return self end
-    local items = self.private.items
-    local i = #items + 1
-    items[i] = value
-    self.private.index[value] = i
+    if value ~= nil and not self.private.map:has(value) then
+        self.private.map:set(value, true)
+    end
     return self
 end
 
 ---@param value any
 ---@return boolean removed
 function lib.set:remove(value)
-    local i = self.private.index[value]
-    if not i then return false end
-
-    local items = self.private.items
-    local lastI = #items
-
-    if i ~= lastI then
-        table.move(items, i + 1, lastI, i)
-        for j = i, lastI - 1 do
-            self.private.index[items[j]] = j
-        end
-    end
-
-    items[lastI] = nil
-    self.private.index[value] = nil
-    return true
+    return self.private.map:delete(value)
 end
 
 ---@param value any
 ---@return boolean
 function lib.set:has(value)
-    return self.private.index[value] ~= nil
+    return self.private.map:has(value)
 end
 
 ---@return integer
 function lib.set:size()
-    return #self.private.items
+    return self.private.map:size()
 end
 
 ---@return boolean
 function lib.set:isEmpty()
-    return #self.private.items == 0
+    return self.private.map:isEmpty()
 end
 
 ---@return Set self
 function lib.set:clear()
-    table.wipe(self.private.items)
-    table.wipe(self.private.index)
+    self.private.map:clear()
     return self
 end
 
 ---@return fun(): any?
 function lib.set:each()
-    local items = self.private.items
-    local i = 0
-    return function()
-        i += 1
-        return items[i]
-    end
+    return self.private.map:keys()
 end
 
 function lib.set:__pairs()
-    return next, self.private.items
+    local it = self.private.map:keys()
+    local i = 0
+    return function()
+        local v = it()
+        if v == nil then return nil end
+        i += 1
+        return i, v
+    end
 end
 
 lib.set.__ipairs = lib.set.__pairs
@@ -97,15 +80,14 @@ lib.set.__len = lib.set.size
 
 ---@return Array
 function lib.set:toArray()
-    return lib.array:from(self.private.items)
+    return lib.array:from(self:each())
 end
 
 ---@param other Set
 ---@return Set
 function lib.set:union(other)
     local result = lib.set:new()
-    local items = self.private.items
-    for i = 1, #items do result:add(items[i]) end
+    for v in self:each() do result:add(v) end
     for v in other:each() do result:add(v) end
     return result
 end
@@ -114,9 +96,8 @@ end
 ---@return Set
 function lib.set:intersection(other)
     local result = lib.set:new()
-    local items = self.private.items
-    for i = 1, #items do
-        if other:has(items[i]) then result:add(items[i]) end
+    for v in self:each() do
+        if other:has(v) then result:add(v) end
     end
     return result
 end
@@ -125,9 +106,8 @@ end
 ---@return Set
 function lib.set:difference(other)
     local result = lib.set:new()
-    local items = self.private.items
-    for i = 1, #items do
-        if not other:has(items[i]) then result:add(items[i]) end
+    for v in self:each() do
+        if not other:has(v) then result:add(v) end
     end
     return result
 end
@@ -135,10 +115,9 @@ end
 ---@param other Set
 ---@return boolean
 function lib.set:equals(other)
-    if #self.private.items ~= other:size() then return false end
-    local items = self.private.items
-    for i = 1, #items do
-        if not other:has(items[i]) then return false end
+    if self:size() ~= other:size() then return false end
+    for v in self:each() do
+        if not other:has(v) then return false end
     end
     return true
 end
@@ -146,10 +125,9 @@ end
 ---@param other Set
 ---@return boolean
 function lib.set:isSubsetOf(other)
-    if #self.private.items > other:size() then return false end
-    local items = self.private.items
-    for i = 1, #items do
-        if not other:has(items[i]) then return false end
+    if self:size() > other:size() then return false end
+    for v in self:each() do
+        if not other:has(v) then return false end
     end
     return true
 end

--- a/imports/set/shared.lua
+++ b/imports/set/shared.lua
@@ -6,8 +6,12 @@
     Copyright © 2025 Linden <https://github.com/thelindat>
 ]]
 
+---@class SetPrivate
+---@field map Map
+
 ---@class Set : OxClass
 ---@field private new SetConstructor
+---@field private private SetPrivate
 lib.set = lib.class('Set')
 
 ---@class SetConstructor
@@ -16,7 +20,7 @@ lib.set = lib.class('Set')
 function lib.set:constructor(...)
     self.private.map = lib.map:new()
 
-    local args = { ... } ---@type any[]
+    local args = { ... }
     for i = 1, select('#', ...) do
         self:add(args[i])
     end
@@ -65,10 +69,10 @@ function lib.set:each()
 end
 
 function lib.set:__pairs()
-    local it = self.private.map:keys() ---@type fun(): any?
-    local i = 0 ---@type integer
+    local it = self.private.map:keys()
+    local i = 0
     return function()
-        local v = it() ---@type any?
+        local v = it()
         if v == nil then return nil end
         i += 1
         return i, v
@@ -86,7 +90,7 @@ end
 ---@param other Set
 ---@return Set
 function lib.set:union(other)
-    local result = lib.set:new() ---@type Set
+    local result = lib.set:new()
     for v in self:each() do result:add(v) end
     for v in other:each() do result:add(v) end
     return result
@@ -95,7 +99,7 @@ end
 ---@param other Set
 ---@return Set
 function lib.set:intersection(other)
-    local result = lib.set:new() ---@type Set
+    local result = lib.set:new()
     for v in self:each() do
         if other:has(v) then result:add(v) end
     end
@@ -105,7 +109,7 @@ end
 ---@param other Set
 ---@return Set
 function lib.set:difference(other)
-    local result = lib.set:new() ---@type Set
+    local result = lib.set:new()
     for v in self:each() do
         if not other:has(v) then result:add(v) end
     end

--- a/imports/set/shared.lua
+++ b/imports/set/shared.lua
@@ -16,7 +16,7 @@ lib.set = lib.class('Set')
 function lib.set:constructor(...)
     self.private.map = lib.map:new()
 
-    local args = { ... }
+    local args = { ... } ---@type any[]
     for i = 1, select('#', ...) do
         self:add(args[i])
     end
@@ -65,10 +65,10 @@ function lib.set:each()
 end
 
 function lib.set:__pairs()
-    local it = self.private.map:keys()
-    local i = 0
+    local it = self.private.map:keys() ---@type fun(): any?
+    local i = 0 ---@type integer
     return function()
-        local v = it()
+        local v = it() ---@type any?
         if v == nil then return nil end
         i += 1
         return i, v
@@ -86,7 +86,7 @@ end
 ---@param other Set
 ---@return Set
 function lib.set:union(other)
-    local result = lib.set:new()
+    local result = lib.set:new() ---@type Set
     for v in self:each() do result:add(v) end
     for v in other:each() do result:add(v) end
     return result
@@ -95,7 +95,7 @@ end
 ---@param other Set
 ---@return Set
 function lib.set:intersection(other)
-    local result = lib.set:new()
+    local result = lib.set:new() ---@type Set
     for v in self:each() do
         if other:has(v) then result:add(v) end
     end
@@ -105,7 +105,7 @@ end
 ---@param other Set
 ---@return Set
 function lib.set:difference(other)
-    local result = lib.set:new()
+    local result = lib.set:new() ---@type Set
     for v in self:each() do
         if not other:has(v) then result:add(v) end
     end


### PR DESCRIPTION
## Add `lib.map`, refactor `lib.set` to use it

Adds an insertion-ordered key/value collection with amortized O(1) delete, and rewires `lib.set` to use it internally so Set's `remove` goes from O(n) to amortized O(1) without any public-API change.

## `lib.map`: insertion-ordered key/value collection

Storage is a dense entries array (in insertion order) plus a hashmap of `key → array position`. Deletes mark the slot with a sentinel rather than shifting; a periodic in-place rebuild compacts when tombstoned slots outnumber live ones.

```lua
local m = lib.map:new({ a = 1, b = 2 })   -- optional initial table
m:set('c', 3):set('d', 4)                 -- chainable; insertion-ordered
m:get('a')                                -- 1
m:has('a')                                -- true
m:delete('b')                             -- true; amortized O(1), no shift
m:size()                                  -- 3
#m                                        -- 3   (__len)

for k, v in pairs(m) do                   -- __pairs; insertion order
    print(k, v)
end

for k in m:keys() do ... end              -- iterator over keys
for v in m:values() do ... end            -- iterator over values
for k, v in m:entries() do ... end        -- iterator over (k, v); :each is an alias

m:toTable()                               -- plain Lua table snapshot, for json.encode / interop
m:toArray()                               -- Array of { key, value } in insertion order
```

### Notes

- **Constructor accepts another Map**. Passing one preserves insertion order (because `pairs` on a Map honors `__pairs`).
- **`set(k, nil)` is equivalent to `delete(k)`**. Mirrors Lua table semantics.
- **Updating an existing key keeps its position**
- **Iteration order from a Lua table literal is not guaranteed** by Lua. If order matters at construction time, build the Map explicitly with chained `:set` calls.

## `lib.set` refactor

`lib.set` now wraps a `lib.map` internally (value of every entry is `true`). All public methods and metamethods unchanged: same constructor, same `add`/`remove`/`has`/`each`/`__pairs`/`__ipairs`/`__len`/set-algebra surface, same `(i, v)` yield shape.

Behavioral diff:

- `remove` went from **O(n)** (shift + reindex) to **amortized O(1)** via Map's tombstone delete.
- Insertion order still preserved.
- No API change for callers.

