### PR TITLE
fix(progress): ensure prop data is not empty before processing

### DIFF
--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -195,7 +195,7 @@ local function startProgress(data, nuiMessage)
         Wait(0)
     end
 
-    if data.prop then
+    if data.prop and next(data.prop) ~= nil then
         TriggerServerEvent('ox_lib:progressProps', nil)
     end
 

--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -116,7 +116,7 @@ local function startProgress(data, nuiMessage)
     local invBusy <close> = setBusyState()
     progress = data
 
-    if data.prop then
+    if data.prop and next(data.prop) ~= nil then
         if table.type(data.prop) ~= 'array' then
             local model = data.prop.model
 


### PR DESCRIPTION
### Fix Empty `prop` Handling

Prevents errors when `data.prop` is an empty table (`prop = []`) by ensuring the prop loading function is only called when a valid prop definition exists.

**What Changed**

* Added `next(data.prop) ~= nil` to the prop validation

* Prevents `loadPropModel(model)` from being called without a model.
* Fixes errors caused by empty `prop` tables (`prop = []`).
