### PR TITLE
Fixed lib.setVehicleProperties()

### DIFF
--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -663,7 +663,7 @@ function lib.setVehicleProperties(vehicle, props, fixVehicle)
     end
 
     if props.bulletProofTyres ~= nil then
-        SetVehicleTyresCanBurst(vehicle, props.bulletProofTyres)
+        SetVehicleTyresCanBurst(vehicle, not props.bulletProofTyres)
     end
 
     if gameBuild >= 2372 and props.driftTyres ~= nil then


### PR DESCRIPTION
If you passed `props.bulletProofTyres = true`, the tires didn't become bulletproof because it took the value in reverse.