### PR TITLE
fix: validation, correctness & performance hardening

### DIFF
--- a/imports/array/shared.lua
+++ b/imports/array/shared.lua
@@ -12,7 +12,6 @@ lib.array = lib.class('Array')
 
 local table_unpack = table.unpack
 local table_remove = table.remove
-local table_clone = table.clone
 local table_concat = table.concat
 local table_type = table.type
 
@@ -79,8 +78,13 @@ end
 ---Create a new array containing the elements of two or more arrays.
 ---@param ... ArrayLike
 function lib.array:merge(...)
-    local newArr = table_clone(self)
+    local result = lib.array:new()
     local length = #self
+
+    for i = 1, length do
+        result[i] = self[i]
+    end
+
     local arrays = { ... }
 
     for i = 1, #arrays do
@@ -88,11 +92,11 @@ function lib.array:merge(...)
 
         for j = 1, #arr do
             length += 1
-            newArr[length] = arr[j]
+            result[length] = arr[j]
         end
     end
 
-    return lib.array:new(table_unpack(newArr))
+    return result
 end
 
 ---Tests if all elements in an array succeed in passing the provided test function.
@@ -131,7 +135,7 @@ end
 ---Creates a new array containing the elements from an array that pass the test of the provided function.
 ---@param testFn fun(element: unknown): boolean
 function lib.array:filter(testFn)
-    local newArr = {}
+    local arr = lib.array:new()
     local length = 0
 
     for i = 1, #self do
@@ -139,11 +143,11 @@ function lib.array:filter(testFn)
 
         if testFn(element) then
             length += 1
-            newArr[length] = element
+            arr[length] = element
         end
     end
 
-    return lib.array:new(table_unpack(newArr))
+    return arr
 end
 
 ---Returns the first or last element of an array that passes the provided test function.
@@ -262,18 +266,30 @@ end
 ---@return T
 function lib.array:reduce(reducer, initialValue, reverse)
     local length = #self
+    -- Compare against nil (not truthiness) so a falsy initial value such as `false` or `0` is honoured.
+    local hasInitial = initialValue ~= nil
     local accumulator, startIdx
 
     if reverse then
-        accumulator = initialValue or self[length]
-        startIdx = initialValue and length or length - 1
+        if hasInitial then
+            accumulator = initialValue
+            startIdx = length
+        else
+            accumulator = self[length]
+            startIdx = length - 1
+        end
 
         for i = startIdx, 1, -1 do
             accumulator = reducer(accumulator, self[i], i)
         end
     else
-        accumulator = initialValue or self[1]
-        startIdx = initialValue and 1 or 2
+        if hasInitial then
+            accumulator = initialValue
+            startIdx = 1
+        else
+            accumulator = self[1]
+            startIdx = 2
+        end
 
         for i = startIdx, length do
             accumulator = reducer(accumulator, self[i], i)

--- a/imports/callback/client.lua
+++ b/imports/callback/client.lua
@@ -51,7 +51,8 @@ local function triggerServerCallback(_, event, delay, cb, ...)
     local key
 
     repeat
-        key = ('%s:%s'):format(event, math.random(0, 100000))
+        -- High-entropy key (~62 bits) so the server cannot trivially predict/forge a pending callback response.
+        key = ('%s:%x%x'):format(event, math.random(0, 0x7FFFFFFF), math.random(0, 0x7FFFFFFF))
     until not pendingCallbacks[key]
 
     TriggerServerEvent('ox_lib:validateCallback', event, cache.resource, key)

--- a/imports/callback/server.lua
+++ b/imports/callback/server.lua
@@ -32,7 +32,8 @@ local function triggerClientCallback(_, event, playerId, cb, ...)
     local key
 
     repeat
-        key = ('%s:%s:%s'):format(event, math.random(0, 100000), playerId)
+        -- High-entropy key (~62 bits) so a client cannot brute-force/forge a pending callback response.
+        key = ('%s:%x%x:%s'):format(event, math.random(0, 0x7FFFFFFF), math.random(0, 0x7FFFFFFF), playerId)
     until not pendingCallbacks[key]
 
     TriggerClientEvent('ox_lib:validateCallback', playerId, event, cache.resource, key)

