### PR TITLE
fix(types): preserve radial icon strictness

### DIFF
--- a/package/client/interface/radial.ts
+++ b/package/client/interface/radial.ts
@@ -3,7 +3,7 @@ import type { IconName, IconPrefix } from '@fortawesome/fontawesome-common-types
 type RadialItem = {
   id: string;
   label: string;
-  icon: IconName | [IconPrefix, IconName] | string;
+  icon: IconName | [IconPrefix, IconName];
   onSelect?: (currentMenu: string | null, itemIndex: number) => void | string;
   menu?: string;
   iconWidth?: number;


### PR DESCRIPTION
Fixes #815.

Removes the redundant `string` type so radial icons retain Font Awesome type checking.