### PR TITLE
feat(require): relative path searcher for ./ and ../

### DIFF
--- a/imports/require/shared.lua
+++ b/imports/require/shared.lua
@@ -97,8 +97,106 @@ end
 ---| fun(modName: string): function loader
 ---| fun(modName: string): nil, string errmsg
 
+local relativeCache = {}
+
+---@param modName string
+local function relativeSearcher(modName)
+    if modName:sub(1, 2) ~= './' and modName:sub(1, 3) ~= '../' then
+        return nil, 'not a relative path'
+    end
+
+    local src
+    local i = 3
+
+    while true do
+        local info = debug.getinfo(i, 'S')
+        if not info then break end
+
+        local source = info.source
+
+        if source and source:sub(1, 1) == '@' and not source:find('^@+ox_lib/imports/require/') then
+            src = source
+            break
+        end
+
+        i += 1
+    end
+
+    if not src then
+        return nil, ("cannot resolve relative path '%s' without a file source"):format(modName)
+    end
+
+    local resource = src:match('^@+([^/]+)/') or cache.resource
+    local dir = src:match('^@+[^/]+/(.+)/[^/]+%.lua$') or ''
+    local parts = {}
+
+    for part in dir:gmatch('[^/]+') do
+        parts[#parts + 1] = part
+    end
+
+    local rest = modName
+
+    while true do
+        if rest:sub(1, 3) == '../' then
+            if #parts == 0 then
+                return nil, ("relative path '%s' goes above the resource root"):format(modName)
+            end
+            parts[#parts] = nil
+            rest = rest:sub(4)
+        elseif rest:sub(1, 2) == './' then
+            rest = rest:sub(3)
+        else
+            break
+        end
+    end
+
+    rest = rest:gsub('%.lua$', '')
+
+    if rest == '' then
+        return nil, ("relative path '%s' resolves to no module"):format(modName)
+    end
+
+    local prefix = #parts > 0 and (table.concat(parts, '/') .. '/') or ''
+    local relativePath = rest:gsub('%.', '/')
+    local cacheKey = ('%s/%s%s'):format(resource, prefix, relativePath)
+    local cached = relativeCache[cacheKey]
+
+    if cached ~= nil then
+        if cached == '__loading' then
+            error(("^1circular-dependency occurred when loading module '%s'^0"):format(modName), 3)
+        end
+
+        return function() return cached end
+    end
+
+    local fileName = prefix .. relativePath .. '.lua'
+    local file = LoadResourceFile(resource, fileName)
+
+    if not file then
+        local initPath = prefix .. relativePath .. '/init.lua'
+        file = LoadResourceFile(resource, initPath)
+
+        if not file then
+            return nil, ("no file '@%s/%s'\n\tno file '@%s/%s'"):format(resource, fileName, resource, initPath)
+        end
+
+        fileName = initPath
+    end
+
+    local chunk = assert(load(file, ('@@%s/%s'):format(resource, fileName), 't'))
+
+    return function()
+        relativeCache[cacheKey] = '__loading'
+        local result = chunk()
+        if result == nil then result = true end
+        relativeCache[cacheKey] = result
+        return result
+    end
+end
+
 ---@type PackageSearcher[]
 package.searchers = {
+    relativeSearcher,
     function(modName)
         local ok, result = pcall(_require, modName)
 
@@ -159,15 +257,19 @@ function lib.require(modName)
         error(("module name must be a string (received '%s')"):format(modName), 3)
     end
 
-    local module = loaded[modName]
+    local isRelative = modName:sub(1, 2) == './' or modName:sub(1, 3) == '../'
 
-    if module == '__loading' then
-        error(("^1circular-dependency occurred when loading module '%s'^0"):format(modName), 2)
+    if not isRelative then
+        local module = loaded[modName]
+
+        if module == '__loading' then
+            error(("^1circular-dependency occurred when loading module '%s'^0"):format(modName), 2)
+        end
+
+        if module ~= nil then return module end
+
+        loaded[modName] = '__loading'
     end
-
-    if module ~= nil then return module end
-
-    loaded[modName] = '__loading'
 
     local err = {}
 
@@ -176,9 +278,12 @@ function lib.require(modName)
 
         if result then
             if type(result) == 'function' then result = result() end
-            loaded[modName] = result or result == nil
 
-            return loaded[modName]
+            if not isRelative then
+                loaded[modName] = result or result == nil
+            end
+
+            return result or result == nil
         end
 
         err[#err + 1] = errMsg


### PR DESCRIPTION
## Summary

Compromise follow-up to [#805](https://github.com/overextended/ox_lib/pull/805), which was closed with the rationale that `lib.require` should stay aligned with standard `lua_require` (no relative paths in the entry function). Instead we use a custom `package.searchers` entry to add relative path support.

Strict superset over upstream. Non-relative paths take an immediate early-return branch and behave identically to current `lib.require`.

## Examples

| Caller file | Call | Resolves to |
|---|---|---|
| `<res>/server/test.lua` | `lib.require('./main')` | `<res>/server/main.lua` |
| `<res>/server/test.lua` | `lib.require('./test.lua')` | `<res>/server/test.lua` (`.lua` stripped) |
| `<res>/server/test.lua` | `lib.require('./util.helpers')` | `<res>/server/util/helpers.lua` |
| `<res>/server/sub/x.lua` | `lib.require('../main')` | `<res>/server/main.lua` |
| `<res>/server/sub/x.lua` | `lib.require('../../config')` | `<res>/config.lua` |
| `<res>/main.lua` | `lib.require('./foo')` | `<res>/foo.lua` |

## Implementation

Two pieces:

1. **A new searcher `relativeSearcher`** prepended to `package.searchers`. For relative `modName`s it walks the call stack to find the caller's file, resolves `./` and `../` against it, falls back to `<path>/init.lua` matching standard `package.path` semantics, and maintains its own `relativeCache` keyed by resolved absolute path.

2. **`lib.require` skips the main `loaded[]` cache for relative paths.** Required for correctness as that cache is keyed by input `modName`, so two callers passing `'./foo'` from different files would otherwise collide on the wrong-keyed entry. The searcher's own cache (keyed by resolved path) handles dedup correctly.

Errors clearly on:
- `lib.require('../foo')` from resource root → `goes above the resource root`
- `lib.require('./')` or anything that strips to nothing → `resolves to no module`
- Mutual `./` requires (A → B → A) → `circular-dependency` (same message as the existing absolute-path detection)
- File not found → standard `no file '@...'` message listing both `.lua` and `/init.lua` attempts

## Why the compromise has costs vs the original PR

The previous PR was architecturally cleaner: single cache layer keyed by resolved name, `lib.require` calls one helper at the top, no special-casing in the cache lookup. The maintainer's preferred path (searcher-only) has two unavoidable costs:

- **Two cache layers.** `lib.require`'s existing `loaded[]` can't share entries with relative paths because it's keyed by input string. The searcher has to maintain its own.
- **`lib.require` still needs a minimal change** to skip its main cache for relative paths. Without that, two callers from different directories using `'./foo'` would hit the wrong-keyed entry. There's no way to fix this from the searcher side alone.
- **Scope narrows to `lib.require` only.** `lib.load` and `lib.loadJson` don't go through `package.searchers`, so they don't get relative path support in this version. The original PR covered all three.

If those tradeoffs are deal-breakers, the original PR's preprocessing approach is the more honest path.