--- a/imports/getClosestObject/shared.lua
+++ b/imports/getClosestObject/shared.lua
@@ -18,13 +18,15 @@ function lib.getClosestObject(coords, maxDistance)
 	for i = 1, #objects do
 		local object = objects[i]
 
-		local objectCoords = GetEntityCoords(object)
-		local distance = #(coords - objectCoords)
+		if DoesEntityExist(object) then
+			local objectCoords = GetEntityCoords(object)
+			local distance = #(coords - objectCoords)
 
-		if distance < maxDistance then
-			maxDistance = distance
-			closestObject = object
-			closestCoords = objectCoords
+			if distance < maxDistance then
+				maxDistance = distance
+				closestObject = object
+				closestCoords = objectCoords
+			end
 		end
 	end
 

--- a/imports/getClosestPed/shared.lua
+++ b/imports/getClosestPed/shared.lua
@@ -18,7 +18,7 @@ function lib.getClosestPed(coords, maxDistance)
 	for i = 1, #peds do
 		local ped = peds[i]
 
-        if not IsPedAPlayer(ped) then
+        if DoesEntityExist(ped) and not IsPedAPlayer(ped) then
             local pedCoords = GetEntityCoords(ped)
             local distance = #(coords - pedCoords)
 

--- a/imports/getClosestPlayer/client.lua
+++ b/imports/getClosestPlayer/client.lua
@@ -24,10 +24,8 @@ function lib.getClosestPlayer(coords, maxDistance, includePlayer)
 
 		if playerId ~= cache.playerId or includePlayer then
 			local playerPed = GetPlayerPed(playerId)
-			local playerCoords = GetEntityCoords(playerPed)
-
-            local vehicle = GetVehiclePedIsIn(playerPed, false)
-            local playerCoords = vehicle == 0 and GetEntityCoords(playerPed) or GetWorldPositionOfEntityBone(playerPed, 0)
+			local vehicle = GetVehiclePedIsIn(playerPed, false)
+			local playerCoords = vehicle == 0 and GetEntityCoords(playerPed) or GetWorldPositionOfEntityBone(playerPed, 0)
             
 			local distance = #(coords - playerCoords)
 

--- a/imports/getClosestVehicle/shared.lua
+++ b/imports/getClosestVehicle/shared.lua
@@ -19,7 +19,7 @@ function lib.getClosestVehicle(coords, maxDistance, includePlayerVehicle)
 	for i = 1, #vehicles do
 		local vehicle = vehicles[i]
 
-		if lib.context == 'server' or not cache.vehicle or vehicle ~= cache.vehicle or includePlayerVehicle then
+		if DoesEntityExist(vehicle) and (lib.context == 'server' or not cache.vehicle or vehicle ~= cache.vehicle or includePlayerVehicle) then
 			local vehicleCoords = GetEntityCoords(vehicle)
 			local distance = #(coords - vehicleCoords)
 

--- a/imports/getFilesInDirectory/server.lua
+++ b/imports/getFilesInDirectory/server.lua
@@ -13,6 +13,11 @@
 function lib.getFilesInDirectory(path, pattern)
     local resource = cache.resource
 
+    -- io.readdir is NOT sandboxed to the resource directory, so reject directory traversal.
+    if type(path) ~= 'string' or path:find('..', 1, true) then
+        error("path must be a string and cannot contain '..' (directory traversal is not allowed)", 2)
+    end
+
     if path:sub(1, 1) ~= '@' then
         path = ('%s/%s'):format(GetResourcePath(resource), path)
     end

--- a/imports/getNearbyObjects/shared.lua
+++ b/imports/getNearbyObjects/shared.lua
@@ -18,15 +18,17 @@ function lib.getNearbyObjects(coords, maxDistance)
 	for i = 1, #objects do
 		local object = objects[i]
 
-        local objectCoords = GetEntityCoords(object)
-        local distance = #(coords - objectCoords)
+        if DoesEntityExist(object) then
+            local objectCoords = GetEntityCoords(object)
+            local distance = #(coords - objectCoords)
 
