### PR TITLE
fix(cron): support a single named month in expressions

### DIFF
--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -135,7 +135,7 @@ local function parseCron(value, unit)
             end
         end
         if #months > 0 then
-            return table.concat(months, ',')
+            return #months == 1 and tonumber(months[1]) or table.concat(months, ',')
         end
     end
 


### PR DESCRIPTION
### Problem
A single named month (e.g. `jan`) never runs. `parseCron` returns it as the string `"1"`, which `getTimeUnit` can't match (not a step/range/list) → returns `false` → the task is stopped. Numeric (`1`) and lists (`jan,feb`) work fine.

### Reproduce
```lua
lib.cron.new('* * * jun *', fn) -- never runs (named, current month)
lib.cron.new('* * * 6 *',   fn) -- runs (numeric)
```

### Fix
Return a `number` for a single parsed month so it takes the numeric path:

