### PR TITLE
feat(require): support ./ and ../ relative paths

### DIFF
--- a/imports/require/shared.lua
+++ b/imports/require/shared.lua
@@ -21,6 +21,66 @@ package = {
 
 ---@param modName string
 ---@return string
+local function resolveRelative(modName)
+    if not modName:find('^%.%.?/') then return modName end
+
+    local src
+    local i = 3
+
+    while true do
+        local info = debug.getinfo(i, 'S')
+        if not info then break end
+
+        local source = info.source
+
+        if source and source:sub(1, 1) == '@' and not source:find('^@+ox_lib/imports/require/') then
+            src = source
+            break
+        end
+
+        i += 1
+    end
+
+    if not src then
+        error(("cannot resolve relative path '%s' without a file source"):format(modName), 4)
+    end
+
+    local dir = src:match('^@+[^/]+/(.+)/[^/]+%.lua$') or ''
+    local parts = {}
+
+    for part in dir:gmatch('[^/]+') do
+        parts[#parts + 1] = part
+    end
+
+    local rest = modName
+
+    while true do
+        if rest:sub(1, 3) == '../' then
+            if #parts == 0 then
+                error(("relative path '%s' goes above the resource root"):format(modName), 4)
+            end
+            parts[#parts] = nil
+            rest = rest:sub(4)
+        elseif rest:sub(1, 2) == './' then
+            rest = rest:sub(3)
+        else
+            break
+        end
+    end
+
+    rest = rest:gsub('%.lua$', ''):gsub('%.json$', '')
+
+    if rest == '' then
+        error(("relative path '%s' resolves to no module"):format(modName), 4)
+    end
+
+    if #parts == 0 then return rest end
+
+    return table.concat(parts, '.') .. '.' .. rest
+end
+
+---@param modName string
+---@return string
 ---@return string
 local function getModuleInfo(modName)
     local resource = modName:match('^@(.-)/.+') --[[@as string?]]
@@ -125,6 +185,8 @@ function lib.load(filePath, env)
         error(("file path must be a string (received '%s')"):format(filePath), 2)
     end
 
+    filePath = resolveRelative(filePath)
+
     local result, err = loadModule(filePath, env)
 
     if result then return result() end
@@ -139,6 +201,8 @@ function lib.loadJson(filePath)
     if type(filePath) ~= 'string' then
         error(("file path must be a string (received '%s')"):format(filePath), 2)
     end
+
+    filePath = resolveRelative(filePath)
 
     local resourceSrc, modPath = getModuleInfo(filePath:gsub('%.', '/'))
     local resourceFile = LoadResourceFile(resourceSrc, ('%s.json'):format(modPath))
@@ -158,6 +222,8 @@ function lib.require(modName)
     if type(modName) ~= 'string' then
         error(("module name must be a string (received '%s')"):format(modName), 3)
     end
+
+    modName = resolveRelative(modName)
 
     local module = loaded[modName]
 


### PR DESCRIPTION
## Summary

Adds compatibility for relative module paths in `lib.require`, `lib.load`, and `lib.loadJson`, resolved against the file containing the call.

## What this PR does

| Caller file | Call | Resolves to |
|---|---|---|
| `<res>/server/test.lua` | `lib.require('./main')` | `<res>/server/main.lua` |
| `<res>/server/test.lua` | `lib.require('./test.lua')` | `<res>/server/test.lua` |
| `<res>/server/test.lua` | `lib.require('./util.helpers')` | `<res>/server/util/helpers.lua` |
| `<res>/server/sub/x.lua` | `lib.require('../main')` | `<res>/server/main.lua` |
| `<res>/server/sub/x.lua` | `lib.require('../../config')` | `<res>/config.lua` |
| `<res>/main.lua` | `lib.require('./foo')` | `<res>/foo.lua` |
| `<res>/server/x.lua` | `lib.loadJson('./shops')` | reads `<res>/server/shops.json` |
| `<res>/server/x.lua` | `lib.loadJson('./shops.json')` | `.json` extension is stripped |

## Notes

- **Cache key converges across forms.** `./foo` from `server/test.lua` and `server.foo` from anywhere both resolve to the same internal name, so they share the cached module.
- **`.lua` and `.json` extensions are stripped** from the relative segment so user-typed extensions Just Work. Absolute calls still expect no extension (pre-existing behavior, unchanged).
- **`@resource/...` cross-resource paths are unaffected.** The guard only matches `./` or `../` prefixes.
- **Non-relative calls take the early-return branch** at the top of `resolveRelative`, so existing call sites are identical to upstream.


## Behavior change worth flagging

Anyone who was writing `lib.require('./foo')` in upstream and relying on it loading the root-level `<resource>/foo.lua` (the accidental upstream behavior) will see the call now resolve to `<callerDir>/foo.lua` instead. The explicit-intent fix for `./` is a real semantic change in that case. Likely never written intentionally.