-        if distance < maxDistance then
-            count += 1
-            nearby[count] = {
-                object = object,
-                coords = objectCoords
-            }
+            if distance < maxDistance then
+                count += 1
+                nearby[count] = {
+                    object = object,
+                    coords = objectCoords
+                }
+            end
         end
 	end
 

--- a/imports/getNearbyPeds/shared.lua
+++ b/imports/getNearbyPeds/shared.lua
@@ -18,7 +18,7 @@ function lib.getNearbyPeds(coords, maxDistance)
     for i = 1, #peds do
         local ped = peds[i]
 
-        if not IsPedAPlayer(ped) then
+        if DoesEntityExist(ped) and not IsPedAPlayer(ped) then
             local pedCoords = GetEntityCoords(ped)
             local distance = #(coords - pedCoords)
 

--- a/imports/getNearbyVehicles/shared.lua
+++ b/imports/getNearbyVehicles/shared.lua
@@ -19,7 +19,7 @@ function lib.getNearbyVehicles(coords, maxDistance, includePlayerVehicle)
 	for i = 1, #vehicles do
 		local vehicle = vehicles[i]
 
-		if lib.context == 'server' or not cache.vehicle or vehicle ~= cache.vehicle or includePlayerVehicle then
+		if DoesEntityExist(vehicle) and (lib.context == 'server' or not cache.vehicle or vehicle ~= cache.vehicle or includePlayerVehicle) then
 			local vehicleCoords = GetEntityCoords(vehicle)
 			local distance = #(coords - vehicleCoords)
 

--- a/imports/grid/shared.lua
+++ b/imports/grid/shared.lua
@@ -80,6 +80,12 @@ function lib.grid.getCell(point)
     return lastCell.cell
 end
 
+local function cloneEntries(src)
+    local out = lib.array:new()
+    for i = 1, #src do out[i] = src[i] end
+    return out
+end
+
 ---@param point vector
 ---@param filter? fun(entry: GridEntry): boolean
 ---@return Array<GridEntry>
@@ -91,7 +97,8 @@ function lib.grid.getNearbyEntries(point, filter)
         gridCache.maxX == maxX and
         gridCache.minY == minY and
         gridCache.maxY == maxY then
-        return gridCache.entries
+        -- Copy so callers mutating the result can't corrupt the cache.
+        return cloneEntries(gridCache.entries)
     end
 
     local entries = lib.array:new()
@@ -131,6 +138,10 @@ end
 
 ---@param entry { coords: vector, length?: number, width?: number, radius?: number, [string]: any }
 function lib.grid.addEntry(entry)
+    if not entry.radius and (not entry.length or not entry.width) then
+        error("grid entry requires 'radius', or both 'length' and 'width'", 2)
+    end
+
     entry.length = entry.length or entry.radius * 2
     entry.width = entry.width or entry.radius * 2
     local minX, maxX, minY, maxY = getGridDimensions(entry.coords, entry.length, entry.width)
@@ -146,9 +157,9 @@ function lib.grid.addEntry(entry)
         end
 
         grid[y] = row
-
-        table.wipe(gridCache)
     end
+
+    table.wipe(gridCache)
 end
 
 ---@param entry table A table that was added to the grid previously.

--- a/imports/heap/shared.lua
+++ b/imports/heap/shared.lua
@@ -76,8 +76,14 @@ function lib.heap:push(...)
     local items = self.private.items
     local lt = self.private.lt
     local startIndex = #items
+    local args = { ... }
 
-    table.move({ ... }, 1, n, startIndex + 1, items)
+    -- Reject nil before mutating, otherwise a hole corrupts ordering and size().
+    for i = 1, n do
+        if args[i] == nil then error("heap values cannot be nil", 2) end
+    end
+
+    table.move(args, 1, n, startIndex + 1, items)
 
     for i = 1, n do
         siftUp(items, startIndex + i, lt)

--- a/imports/map/shared.lua
+++ b/imports/map/shared.lua
@@ -206,8 +206,21 @@ function lib.map:__pack()
 end
 
 function lib.map:__tojson()
+    -- Build the order from live keys only, since self.private.keys may still hold TOMBSTONEs.
+    local keys = self.private.keys
+    local order = {}
+    local n = 0
+
+    for i = 1, #keys do
+        local k = keys[i]
+        if k ~= TOMBSTONE then
+            n += 1
+            order[n] = k
+        end
+    end
+
     return json.encode(setmetatable(self:toTable(), {
-        __jsonorder = self.private.keys
+        __jsonorder = order
     }))
 end
 

