### PR TITLE
fix: check file existence before LoadResourceFile module probes

### DIFF
--- a/imports/require/shared.lua
+++ b/imports/require/shared.lua
@@ -50,6 +50,45 @@ end
 
 local tempData = {}
 
+-- Sandboxed builds log an error for every LoadResourceFile miss, so list
+-- directories via io.readdir before probing candidate paths. A failed or
+-- unavailable readdir falls back to probing (listing == false).
+local dirListings = {}
+
+local function resourceFileExists(resource, fileName)
+    if type(io) ~= 'table' or not io.readdir then return true end
+
+    local dir, file = fileName:match('^(.*)/([^/]+)$')
+
+    if not file then
+        dir, file = '', fileName
+    end
+
+    local key = ('@%s/%s'):format(resource, dir)
+    local listing = dirListings[key]
+
+    if listing == nil then
+        listing = false
+        local ok, handle = pcall(io.readdir, key)
+
+        if ok and handle then
+            listing = {}
+
+            for entry in handle:lines() do
+                listing[entry] = true
+            end
+
+            pcall(handle.close, handle)
+        end
+
+        dirListings[key] = listing
+    end
+
+    if not listing then return true end
+
+    return listing[file] == true
+end
+
 ---@param name string
 ---@param path string
 ---@return string? filename
@@ -61,7 +100,7 @@ function package.searchpath(name, path)
 
     for template in path:gmatch('[^;]+') do
         local fileName = template:gsub('^%./', ''):gsub('?', modName:gsub('%.', '/') or modName)
-        local file = LoadResourceFile(resource, fileName)
+        local file = resourceFileExists(resource, fileName) and LoadResourceFile(resource, fileName) or nil
 
         if file then
             tempData[1] = file

--- a/init.lua
+++ b/init.lua
@@ -43,10 +43,49 @@ local context = IsDuplicityVersion() and 'server' or 'client'
 
 function noop() end
 
+-- Sandboxed builds log an error for every LoadResourceFile miss, so list each
+-- module directory via io.readdir before probing files. Falls back to probing
+-- when io.readdir is unavailable (listing == false).
+local moduleFiles = {}
+
+local function getModuleFiles(dir)
+    local listing = moduleFiles[dir]
+
+    if listing == nil then
+        listing = false
+
+        if type(io) == 'table' and io.readdir then
+            local ok, handle = pcall(io.readdir, ('@%s/%s'):format(ox_lib, dir))
+
+            if ok and handle then
+                listing = {}
+
+                for entry in handle:lines() do
+                    listing[entry] = true
+                end
+
+                pcall(handle.close, handle)
+            end
+        end
+
+        moduleFiles[dir] = listing
+    end
+
+    return listing
+end
+
+local function loadResourceFileSafe(dir, file)
+    local listing = getModuleFiles(dir)
+
+    if listing and not listing[file] then return nil end
+
+    return LoadResourceFile(ox_lib, ('%s/%s'):format(dir, file))
+end
+
 local function loadModule(self, module)
     local dir = ('imports/%s'):format(module)
-    local chunk = LoadResourceFile(ox_lib, ('%s/%s.lua'):format(dir, context))
-    local shared = LoadResourceFile(ox_lib, ('%s/shared.lua'):format(dir))
+    local chunk = loadResourceFileSafe(dir, ('%s.lua'):format(context))
+    local shared = loadResourceFileSafe(dir, 'shared.lua')
 
     if shared then
         chunk = (chunk and ('%s\n%s'):format(shared, chunk)) or shared

--- a/resource/init.lua
+++ b/resource/init.lua
@@ -2,6 +2,45 @@ local debug_getinfo = debug.getinfo
 
 function noop() end
 
+-- Sandboxed builds log an error for every LoadResourceFile miss, so list each
+-- module directory via io.readdir before probing files. Falls back to probing
+-- when io.readdir is unavailable (listing == false).
+local moduleFiles = {}
+
+local function getModuleFiles(dir)
+    local listing = moduleFiles[dir]
+
+    if listing == nil then
+        listing = false
+
+        if type(io) == 'table' and io.readdir then
+            local ok, handle = pcall(io.readdir, ('@ox_lib/%s'):format(dir))
+
+            if ok and handle then
+                listing = {}
+
+                for entry in handle:lines() do
+                    listing[entry] = true
+                end
+
+                pcall(handle.close, handle)
+            end
+        end
+
+        moduleFiles[dir] = listing
+    end
+
+    return listing
+end
+
+local function loadResourceFileSafe(resource, dir, file)
+    local listing = getModuleFiles(dir)
+
+    if listing and not listing[file] then return nil end
+
+    return LoadResourceFile(resource, ('%s/%s'):format(dir, file))
+end
+
 lib = setmetatable({
     name = 'ox_lib',
     context = IsDuplicityVersion() and 'server' or 'client',
@@ -16,8 +55,8 @@ lib = setmetatable({
 
     __index = function(self, key)
         local dir = ('imports/%s'):format(key)
-        local chunk = LoadResourceFile(self.name, ('%s/%s.lua'):format(dir, self.context))
-        local shared = LoadResourceFile(self.name, ('%s/shared.lua'):format(dir))
+        local chunk = loadResourceFileSafe(self.name, dir, ('%s.lua'):format(self.context))
+        local shared = loadResourceFileSafe(self.name, dir, 'shared.lua')
 
         if shared then
             chunk = (chunk and ('%s\n%s'):format(shared, chunk)) or shared


### PR DESCRIPTION
## Problem

Newer FiveM server builds with the sandboxed filesystem log an error for every `LoadResourceFile` call on a file that does not exist. ox_lib's module loaders blind-probe paths that frequently do not exist, so every server start (and many `require` calls) now spam the console:

```
[extra-natives-fi] Failed to open file 'cfx_resource_ox_lib:/imports/require/server.lua' (original path imports/require/server.lua) in resource 'ox_lib'.
[extra-natives-fi] Failed to open file 'cfx_resource_ox_lib:/imports/class/server.lua' (original path imports/class/server.lua) in resource 'ox_lib'.
[extra-natives-fi] Failed to open file 'cfx_resource_ox_lib:/imports/print/server.lua' (original path imports/print/server.lua) in resource 'ox_lib'.
[extra-natives-fi] Failed to open file 'cfx_resource_ox_lib:/imports/array/server.lua' (original path imports/array/server.lua) in resource 'ox_lib'.
```

Three loaders probe blindly:

- `init.lua` `loadModule` tries `imports/<module>/<context>.lua` before falling back to `shared.lua`; many modules only ship `shared.lua`
- `resource/init.lua` lazy `lib.<module>` metatable has the same probe for ox_lib's own bootstrap
- `imports/require/shared.lua` `package.searchpath` tries `?.lua` before `?/init.lua` for every required module

Everything still works (the fallback loads), but the log noise makes real errors easy to miss.

## Fix

List each directory once with the sandbox's `io.readdir` API (already used by `lib.getFilesInDirectory`) and only call `LoadResourceFile` for files that actually exist. Listings are cached per directory.

The guard fails open in every uncertain case, so behaviour is unchanged wherever `io.readdir` cannot answer:

- `io.readdir` missing (older builds / client) falls back to the old probing
- `io.readdir` erroring or returning no handle (e.g. blocked cross-resource reads in `require`) falls back to the old probing

Tested on a live server: the four startup lines above are gone, module loading and `require` (including `@resource.module` and `?/init.lua` layouts) behave as before.

