### PR TITLE
feat(radial): Allow open specific radial menu as root

### DIFF
--- a/package/client/interface/radial.ts
+++ b/package/client/interface/radial.ts
@@ -19,6 +19,8 @@ export const registerRadial = (radial: { id: string; items: Omit<RadialItem, 'id
 
 export const getCurrentRadialId = () => exports.ox_lib.getCurrentRadialId();
 
+export const showRadialMenu = (menuId: string) => exports.ox_lib.showRadialMenu(menuId);
+
 export const hideRadial = () => exports.ox_lib.hideRadial();
 
 export const disableRadial = (state: boolean) => exports.ox_lib.disableRadial(state);

--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -38,6 +38,10 @@ local menuHistory = {}
 ---@type RadialMenuProps?
 local currentRadial = nil
 
+---The registered menu opened directly with lib.showRadialMenu.
+---@type RadialMenuProps?
+local rootRadial = nil
+
 ---Open a the global radial menu or a registered radial submenu with the given id.
 ---@param id string?
 ---@param option number?
@@ -65,7 +69,7 @@ local function showRadial(id, option)
         action = 'openRadialMenu',
         data = {
             items = radial and radial.items or menuItems,
-            sub = radial and true or nil,
+            sub = radial and radial ~= rootRadial or nil,
             option = option
         }
     })
@@ -138,6 +142,7 @@ function lib.hideRadial()
 
     isOpen = false
     currentRadial = nil
+    rootRadial = nil
 end
 
 ---Registers an item or array of items in the global radial menu.
