### PR TITLE
fix(types): make input dialog options optional

### DIFF
--- a/package/client/interface/input.ts
+++ b/package/client/interface/input.ts
@@ -155,7 +155,7 @@ type RowInput =
 type inputDialog = (
   heading: string,
   rows: string[] | RowInput[],
-  options: {
+  options?: {
     allowCancel?: boolean;
   },
 ) => Promise<Array<string | number | boolean> | undefined>;


### PR DESCRIPTION
Fixes #816.

Makes `inputDialog` options optional to match the existing Lua API.