### PR TITLE
fix(class): allow inherited methods to access private fields

### DIFF
--- a/imports/class/shared.lua
+++ b/imports/class/shared.lua
@@ -71,19 +71,26 @@ local function validatePrivateAccess(class)
 
         if not di or not di.func then return false end
 
-        local method = classes[class][di.func]
+        local currentClass = class
 
-        if not method then
-            for k, v in pairs(class) do
-                if v == di.func then
-                    method = v
-                    classes[class][method] = k
-                    break
+        while currentClass do
+            local classMethods = classes[currentClass]
+            local method = classMethods and classMethods[di.func]
+
+            if classMethods and not method then
+                for k, v in pairs(currentClass) do
+                    if v == di.func then
+                        method = v
+                        classMethods[method] = k
+                        break
+                    end
                 end
             end
-        end
 
-        if method then return true end
+            if method then return true end
+
+            currentClass = getmetatable(currentClass)
+        end
 
         level += 1
     end


### PR DESCRIPTION
  ## Introduction

  Private-field validation currently checks methods only against the concrete class used to create an instance. This
  prevents methods inherited from a parent class from accessing self.private, even though those methods are valid
  members of the instance’s inheritance hierarchy.

  ## Summary

  This change updates private-access validation to traverse the class metatable chain. Methods defined on a parent class
  can therefore access private instance state when invoked on a derived-class instance.

  ## Changes

  - Start validation from the concrete instance class.
  - Walk through parent classes using the metatable chain.
  - Check each class for the calling method.
  - Discover and cache methods against the class where they are defined.
  - Preserve access restrictions for functions outside the class hierarchy.

  ## Why This Is Needed

  Without this change, inherited methods can execute on subclass instances but may unexpectedly fail when reading or
  writing self.private.

  For example, a method defined on GameEntity should remain functional when inherited by Vehicle. The previous
  implementation searched only Vehicle, so it could reject the parent method despite it being part of the instance’s
  valid class hierarchy.

  The updated behavior also aligns with the existing annotation of the private-state container as protected, indicating
  that it is intended to be accessible within the inheritance hierarchy.

  ## Impact

  - Fixes private-state access from inherited methods.
  - Improves consistency between inheritance and access validation.
  - Does not expose private state to unrelated callers.
  - Retains cached method lookups to avoid repeated discovery work.

  ## Conclusion

  This change makes inherited class behavior consistent and ensures parent methods remain usable on derived instances
  without weakening access restrictions outside the class hierarchy.