@@ -304,6 +309,7 @@ RegisterNUICallback('radialClose', function(_, cb)
 
     isOpen = false
     currentRadial = nil
+    rootRadial = nil
 end)
 
 RegisterNUICallback('radialTransition', function(_, cb)
@@ -324,6 +330,58 @@ function lib.disableRadial(state)
 
     if isOpen and state then
         return lib.hideRadial()
+    end
+end
+
+---Shows a registered menu as root without affecting global menus.
+---@param id string
+---@param option number?
+function lib.showRadialMenu(id, option)
+    local radial = id and menus[id]
+    if not radial then return end
+
+    if isDisabled then return end
+
+    if isOpen then
+        return lib.hideRadial()
+    end
+
+    local radialItems = radial.items
+    if #radialItems == 0 or IsNuiFocused() or IsPauseMenuActive() then return end
+
+    isOpen = true
+    currentRadial = radial
+    rootRadial = radial
+    table.wipe(menuHistory)
+
+    SendNUIMessage({
+        action = 'openRadialMenu',
+        data = false
+    })
+
+    Wait(100)
+
+    if not isOpen then return end
+
+    lib.setNuiFocus(true)
+    SetCursorLocation(0.5, 0.5)
+
+    SendNUIMessage({
+        action = 'openRadialMenu',
+        data = {
+            items = radialItems,
+            option = option
+        }
+    })
+
+    while isOpen do
+        DisablePlayerFiring(cache.playerId, true)
+        DisableControlAction(0, 1, true)
+        DisableControlAction(0, 2, true)
+        DisableControlAction(0, 142, true)
+        DisableControlAction(2, 199, true)
+        DisableControlAction(2, 200, true)
+        Wait(0)
     end
 end
 

--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -26,6 +26,8 @@
 
 local isOpen = false
 
+local isDisabled = false
+
 ---@type table<string, RadialMenuProps>
 local menus = {}
 
@@ -112,6 +114,46 @@ local function refreshRadial(menuId)
 
     table.wipe(menuHistory)
     showRadial()
+end
+
+---Validates requirements and shows the requested radial menu.
+---@param id string? If not provided, the global radial menu will be shown.
+local function onRadialOpen(id)
+    local radial = id and menus[id]
+
+    if isDisabled or (id and not radial) then return end
+
+    if isOpen then
+        if rootRadial == radial then
+            return lib.hideRadial()
+        end
+
+        rootRadial = radial
+        table.wipe(menuHistory)
+        return showRadial(id)
+    end
+
+    local items = radial and radial.items or menuItems
+    if #items == 0 or IsNuiFocused() or IsPauseMenuActive() then return end
+
+    isOpen = true
+    rootRadial = radial
+    table.wipe(menuHistory)
+
+    lib.setNuiFocus(true)
+    SetCursorLocation(0.5, 0.5)
+
+    showRadial(id)
+
+    while isOpen do
+        DisablePlayerFiring(cache.playerId, true)
+        DisableControlAction(0, 1, true)
+        DisableControlAction(0, 2, true)
+        DisableControlAction(0, 142, true)
+        DisableControlAction(2, 199, true)
+        DisableControlAction(2, 200, true)
+        Wait(0)
+    end
 end
 
 ---Registers a radial sub menu with predefined options.
@@ -321,8 +363,6 @@ RegisterNUICallback('radialTransition', function(_, cb)
     cb(true)
 end)
 
-local isDisabled = false
-
 ---Disallow players from opening the radial menu.
 ---@param state boolean
 function lib.disableRadial(state)
@@ -336,58 +376,7 @@ end
 ---Shows a registered menu as root without affecting global menus.
 ---@param id string
 function lib.showRadialMenu(id)
-    local radial = id and menus[id]
-    if not radial then return end
-
-    if isDisabled then return end
-
-    if isOpen then
-        --Transitions between different root menus
-        if rootRadial == radial then
-            return lib.hideRadial()
-        end
-
-        rootRadial = radial
-        table.wipe(menuHistory)
-        return showRadial(id)
-    end
-
-    local radialItems = radial.items
-    if #radialItems == 0 or IsNuiFocused() or IsPauseMenuActive() then return end
-
-    isOpen = true
-    currentRadial = radial
-    rootRadial = radial
-    table.wipe(menuHistory)
-
-    SendNUIMessage({
-        action = 'openRadialMenu',
-        data = false
-    })
-
-    Wait(100)
-
-    if not isOpen then return end
-
-    lib.setNuiFocus(true)
-    SetCursorLocation(0.5, 0.5)
-
-    SendNUIMessage({
-        action = 'openRadialMenu',
-        data = {
-            items = radialItems,
-        }
-    })
-
-    while isOpen do
-        DisablePlayerFiring(cache.playerId, true)
-        DisableControlAction(0, 1, true)
-        DisableControlAction(0, 2, true)
-        DisableControlAction(0, 142, true)
-        DisableControlAction(2, 199, true)
-        DisableControlAction(2, 200, true)
-        Wait(0)
-    end
+    onRadialOpen(id)
 end
 
 lib.addKeybind({
@@ -395,45 +384,7 @@ lib.addKeybind({
     description = locale('open_radial_menu'),
     defaultKey = 'z',
     onPressed = function()
-        if isDisabled then return end
-
-        if isOpen then
-            --Transitions between different root menus
-            if rootRadial then
-                rootRadial = nil
-                table.wipe(menuHistory)
-                return showRadial()
-            end
-
-            return lib.hideRadial()
-        end
-
-        if #menuItems == 0 or IsNuiFocused() or IsPauseMenuActive() then return end
-
-        isOpen = true
-        currentRadial = nil
-        rootRadial = nil
-        table.wipe(menuHistory)
-
-        SendNUIMessage({
-            action = 'openRadialMenu',
-            data = {
-                items = menuItems
-            }
-        })
-
-        lib.setNuiFocus(true)
-        SetCursorLocation(0.5, 0.5)
-
-        while isOpen do
-            DisablePlayerFiring(cache.playerId, true)
-            DisableControlAction(0, 1, true)
-            DisableControlAction(0, 2, true)
-            DisableControlAction(0, 142, true)
-            DisableControlAction(2, 199, true)
-            DisableControlAction(2, 200, true)
-            Wait(0)
-        end
+        onRadialOpen()
     end,
     -- onReleased = lib.hideRadial,
 })

--- a/resource/interface/client/radial.lua
+++ b/resource/interface/client/radial.lua
@@ -335,15 +335,21 @@ end
 
 ---Shows a registered menu as root without affecting global menus.
 ---@param id string
----@param option number?
-function lib.showRadialMenu(id, option)
+function lib.showRadialMenu(id)
     local radial = id and menus[id]
     if not radial then return end
 
     if isDisabled then return end
 
     if isOpen then
-        return lib.hideRadial()
+        --Transitions between different root menus
+        if rootRadial == radial then
+            return lib.hideRadial()
+        end
+
+        rootRadial = radial
+        table.wipe(menuHistory)
+        return showRadial(id)
     end
 
     local radialItems = radial.items
@@ -370,7 +376,6 @@ function lib.showRadialMenu(id, option)
         action = 'openRadialMenu',
         data = {
             items = radialItems,
-            option = option
         }
     })
 
@@ -393,12 +398,22 @@ lib.addKeybind({
         if isDisabled then return end
 
         if isOpen then
+            --Transitions between different root menus
+            if rootRadial then
+                rootRadial = nil
+                table.wipe(menuHistory)
+                return showRadial()
+            end
+
             return lib.hideRadial()
         end
 
         if #menuItems == 0 or IsNuiFocused() or IsPauseMenuActive() then return end
 
         isOpen = true
+        currentRadial = nil
+        rootRadial = nil
+        table.wipe(menuHistory)
 
         SendNUIMessage({
             action = 'openRadialMenu',


### PR DESCRIPTION
### Description

I hope I wasn't blind and missed something obvious.

Adds lib.showRadialMenu(id), allowing a menu registered with lib.registerRadial to be opened directly as an independent root menu.

Previously, registered radial menus could only be reached by referencing them as a submenu from another radial item. This made context-specific radial menus depend on the global radial menu, even when they were intended to operate separately.

This allows resources to open their own registered radial menus without adding temporary items to, replacing, or otherwise modifying the global radial menu.

**Example**
```
lib.registerRadial({
    id = 'vehicle_actions',
    items = {
        {
            label = 'Toggle Engine',
            icon = 'power-off',
            onSelect = function()
                -- Toggle the vehicle engine.
            end
        },
        {
            label = 'More Options',
            icon = 'ellipsis',
            menu = 'vehicle_more_options'
        }
    }
})
lib.showRadialMenu('vehicle_actions')
```

### Behaviour

**A menu opened with lib.showRadialMenu:**
- Is displayed as a root menu without a back button.
- Does not affect the items in the global radial menu.
- Can open registered child menus normally.
- Shows the back button inside child menus and returns to the directly opened root.
- Transitions directly when called with a different registered root menu while one is already open.
- Transitions to the global radial menu when the normal radial keybind is pressed.
- Uses the existing radial focus, cursor, pause-menu, disabled-state, and control-blocking behaviour.

### Implementation

A separate rootRadial reference is used to distinguish the active root from its child menus.

This allows the existing showRadial transition and history logic to be reused while determining whether the current registered menu should be rendered as a root or submenu.

**Root state and menu history are reset when:**
- The radial menu is closed.
- Another registered root is opened.
- The user transitions back to the global radial menu.
- The global radial menu is opened normally.

### Compatibility

This does not change the existing lib.registerRadial, lib.addRadialItem, or global radial menu APIs. 
I have tested on the following.
1. latest release QBX with qbx_radialmenu with no issues or compatibility issues.
2. latest release QBX with my own custom radialmenu with no issues or compatibility issues.
3. All regular Radial functions work as intended, refreshRadial() still functions with lib.showRadialMenu()