### PR TITLE
fix(zones): track grid cell locally instead of sharing cache keys

### DIFF
--- a/imports/points/client.lua
+++ b/imports/points/client.lua
@@ -28,6 +28,7 @@ local nearbyCount = 0
 ---@type CPoint?
 local closestPoint
 local tick
+local lastCellX, lastCellY
 
 local function removePoint(self)
     if closestPoint?.id == self.id then
@@ -51,7 +52,7 @@ CreateThread(function()
         cache.coords = coords
         closestPoint = nil
 
-        if cellX ~= cache.lastCellX or cellY ~= cache.lastCellY then
+        if cellX ~= lastCellX or cellY ~= lastCellY then
             for i = 1, nearbyCount do
                 local point = nearbyPoints[i]
 
@@ -67,8 +68,8 @@ CreateThread(function()
                 end
             end
 
-            cache.lastCellX = cellX
-            cache.lastCellY = cellY
+            lastCellX = cellX
+            lastCellY = cellY
         end
 
         if nearbyCount ~= 0 then

--- a/imports/zones/shared.lua
+++ b/imports/zones/shared.lua
@@ -158,6 +158,7 @@ local enteringZones = lib.context == 'client' and lib.array:new() --[[@as Array<
 local nearbyZones = lib.array:new() --[[@as Array<CZone>]]
 local glm_polygon_contains = glm.polygon.contains
 local tick
+local lastCellX, lastCellY
 
 ---@param zone CZone
 local function removeZone(zone)
@@ -189,7 +190,7 @@ CreateThread(function()
         local cellX, cellY = lib.grid.getCellPosition(coords)
         cache.coords = coords
 
-        if cellX ~= cache.lastCellX or cellY ~= cache.lastCellY then
+        if cellX ~= lastCellX or cellY ~= lastCellY then
             for i = 1, #nearbyZones do
                 local zone = nearbyZones[i]
 
@@ -207,8 +208,8 @@ CreateThread(function()
                 end
             end
 
-            cache.lastCellX = cellX
-            cache.lastCellY = cellY
+            lastCellX = cellX
+            lastCellY = cellY
         end
 
         nearbyZones = zones


### PR DESCRIPTION
### Problem
`points` and `zones` both use the **same** global keys `cache.lastCellX` / `cache.lastCellY` to detect grid-cell changes. When a resource loads both, whichever thread runs first after a cell change updates the keys, so the other **skips its cross-cell `onExit` block** (the safety net from #732). On a teleport / fast travel where an entity leaves the nearby set in one tick: `onExit` is never called, `insideZones` is never cleared (its `inside` callback keeps firing), and re-entering doesn't re-fire `onEnter`. The victim is whichever module loaded second.

### Reproduce
Load both modules, register a zone with `onExit`/`inside`, stand inside, then teleport well beyond one grid cell in a single frame → `onExit` doesn't fire and `inside` keeps running.

### Fix
Give each module its own `local lastCellX, lastCellY` instead of the shared `cache` keys (same change in `imports/points/client.lua` and `imports/zones/shared.lua`). `cache.coords` stays shared. A repo-wide grep confirms no other reader of `cache.lastCellX`/`cache.lastCellY` — they aren't part of the public `cache` API.