--- a/imports/points/client.lua
+++ b/imports/points/client.lua
@@ -170,6 +170,10 @@ function lib.points.new(...)
     self.distance = self.distance or args[2]
     self.radius = self.distance
 
+    if type(self.radius) ~= 'number' then
+        error("point requires a numeric 'distance'", 2)
+    end
+
     if args[3] then
         for k, v in pairs(args[3]) do
             self[k] = v

--- a/imports/timer/shared.lua
+++ b/imports/timer/shared.lua
@@ -107,14 +107,15 @@ function timer:restart(async)
     self:start(async)
 end
 
+-- Defined once and rounds arithmetically instead of allocating a closure + format string per call.
+local function roundedfloat(value)
+    return math.floor(value * 100 + 0.5) / 100
+end
+
 function timer:getTimeLeft(format)
     local ms = self.private.paused
         and self.private.currentTimeLeft
         or self.private.currentTimeLeft - (GetGameTimer() - self.private.startTime)
-
-    local roundedfloat = function(value)
-        return tonumber(string.format('%.2f', value))
-    end
 
     if format == 'ms' then
         return roundedfloat(ms)

--- a/imports/zones/shared.lua
+++ b/imports/zones/shared.lua
@@ -103,8 +103,6 @@ local function getTriangles(polygon, height, type)
     local indices = table.create(numPoints, 0)
     local reverse = signedArea(polygon) < 0
 
-    print(signedArea(polygon), isCCW(polygon[1], polygon[2], polygon[3]))
-
     for i = 1, numPoints do
         indices[i] = reverse and numPoints + 1 - i or i
     end
@@ -340,7 +338,8 @@ end
 local function contains(self, coords, updateDistance)
     if updateDistance then self.distance = #(self.coords - coords) end
 
-    return glm_polygon_contains(self.polygon, coords, self.thickness / 4)
+    -- Half the thickness matches the drawn volume (debugPoly/getTriangles extrude by thickness/2).
+    return glm_polygon_contains(self.polygon, coords, self.thickness / 2)
 end
 
 local function insideSphere(self, coords, updateDistance)
@@ -466,9 +465,10 @@ function lib.zones.poly(data)
         end)
 
         local zCoord = coordsArray[1].coord
-        local averageTo = 1
+        -- Default to averaging every Z; only shrink once a lower count is found (else all-equal counts stay deterministic).
+        local averageTo = #coordsArray
 
-        for i = 1, #coordsArray do
+        for i = 2, #coordsArray do
             if coordsArray[i].count < coordsArray[1].count then
                 averageTo = i - 1
                 break

--- a/init.lua
+++ b/init.lua
@@ -141,7 +141,11 @@ function SetInterval(callback, interval, ...)
             Wait(interval)
 
             if interval < 0 then break end
-            callback(table.unpack(args))
+
+            local ok, err = pcall(callback, table.unpack(args))
+
+            -- Surface the error without killing the interval loop (which would leak intervals[id]).
+            if not ok then CreateThread(function() error(err, 0) end) end
         until false
         intervals[id] = nil
     end)

--- a/resource/interface/client/alert.lua
+++ b/resource/interface/client/alert.lua
@@ -56,7 +56,8 @@ function lib.closeAlertDialog(reason)
     local p = alert
     alert = nil
 
