### PR TITLE
feat: add support for broken off vehicle wheels

### DIFF
--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -195,7 +195,11 @@ function lib.getVehicleProperties(vehicle)
 
         for i = 0, 7 do
             if IsVehicleTyreBurst(vehicle, i, false) then
-                damage.tyres[i] = IsVehicleTyreBurst(vehicle, i, true) and 2 or 1
+                if not IsVehicleWheelBrokenOff(vehicle, i) then
+                    damage.tyres[i] = IsVehicleTyreBurst(vehicle, i, true) and 2 or 1
+                else
+                    damage.tyres[i] = 3
+                end
             end
         end
 
@@ -430,7 +434,11 @@ function lib.setVehicleProperties(vehicle, props, fixVehicle)
 
     if props.tyres then
         for tyre, state in pairs(props.tyres) do
-            SetVehicleTyreBurst(vehicle, tonumber(tyre) --[[@as number]], state == 2, 1000.0)
+            if state == 3 then
+                BreakOffVehicleWheel(vehicle, tonumber(tyre) --[[@as number]], false, true, true, false)
+            else
+                SetVehicleTyreBurst(vehicle, tonumber(tyre) --[[@as number]], state == 2, 1000.0)
+            end
         end
     end
 


### PR DESCRIPTION
## Description

This update adds support for tracking and setting "broken off" vehicle wheels in `lib.getVehicleProperties` and `lib.setVehicleProperties`. 

- **`lib.getVehicleProperties`**: Now detects if a wheel is broken off (`IsVehicleWheelBrokenOff`) and assigns it a state of `3`.
- **`lib.setVehicleProperties`**: Now correctly handles the `3` state by using `BreakOffVehicleWheel` to physically remove the wheel from the vehicle.

This ensures that broken-off wheels are correctly persisted in the vehicle's properties data.