-    if reason then p:reject(reason) else p:resolve() end
+    -- Always resolve (not reject), since lib.alertDialog awaits this and a rejection would error.
+    p:resolve()
 end
 
 RegisterNUICallback('closeAlert', function(data, cb)

--- a/resource/interface/client/main.lua
+++ b/resource/interface/client/main.lua
@@ -9,14 +9,21 @@
 ---@alias IconProp 'fas' | 'far' | 'fal' | 'fat' | 'fad' | 'fab' | 'fak' | 'fass'
 
 local keepInput = IsNuiFocusKeepingInput()
+local hasFocus = false
 
 function lib.setNuiFocus(allowInput, disableCursor)
-    keepInput = IsNuiFocusKeepingInput()
+    -- Only snapshot keep-input on the first acquisition, so a nested UI can't overwrite it.
+    if not hasFocus then
+        keepInput = IsNuiFocusKeepingInput()
+        hasFocus = true
+    end
+
     SetNuiFocus(true, not disableCursor)
     SetNuiFocusKeepInput(allowInput)
 end
 
 function lib.resetNuiFocus()
+    hasFocus = false
     SetNuiFocus(false, false)
     SetNuiFocusKeepInput(keepInput)
 end

--- a/resource/interface/client/menu.lua
+++ b/resource/interface/client/menu.lua
@@ -116,11 +116,14 @@ end
 ---@param options MenuOptions | MenuOptions[]
 ---@param index? number
 function lib.setMenuOptions(id, options, index)
+    local menu = registeredMenus[id]
+    if not menu then error(('No menu with id %s was found'):format(id)) end
+
     if index then
-        registeredMenus[id].options[index] = options
+        menu.options[index] = options
     else
         if not options[1] then error('Invalid override format used, expected table of options.') end
-        registeredMenus[id].options = options
+        menu.options = options
     end
 end
 
@@ -175,7 +178,8 @@ RegisterNUICallback('changeSelected', function(data, cb)
         return error("Menu args must be passed as a table")
     end
 
-    if not args then args = {} end
+    -- Clone so repeated selections don't accumulate keys on the option's stored args table.
+    args = args and table.clone(args) or {}
     if data[2] then args[data[3]] = true end
 
     if data[2] and not args.isCheck then

--- a/resource/interface/client/skillcheck.lua
+++ b/resource/interface/client/skillcheck.lua
@@ -36,6 +36,11 @@ function lib.cancelSkillCheck()
     end
 
     SendNUIMessage({action = 'skillCheckCancel'})
+
+    -- Resolve locally so the caller never deadlocks if the NUI fails to echo skillCheckOver.
+    lib.resetNuiFocus()
+    skillcheck:resolve(false)
+    skillcheck = nil
 end
 
 ---@return boolean

--- a/resource/interface/server/progress.lua
+++ b/resource/interface/server/progress.lua
@@ -2,11 +2,32 @@ local maxProps = GetConvarInt('ox:progressPropLimit', 2)
 
 ---@param props ProgressPropProps | ProgressPropProps[] | nil
 RegisterNetEvent('ox_lib:progressProps', function(props)
-    if type(props) == 'table' then
-        props = #props > maxProps and { table.unpack(props, 1, maxProps) } or props
-    else
-        props = nil
+    if type(props) ~= 'table' then
+        return Player(source).state:set('lib:progressProps', nil, true)
     end
 
-    Player(source).state:set('lib:progressProps', props, true)
+    -- The API accepts a single prop or an array, so wrap a lone prop object before validating.
+    if props.model ~= nil then props = { props } end
+
+    -- props is replicated to other clients, so only accept a bounded array of prop tables.
+    if table.type(props) == 'hash' then
+        return Player(source).state:set('lib:progressProps', nil, true)
+    end
+
+    local sanitized = {}
+    local count = 0
+
+    for i = 1, #props do
+        local prop = props[i]
+        local model = type(prop) == 'table' and prop.model
+
+        if type(model) == 'string' or type(model) == 'number' then
+            count += 1
+            sanitized[count] = prop
+
+            if count >= maxProps then break end
+        end
+    end
+
+    Player(source).state:set('lib:progressProps', count > 0 and sanitized or nil, true)
 end)

--- a/resource/state/server.lua
+++ b/resource/state/server.lua
@@ -36,10 +36,17 @@ lib.callback.register('ox_lib:requestSetStateBag', function(playerId, bag, key, 
         return false
     end
 
+    local entityId = targetId and NetworkGetEntityFromNetworkId(targetId) or 0
+
+    -- A client may only mutate state bags for entities it currently owns.
+    if targetType == 'entity' and (entityId == 0 or NetworkGetEntityOwner(entityId) ~= playerId) then
+        return false
+    end
+
     local hook <close> = pipeline:dispatch({
         playerId = playerId,
         targetId = targetId,
-        entityId = NetworkGetEntityFromNetworkId(targetId),
+        entityId = entityId,
         type = targetType,
         bag = bag,
         key = key,

--- a/resource/zoneCreator/server.lua
+++ b/resource/zoneCreator/server.lua
@@ -130,8 +130,35 @@ local parse = {
 	end,
 }
 
+---Sanitises client zone data (safe name charset, numeric coercion) to prevent Lua injection into the generated file.
+local function sanitizeZoneData(data)
+    if type(data) ~= 'table' or not parse[data.zoneType] then return false end
+
+    data.name = type(data.name) == 'string' and data.name:gsub('[^%w_%-]', '') or ''
+    if data.name == '' then data.name = 'zone' end
+
+    for _, key in ipairs({ 'xCoord', 'yCoord', 'zCoord', 'width', 'length', 'height', 'heading', 'radius' }) do
+        if data[key] ~= nil then data[key] = tonumber(data[key]) or 0 end
+    end
+
+    if type(data.points) == 'table' then
+        for i = 1, #data.points do
+            local point = data.points[i]
+
+            if type(point) == 'table' then
+                point.x = tonumber(point.x) or 0
+                point.y = tonumber(point.y) or 0
+            end
+        end
+    end
+
+    return true
+end
+
 RegisterNetEvent('ox_lib:saveZone', function(data)
     if not source or not IsPlayerAceAllowed(source, 'command') then return end
+    if not sanitizeZoneData(data) then return end
+
     local output = (LoadResourceFile(cache.resource, 'created_zones.lua') or '') .. parse[data.zoneType](data)
     SaveResourceFile(cache.resource, 'created_zones.lua', output, -1)
 end)


### PR DESCRIPTION
## Summary

A hardening pass over ox_lib: input validation, a few correctness fixes in the data-structure and interface modules, and some hot-path cleanups. 25 files, +199/-63, rebased on current `main` (the `cache.lastCell` cell-tracking and the context-menu nil guards already landed upstream, so they're excluded).

## Robustness / validation

- **state**: validate entity ownership before applying an `entity:` state-bag write (the owner-guarded `setVehicleProperties` path is unaffected).
- **zoneCreator**: sanitize and type-coerce client-supplied zone data before writing the generated file, and validate `zoneType`.
- **getFilesInDirectory**: reject parent-directory (`..`) traversal in the path.
- **callback**: use higher-entropy keys for pending callbacks.
- **progress**: validate the replicated `progressProps` payload (bounded array of prop tables).

## Correctness

- **array.reduce**: honour a falsy initial value (`false`/`0`) instead of treating it as "no initial value".
- **heap.push**: reject `nil` before mutating, instead of leaving a hole that corrupts ordering and `size()`.
- **map.__tojson**: build `__jsonorder` from live keys only (TOMBSTONE sentinels are no longer emitted).
- **grid**: `getNearbyEntries` returns a copy so callers can't corrupt the cache; `addEntry` validates radius/length and wipes the cache once instead of per row.
- **SetInterval**: a throwing callback no longer kills the loop or leaks the interval id.
- **interface/main**: snapshot the NUI keep-input state only on the first focus acquisition.
- **skillcheck**: `cancelSkillCheck` resolves locally so the caller can't deadlock if the NUI doesn't echo back.
- **alert**: `closeAlertDialog` resolves (instead of rejecting on timeout), matching the documented `| nil` return.
- **menu**: clone an option's `args` before mutating; guard `setMenuOptions` against an unknown id.
- **zones**: vertical containment uses `thickness/2` to match the drawn volume; the non-planar poly z is computed deterministically; a leftover debug `print` is removed.
- **points**: require a numeric `distance`.
- **getClosest*/getNearby***: skip non-existent pool handles via `DoesEntityExist`; drop a dead duplicate `GetEntityCoords` in `getClosestPlayer`.

## Performance

- **array.filter/merge**: build the result directly instead of an intermediate table + `table.unpack` round-trip.
- **timer.getTimeLeft**: hoist the rounding helper out of the hot path and round arithmetically.

## Notes

Data-structure fixes were validated against Lua 5.4 (reduce/heap/map proofs; filter/merge/rounding regression-checked). Happy to split this into smaller, focused PRs if preferred.
